### PR TITLE
Fix opening a user's feed through a mention containing the global feed

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.java
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.java
@@ -15,6 +15,7 @@ import androidx.viewpager.widget.ViewPager;
 import com.mxt.anitrend.R;
 import com.mxt.anitrend.adapter.pager.detail.ProfilePageAdapter;
 import com.mxt.anitrend.base.custom.activity.ActivityBase;
+import com.mxt.anitrend.base.custom.consumer.BaseConsumer;
 import com.mxt.anitrend.base.custom.view.image.WideImageView;
 import com.mxt.anitrend.databinding.ActivityProfileBinding;
 import com.mxt.anitrend.model.entity.base.UserBase;
@@ -146,6 +147,8 @@ public class ProfileActivity extends ActivityBase<UserBase, BasePresenter> imple
                     .showTapTarget(R.string.tip_compose_message_title,
                             R.string.tip_compose_message_text, R.id.action_message);
         }
+
+        getPresenter().notifyAllListeners(new BaseConsumer<>(KeyUtil.USER_BASE_REQ, model), false);
     }
 
     @Override

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserFeedFragment.java
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserFeedFragment.java
@@ -4,8 +4,13 @@ import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 
+import com.mxt.anitrend.base.custom.consumer.BaseConsumer;
+import com.mxt.anitrend.model.entity.base.UserBase;
 import com.mxt.anitrend.util.KeyUtil;
 import com.mxt.anitrend.view.fragment.list.FeedListFragment;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import io.github.wax911.library.model.request.QueryContainerBuilder;
 
@@ -53,8 +58,18 @@ public class UserFeedFragment extends FeedListFragment {
         else
             queryContainer.putVariable(KeyUtil.arg_userName, userName);
 
-        if (queryContainer.containsKey(KeyUtil.arg_userId) || queryContainer.containsKey(KeyUtil.arg_userName))
+        if (queryContainer.containsKey(KeyUtil.arg_userId))
             super.makeRequest();
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
+    public void onUserChange(BaseConsumer<UserBase> consumer) {
+        if (consumer.getRequestMode() == KeyUtil.USER_BASE_REQ) {
+            if (userId != consumer.getChangeModel().getId()) {
+                userId = consumer.getChangeModel().getId();
+                makeRequest();
+            }
+        }
     }
 
 }


### PR DESCRIPTION
# AniTrend Pull Request

## Description
This fixes the issue of having the global feed instead of the user's feed when opening a user's profile through mentions or links to profile

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now if you open another user's profile and go to their feed, it shows the global feed. This fixes that issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Yes, on my phone.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Be kind to code reviewers, please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/master/LICENSE.md).