### PR TITLE
Add a delete dialog to avoid users accidental ly deleting activity posts

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/StatusDeleteWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/StatusDeleteWidget.java
@@ -1,5 +1,6 @@
 package com.mxt.anitrend.base.custom.view.widget;
 
+import android.Manifest;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -7,6 +8,7 @@ import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
 
 import com.mxt.anitrend.R;
 import com.mxt.anitrend.base.custom.consumer.BaseConsumer;
@@ -18,6 +20,7 @@ import com.mxt.anitrend.model.entity.anilist.FeedReply;
 import com.mxt.anitrend.model.entity.anilist.meta.DeleteState;
 import com.mxt.anitrend.presenter.widget.WidgetPresenter;
 import com.mxt.anitrend.util.CompatUtil;
+import com.mxt.anitrend.util.DialogUtil;
 import com.mxt.anitrend.util.KeyUtil;
 import com.mxt.anitrend.util.NotifyUtil;
 import com.mxt.anitrend.util.graphql.AniGraphErrorUtilKt;
@@ -100,16 +103,22 @@ public class StatusDeleteWidget extends FrameLayout implements CustomView, Retro
 
     @Override
     public void onClick(View view) {
-        switch (view.getId()) {
-            case R.id.widget_flipper:
-                if (binding.widgetFlipper.getDisplayedChild() == WidgetPresenter.CONTENT_STATE) {
-                    binding.widgetFlipper.showNext();
-                    presenter.requestData(requestType, getContext(), this);
-                }
-                else
-                    NotifyUtil.INSTANCE.makeText(getContext(), R.string.busy_please_wait, Toast.LENGTH_SHORT).show();
-                break;
-        }
+        DialogUtil.createMessage(getContext(), R.string.dialog_title_delete_activity, R.string.dialog_message_delete_activity, (dialog, which) -> {
+            switch (which) {
+                case POSITIVE:
+                    if (view.getId() == R.id.widget_flipper) {
+                        if (binding.widgetFlipper.getDisplayedChild() == WidgetPresenter.CONTENT_STATE) {
+                            binding.widgetFlipper.showNext();
+                            presenter.requestData(requestType, getContext(), this);
+                        } else
+                            NotifyUtil.INSTANCE.makeText(getContext(), R.string.busy_please_wait, Toast.LENGTH_SHORT).show();
+                    }
+                    break;
+                case NEGATIVE:
+                    NotifyUtil.INSTANCE.makeText(getContext(), R.string.canceled_by_user, Toast.LENGTH_SHORT).show();
+                    break;
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/StatusDeleteWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/StatusDeleteWidget.java
@@ -1,6 +1,5 @@
 package com.mxt.anitrend.base.custom.view.widget;
 
-import android.Manifest;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -8,7 +7,6 @@ import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
 
 import com.mxt.anitrend.R;
 import com.mxt.anitrend.base.custom.consumer.BaseConsumer;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1038,4 +1038,7 @@
         <item>dark</item>
         <item>black</item>
     </string-array>
+
+    <string name="dialog_title_delete_activity" translatable="true">Delete Activity</string>
+    <string name="dialog_message_delete_activity" translatable="true">Are you sure you wanna delete this activity? This is irreversible!!</string>
 </resources>


### PR DESCRIPTION
# AniTrend Pull Request

- [ ] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [x] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved
- [x] I did not commit files that are excluded in the .gitignore file (Happens if you stage files with Android Studio)


## Description
<!--- Describe your changes in detail -->
This PR adds a dialog before deleting an activity post to make sure that the deletion was initiated by the user and not an accidental click.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Be kind to code reviewers, please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/master/LICENSE.md).