### PR TITLE
Add more details to notifications.

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/service/JobDispatcherService.kt
+++ b/app/src/main/java/com/mxt/anitrend/service/JobDispatcherService.kt
@@ -7,7 +7,9 @@ import androidx.work.WorkerParameters
 import com.mxt.anitrend.base.custom.consumer.BaseConsumer
 import com.mxt.anitrend.model.api.retro.WebFactory
 import com.mxt.anitrend.model.api.retro.anilist.UserModel
+import com.mxt.anitrend.model.entity.anilist.Notification
 import com.mxt.anitrend.model.entity.anilist.User
+import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.presenter.base.BasePresenter
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotificationUtil
@@ -82,8 +84,12 @@ class JobDispatcherService(context: Context, workerParams: WorkerParameters) : W
     }
 
     private fun requestNotifications(user: User) {
-        if (user.unreadNotificationCount > 0)
-            notificationUtil.createNotification(user)
+        val notificationsContainer = userEndpoint.getUserNotifications(
+            GraphUtil.getDefaultQuery(false)
+        ).execute().body() as PageContainer<Notification>?
+
+        if (user.unreadNotificationCount > 0 && notificationsContainer != null)
+            notificationUtil.createNotification(user, notificationsContainer)
     }
 
     companion object {

--- a/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
+++ b/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
@@ -7,12 +7,18 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Build
+import android.text.SpannableStringBuilder
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.PRIORITY_HIGH
+import androidx.core.text.bold
 import com.mxt.anitrend.R
+import com.mxt.anitrend.model.entity.anilist.Notification
 import com.mxt.anitrend.model.entity.anilist.User
+import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.view.activity.detail.NotificationActivity
 import org.koin.core.KoinComponent
+import java.lang.StringBuilder
+import kotlin.math.min
 
 /**
  * Created by max on 1/22/2017.
@@ -41,7 +47,68 @@ class NotificationUtil(
         )
     }
 
-    fun createNotification(userGraphContainer: User) {
+    private fun buildBigNotificationContent(unreadCount: Int, notificationsContainer: PageContainer<Notification>): CharSequence {
+
+        // Take the (at most) last 5 unread notifications
+        // and build a list that will be used as the content of the expanded notification.
+
+        val maxNotifications = min(unreadCount, 5)
+        val displayedNotificationsCount = min(maxNotifications, notificationsContainer.pageData.size)
+
+        val builder = SpannableStringBuilder()
+        for (i in 0 until displayedNotificationsCount) {
+            val notification = notificationsContainer.pageData[i]
+            builder.bold {
+                builder.append("• ")
+            }
+            when (notification.type) {
+                KeyUtil.ACTIVITY_MESSAGE,
+                KeyUtil.FOLLOWING,
+                KeyUtil.ACTIVITY_MENTION,
+                KeyUtil.THREAD_COMMENT_MENTION,
+                KeyUtil.THREAD_SUBSCRIBED,
+                KeyUtil.THREAD_COMMENT_REPLY,
+                KeyUtil.ACTIVITY_LIKE,
+                KeyUtil.ACTIVITY_REPLY,
+                KeyUtil.ACTIVITY_REPLY_SUBSCRIBED,
+                KeyUtil.ACTIVITY_REPLY_LIKE,
+                KeyUtil.THREAD_LIKE,
+                KeyUtil.THREAD_COMMENT_LIKE -> {
+                    builder.bold {
+                        builder.append(notification.user.name)
+                    }
+                    builder.append(": ")
+                    builder.append(notification.context)
+                }
+                KeyUtil.AIRING -> {
+                    builder.bold {
+                        builder.append(notification.media.title.userPreferred)
+                    }
+                    builder.append(": ")
+                    builder.append(context.getString(R.string.notification_episode,
+                        notification.episode.toString(), notification.media.title.userPreferred))
+                }
+                KeyUtil.RELATED_MEDIA_ADDITION -> {
+                    builder.bold {
+                        builder.append(notification.media.title.userPreferred)
+                    }
+                    builder.append(": ")
+                    builder.append(notification.context)
+                }
+            }
+            if (i != displayedNotificationsCount - 1) {
+                builder.appendln()
+            }
+        }
+
+        if (unreadCount > displayedNotificationsCount) {
+            builder.append("\n• ...")
+        }
+
+        return builder
+    }
+
+    fun createNotification(userGraphContainer: User, notificationsContainer: PageContainer<Notification>) {
 
         val notificationBuilder = NotificationCompat.Builder(context, KeyUtil.CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_new_releases)
@@ -74,14 +141,17 @@ class NotificationUtil(
         val notificationCount = userGraphContainer.unreadNotificationCount
 
         if (notificationCount > 0) {
+            val notificationContent = buildBigNotificationContent(notificationCount, notificationsContainer)
             notificationBuilder.setContentIntent(multiContentIntent())
-                    .setContentTitle(context.getString(R.string.alerter_notification_title))
-                    .setContentText(context.getString(
+                    .setContentTitle(context.getString(
                             when (notificationCount > 1) {
                                 true -> R.string.text_notifications
                                 else -> R.string.text_notification
                             }, notificationCount)
                     )
+                    .setContentText(notificationContent)
+                    .setStyle(NotificationCompat.BigTextStyle()
+                            .bigText(notificationContent))
 
             defaultNotificationId = defaultNotificationId.inc()
             notificationManager?.notify(defaultNotificationId, notificationBuilder.build())


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [x] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [x] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved
- [x] I did not commit files that are excluded in the .gitignore file (Happens if you stage files with Android Studio)


## Description

Right now, the Android notification shows only the number of unread notifications, and does not provide any context on what those notifications are.

This PR adds a bit more info to the notification so that the user can see right from the drawer his latest notifications.

*Note*: this is a very simple and limited implementation, but it should be sufficient for its limited goal.

## Motivation and Context

Being able to see the latest notifications without opening the app might be a useful feature, especially 
for those users (like me) who keep the notifications around as a reminder.

## How Has This Been Tested?

I personally tested this only on my Samsung S7 Edge.

## Screenshots (if appropriate):

Collapsed notification:

![Collapsed](https://user-images.githubusercontent.com/852259/64911933-5074b400-d728-11e9-87f5-d5f971e6d1a8.jpg)

Expanded notification:

![Expanded](https://user-images.githubusercontent.com/852259/64911934-57032b80-d728-11e9-8e7a-f536873609a5.jpg)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/master/LICENSE.md).