### PR TITLE
Set Start Date on Watching Series

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AutoIncrementWidget.java
@@ -152,7 +152,8 @@ public class AutoIncrementWidget extends LinearLayout implements CustomView, Vie
 
 
     private void updateModelState() {
-        if(model.getProgress() < 1 && CompatUtil.INSTANCE.equals(model.getStatus(), KeyUtil.PLANNING)) {
+        if (model.getProgress() < 1 &&
+                (CompatUtil.INSTANCE.equals(model.getStatus(), KeyUtil.PLANNING) || CompatUtil.INSTANCE.equals(model.getStatus(), KeyUtil.CURRENT))) {
             model.setStatus(KeyUtil.CURRENT);
             model.setStartedAt(DateUtil.INSTANCE.getCurrentDate());
         }


### PR DESCRIPTION
# AniTrend Pull Request

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [x] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved
- [x] I did not commit files that are excluded in the .gitignore file (Happens if you stage files with Android Studio)


## Description
If progress is incremented on a currently watching series, the Start Date will be set. Previously, this would only happen in the case of Planning anime

## Motivation and Context
Anime that are set to watching with no progress won't have start dates set if user doesn't set one manually. Only if the anime was initially in Planning would it be set.

## How Has This Been Tested?
Haven't tested, however, very minimal risk change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Be kind to code reviewers, please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/master/LICENSE.md).