### PR TITLE
ci: disable submit_prod lane in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,19 +48,19 @@ platform :android do
     )
   end
 
-  desc "Promote existing Beta build to Production on Google Play"
-  lane :submit_prod do
-    upload_to_play_store(
-      track: 'beta',
-      track_promote_to: 'production',
-      track_promote_release_status: 'draft',
-      skip_upload_apk: true,
-      skip_upload_aab: true,
-      skip_upload_metadata: skip_metadata_upload,
-      skip_upload_images: skip_metadata_upload,
-      version_code: ENV['VERSION_CODE'],
-    )
-  end
+  # desc "Promote existing Beta build to Production on Google Play"
+  # lane :submit_prod do
+  #  upload_to_play_store(
+  #    track: 'beta',
+  #    track_promote_to: 'production',
+  #    track_promote_release_status: 'draft',
+  #    skip_upload_apk: true,
+  #    skip_upload_aab: true,
+  #    skip_upload_metadata: skip_metadata_upload,
+  #    skip_upload_images: skip_metadata_upload,
+  #    version_code: ENV['VERSION_CODE'],
+  #  )
+  # end
 
   desc "Deploy builds to Google Play"
   lane :deploy do |options|


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/develop/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/develop/CONTRIBUTING.md)
- Double checked that your branch is based on `develop` and targets `develop` (where applicable)
- Pull request has tests (if applicable)
- Documentation is updated (if necessary)
- Description explains the issue/use-case resolved


## Description
<!--- Describe your changes in detail, or link an existing issue here -->
Once the beta build is submitted it is published. The idea of the `submit_prod` lane was to promote the beta build to production automatically but leave it in awaiting review. however this doesn't seem to work as expected so we'll just leave it as is

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (Improves existing functionality)

<!--- Be kind to code reviewers, and please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/AniTrend/anitrend-app/blob/develop/LICENSE.md).
