### PR TITLE
fix(ui): restore changelog dialog visibility after fresh install

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
@@ -108,6 +108,8 @@ class MainActivity : ActivityBase<User, BasePresenter>(), View.OnClickListener,
 
     private var tabMediator: TabLayoutMediator? = null
 
+    private var hasCheckedInstallation = false
+
     private lateinit var menuItems: Menu
 
     private lateinit var mHomeFeed: MenuItem
@@ -426,11 +428,10 @@ class MainActivity : ActivityBase<User, BasePresenter>(), View.OnClickListener,
     }
 
     private fun checkNewInstallation() {
+        if (hasCheckedInstallation) return
+        hasCheckedInstallation = true
         if (presenter.settings.isFreshInstall) {
             presenter.settings.isFreshInstall = false
-            if (presenter.settings.isUpdated) {
-                presenter.settings.setUpdated()
-            }
             mBottomSheet = BottomSheetMessage.Builder()
                 .setText(R.string.app_intro_guide)
                 .setTitle(R.string.app_intro_title)


### PR DESCRIPTION
## What

Fixes a regression from #1029 where the changelog dialog was permanently hidden after a fresh install.

## Root Cause

In `checkNewInstallation()`, the `setUpdated()` call inside the `isFreshInstall` branch prematurely cleared the `isUpdated` flag, then `return` prevented reaching the actual changelog code below. This made the changelog never show for any launch.

Additionally, the bottom sheet lifecycle triggered a second `onResume()` cycle, causing `checkNewInstallation()` to run twice. After `isFreshInstall` was cleared by the first call, the second call would hit `isUpdated=true` and stack the changelog dialog on top of the intro guide.

## Fix

1. **Removed premature `setUpdated()`** from the `isFreshInstall` branch — the `return` alone prevents stacking; let `isUpdated` survive for the next launch.
2. **Added `hasCheckedInstallation` session guard** — prevents the method from executing more than once per activity instance, eliminating the double-invocation caused by the bottom sheet lifecycle.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Fresh install (1st launch) | Changelog stacked on intro guide | Intro guide only |
| 2nd launch | Nothing (changelog permanently dead) | Changelog dialog |
| 3rd+ launch | Nothing | Nothing