### PR TITLE
Set End Date With Auto Increment Widget

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
@@ -166,6 +166,6 @@ public class AutoIncrementWidget extends LinearLayout implements CustomView, Vie
 
     private FuzzyDate getCurrentDate(){
         Calendar calendar = Calendar.getInstance();
-        return new FuzzyDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+        return new FuzzyDate(calendar.get(Calendar.DAY_OF_MONTH), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.YEAR));
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
@@ -17,6 +17,7 @@ import com.mxt.anitrend.base.interfaces.event.RetroCallback;
 import com.mxt.anitrend.base.interfaces.view.CustomView;
 import com.mxt.anitrend.databinding.WidgetAutoIncrementerBinding;
 import com.mxt.anitrend.model.entity.anilist.MediaList;
+import com.mxt.anitrend.model.entity.anilist.meta.FuzzyDate;
 import com.mxt.anitrend.presenter.widget.WidgetPresenter;
 import com.mxt.anitrend.util.CompatUtil;
 import com.mxt.anitrend.util.ErrorUtil;
@@ -24,6 +25,8 @@ import com.mxt.anitrend.util.KeyUtil;
 import com.mxt.anitrend.util.MediaListUtil;
 import com.mxt.anitrend.util.MediaUtil;
 import com.mxt.anitrend.util.NotifyUtil;
+
+import java.util.Calendar;
 
 import retrofit2.Call;
 import retrofit2.Response;
@@ -145,13 +148,24 @@ public class AutoIncrementWidget extends LinearLayout implements CustomView, Vie
         }
     }
 
-    private void updateModelState() {
-        model.setProgress(model.getProgress() + 1);
-        if(MediaUtil.isIncrementLimitReached(model))
-            model.setStatus(KeyUtil.COMPLETED);
 
+    private void updateModelState() {
+        if(model.getProgress() == 0) {
+            model.setStatus(KeyUtil.CURRENT);
+            model.setStartedAt(getCurrentDate());
+        }
+        model.setProgress(model.getProgress() + 1);
+        if(MediaUtil.isIncrementLimitReached(model)) {
+            model.setStatus(KeyUtil.COMPLETED);
+            model.setCompletedAt(getCurrentDate());
+        }
         presenter.setParams(MediaListUtil.getMediaListParams(model, presenter.getDatabase()
                 .getCurrentUser().getMediaListOptions().getScoreFormat()));
         presenter.requestData(requestType, getContext(), this);
+    }
+
+    private FuzzyDate getCurrentDate(){
+        Calendar calendar = Calendar.getInstance();
+        return new FuzzyDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
     }
 }


### PR DESCRIPTION
- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [x] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved
- [x] I did not commit files that are excluded in the .gitignore file (Happens if you stage files with Android Studio)


## Description
Upon using auto-increment, we set the current date as CompletedAt Date along with the Completed status; and sets the status as "Current"  and current date as StartedAt if initial value of watched eps/chaps was 0 

## Motivation and Context
Automates the need to set StartedAt and CompletedAt using Edit Entry option, thus making it a better user-experience

## How Has This Been Tested?

Ran the app, used auto-increment on a Planning entry and Current entry with 25/26 eps and checked if it sets the dates and status.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)