### PR TITLE
ci: fix release workflow and fastlane deploy lane

### DIFF
--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -65,7 +65,7 @@ jobs:
         if: always() # always run even if the previous step fails
         run: |
           files=$(find app/build/outputs/apk/ -type f -name '*.apk')
-          gh release upload "${{ github.ref_name }}" $files
+          gh release upload "${{ github.ref_name }}" $files --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Test Report

--- a/.github/workflows/first-contribution-greeting.yaml
+++ b/.github/workflows/first-contribution-greeting.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: "Hey there! Thank you for creating an issue :) Please take a moment to review our [**community guidelines**](https://github.com/AniTrend/support-query-builder/blob/develop/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved."
-        pr-message: "Hey there! Thank you for this PR :) Please take a moment to review our [**community guidelines**](https://github.com/AniTrend/support-query-builder/blob/develop/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved."
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: "Hey there! Thank you for creating an issue :) Please take a moment to review our [**community guidelines**](https://github.com/AniTrend/support-query-builder/blob/develop/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved."
+        pr_message: "Hey there! Thank you for this PR :) Please take a moment to review our [**community guidelines**](https://github.com/AniTrend/support-query-builder/blob/develop/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,19 +48,19 @@ platform :android do
     )
   end
 
-  # desc "Promote existing Beta build to Production on Google Play"
-  # lane :submit_prod do
-  #  upload_to_play_store(
-  #    track: 'beta',
-  #    track_promote_to: 'production',
-  #    track_promote_release_status: 'draft',
-  #    skip_upload_apk: true,
-  #    skip_upload_aab: true,
-  #    skip_upload_metadata: skip_metadata_upload,
-  #    skip_upload_images: skip_metadata_upload,
-  #    version_code: ENV['VERSION_CODE'],
-  #  )
-  # end
+  desc "Promote existing Beta build to Production on Google Play"
+  lane :submit_prod do
+   upload_to_play_store(
+     track: 'beta',
+     track_promote_to: 'production',
+     track_promote_release_status: 'draft',
+     skip_upload_apk: true,
+     skip_upload_aab: true,
+     skip_upload_metadata: skip_metadata_upload,
+     skip_upload_images: skip_metadata_upload,
+     version_code: ENV['VERSION_CODE'],
+   )
+  end
 
   desc "Deploy builds to Google Play"
   lane :deploy do |options|
@@ -70,7 +70,7 @@ platform :android do
 
     build
     submit_beta
-    submit_prod
+    # submit_prod
   end
 
 end


### PR DESCRIPTION
## Description

Fixes the `android-build` workflow and `fastlane` deploy lane:

- **Disabled immutable releases** (repo setting) — allows `gh release upload` to add APKs after the release is published
- **Added `--clobber`** to `gh release upload` in `.github/workflows/android-build.yaml` — prevents duplicate asset errors on re-runs
- **Commented out `submit_prod`** call in `fastlane/Fastfile` — the lane was previously failing and intentionally skipped, but the calling code was left in, causing the build step to exit with code 1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)
