### PR TITLE
Add google-services.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,7 @@ fabric.properties
 # Credentials File
 secrets.properties
 
+# Google services local configuration
+app/google-services.json
+
 .directory


### PR DESCRIPTION
This pull request adds ``app/google-services.json`` to the ``.gitignore``

When you clone the repo and [follow the getting started instructions](https://anitrend.gitbook.io/project/getting-started) you will end up with a dirty (untracked file) git stage. This pull request fixes that by ignoring the configuration file.