### PR TITLE
Dismiss last notification on "Mark All As Read" in NotificationFragment

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -86,7 +86,7 @@ private val coreModule = module {
         )
     }
 
-    factory {
+    single {
         val context = androidContext()
         NotificationUtil(
             context = context,

--- a/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
+++ b/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
@@ -188,4 +188,8 @@ class NotificationUtil(
             notificationManager?.notify(defaultNotificationId, notificationBuilder.build())
         }
     }
+
+    fun cancelLastNotification() {
+        notificationManager?.cancel(defaultNotificationId)
+    }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/NotificationFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/NotificationFragment.kt
@@ -14,6 +14,7 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.recycler.detail.NotificationAdapter
 import com.mxt.anitrend.base.custom.async.ThreadPool
 import com.mxt.anitrend.base.custom.fragment.FragmentBaseList
+import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.model.entity.anilist.Notification
 import com.mxt.anitrend.model.entity.base.NotificationHistory
 import com.mxt.anitrend.model.entity.base.NotificationHistory_
@@ -22,6 +23,7 @@ import com.mxt.anitrend.presenter.base.BasePresenter
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.NotificationUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.graphql.GraphUtil
 import com.mxt.anitrend.util.media.MediaActionUtil
@@ -164,6 +166,8 @@ class NotificationFragment : FragmentBaseList<Notification, PageContainer<Notifi
 
         presenter.database.getBoxStore(NotificationHistory::class.java)
                 .put(notificationHistories)
+
+        koinOf<NotificationUtil>().cancelLastNotification()
 
         activity?.runOnUiThread {
             if (mAdapter != null)


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/master/CONTRIBUTING.md)
- [ ] double-check your branch is based on `develop` and targets `develop` 
- [ ] Pull request has tests
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved
- [ ] I did not commit files that are excluded in the .gitignore file (Happens if you stage files with Android Studio)


## Description
This change makes "Mark All As Read" in NotificationFragment dismiss the last notification. To make that possible I had to make NotificationUtil a singleton and expose the cancelLastNotification() function.

## Motivation and Context
I thought that it'd be nice if marking notifications as read in app would also dismiss the notification.

## How Has This Been Tested?
Uncommented notification testing code in NotificationFragment and then clicked on "Mark All As Read" button.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Be kind to code reviewers, please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/master/LICENSE.md).