### PR TITLE
Fix Crash on Decimal Score Using Comma

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
@@ -13,6 +13,7 @@ import com.mxt.anitrend.util.CompatUtil;
 import com.mxt.anitrend.util.KeyUtil;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 public class ScoreWidget extends ProgressWidget {
@@ -142,7 +143,8 @@ public class ScoreWidget extends ProgressWidget {
     }
 
     private float getRoundedScore(float score) {
-        return Float.valueOf(new DecimalFormat("#.#").format(score));
+        DecimalFormatSymbols formatSymbols = new DecimalFormatSymbols(Locale.US);
+        return Float.valueOf(new DecimalFormat("#.#", formatSymbols).format(score));
     }
 
     @Override

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
@@ -14,13 +14,15 @@ import com.mxt.anitrend.util.KeyUtil;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.text.ParseException;
 import java.util.Locale;
 
 public class ScoreWidget extends ProgressWidget {
 
     private float scoreMaximum, scoreCurrent;
 
-    private @KeyUtil.ScoreFormat String scoreFormat;
+    private @KeyUtil.ScoreFormat
+    String scoreFormat;
 
     public ScoreWidget(Context context) {
         super(context);
@@ -75,7 +77,7 @@ public class ScoreWidget extends ProgressWidget {
      */
     @Override
     protected void setDefaultDeltaFactor() {
-        if(scoreFormat != null) {
+        if (scoreFormat != null) {
             switch (scoreFormat) {
                 case KeyUtil.POINT_10_DECIMAL:
                     binding.progressCurrent.setInputType(InputType.TYPE_CLASS_NUMBER |
@@ -91,18 +93,18 @@ public class ScoreWidget extends ProgressWidget {
 
     private void setScoreMaximum() {
         binding.progressMaximum.setVisibility(VISIBLE);
-        if(CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
-            binding.progressMaximum.setText(String.format(Locale.getDefault(),"/ %.1f", scoreMaximum));
+        if (CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
+            binding.progressMaximum.setText(String.format(Locale.getDefault(), "/ %.1f", scoreMaximum));
         else
-            binding.progressMaximum.setText(String.format(Locale.getDefault(),"/ %d", (int)scoreMaximum));
+            binding.progressMaximum.setText(String.format(Locale.getDefault(), "/ %d", (int) scoreMaximum));
     }
 
     public void setScoreCurrent(float scoreCurrent) {
         this.scoreCurrent = scoreCurrent;
-        if(CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
+        if (CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
             binding.progressCurrent.setText(String.format(Locale.getDefault(), "%.1f", scoreCurrent));
         else
-            binding.progressCurrent.setText(String.format(Locale.getDefault(), "%d", (int)scoreCurrent));
+            binding.progressCurrent.setText(String.format(Locale.getDefault(), "%d", (int) scoreCurrent));
     }
 
     public float getScoreCurrent() {
@@ -110,7 +112,7 @@ public class ScoreWidget extends ProgressWidget {
     }
 
     private boolean boundCheck(float delta) {
-        if(scoreMaximum < 1f)
+        if (scoreMaximum < 1f)
             return delta > -0.1f;
         return delta > -0.1f && delta <= scoreMaximum;
     }
@@ -118,10 +120,10 @@ public class ScoreWidget extends ProgressWidget {
     private void scoreChange(float delta) {
         if (boundCheck(delta)) {
             scoreCurrent = delta;
-            if(CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
+            if (CompatUtil.equals(scoreFormat, KeyUtil.POINT_10_DECIMAL))
                 binding.progressCurrent.setText(String.format(Locale.getDefault(), "%.1f", scoreCurrent));
             else
-                binding.progressCurrent.setText(String.format(Locale.getDefault(), "%d", (int)scoreCurrent));
+                binding.progressCurrent.setText(String.format(Locale.getDefault(), "%d", (int) scoreCurrent));
             binding.progressCurrent.setSelection(binding.progressCurrent.getText().length());
         }
     }
@@ -154,11 +156,16 @@ public class ScoreWidget extends ProgressWidget {
         String currentChange = editable.toString();
         float temporaryValue = 0;
         try {
-            temporaryValue = !TextUtils.isEmpty(currentChange) ? Float.parseFloat(currentChange) : 0;
-        } catch (NumberFormatException e) {
+            temporaryValue = !TextUtils.isEmpty(currentChange) ? new DecimalFormat("#.#").parse(currentChange).floatValue() : 0;
+        } catch (ParseException e) {
             e.printStackTrace();
         }
-        if(boundCheck(temporaryValue))
+        if (scoreFormat.equals(KeyUtil.POINT_10_DECIMAL) && !boundCheck(temporaryValue)) {
+            temporaryValue /= 10;
+            scoreCurrent = temporaryValue;
+            binding.progressCurrent.post(() -> scoreChange(scoreCurrent));
+        }
+        if (boundCheck(temporaryValue))
             scoreCurrent = temporaryValue;
         else
             binding.progressCurrent.post(() -> scoreChange(scoreCurrent));

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/ScoreWidget.java
@@ -3,8 +3,8 @@ package com.mxt.anitrend.base.custom.view.widget;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.text.Editable;
-import android.text.InputType;
 import android.text.TextUtils;
+import android.text.method.DigitsKeyListener;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -80,8 +80,8 @@ public class ScoreWidget extends ProgressWidget {
         if (scoreFormat != null) {
             switch (scoreFormat) {
                 case KeyUtil.POINT_10_DECIMAL:
-                    binding.progressCurrent.setInputType(InputType.TYPE_CLASS_NUMBER |
-                            InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                    char separator = DecimalFormatSymbols.getInstance().getDecimalSeparator();
+                    binding.progressCurrent.setKeyListener(DigitsKeyListener.getInstance("0123456789" + separator));
                     deltaFactor = 0.1f;
                     break;
                 default:


### PR DESCRIPTION

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [x] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved
- [x] I did not commit files that are excluded in the .gitignore file

## Description
In some countries, decimals are represented as `1,0` instead of `1.0`. This pattern is not correctly understood by the app and causes incorrect Score being set or causing a crash. 
Also makes the score to be converted automatically into a proper decimal when giving a double digit input. (`58` will automatically change to `5.8`)

## Motivation and Context
Fixes the bug, allowing people to use the `1,0` pattern when using the Decimal Score System as per their Locale. 
For the automatic decimal conversion, let's the user give a faster way to input scores as well as not get puzzled with the likely confusion when the scores were being reset on double digit input.

## How Has This Been Tested?
Used increment and decrement buttons to set, then refresh to check the Score again.
Repeated for both locales (comma and dot separator) and keyboard input instead of the increment/decrement buttons. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)