### PR TITLE
ci: enable version-updater auto-merge with app-token PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'renovate[bot]' || github.ref == 'refs/heads/platform/update-version-meta-data' || github.event_name == 'workflow_dispatch'
+    if: github.actor == 'renovate[bot]' || github.head_ref == 'platform/update-version-meta-data' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: hmarr/auto-approve-action@v4.0.0
         with:

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -14,18 +14,44 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Configure properties
         run: bash .github/scripts/setup-config.sh
 
       - name: Generate version information
+        id: version
         run: |
+          CURRENT_VERSION=""
+          if [[ -f gradle/version.properties ]]; then
+            CURRENT_VERSION="$(grep '^version=' gradle/version.properties | cut -d'=' -f2)"
+          fi
+
+          PREVIOUS_VERSION_DISPLAY="$CURRENT_VERSION"
+          if [[ -z "$PREVIOUS_VERSION_DISPLAY" ]]; then
+            PREVIOUS_VERSION_DISPLAY="unknown"
+          fi
+
           # Extract version from event payload
           VERSION="${{ github.event.client_payload.version }}"
           echo "$VERSION" > VERSION
+
+          {
+            printf 'previous_version=%s\n' "$CURRENT_VERSION"
+            printf 'previous_version_display=%s\n' "$PREVIOUS_VERSION_DISPLAY"
+            printf 'next_version=%s\n' "$VERSION"
+          } >> "$GITHUB_OUTPUT"
 
           # Parse and compute code
           IFS='.' read -ra VER <<< "$VERSION"
@@ -66,17 +92,30 @@ jobs:
         run: rm VERSION
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           signoff: true
           delete-branch: true
-          commit-message: "automation: update version.properties and version.json"
+          commit-message: "automation: bump version ${{ steps.version.outputs.previous_version_display }} -> ${{ steps.version.outputs.next_version }}"
           author: "Author <actions@github.com>"
-          title: "platform: automated version update"
+          title: "platform: bump version ${{ steps.version.outputs.previous_version_display }} -> ${{ steps.version.outputs.next_version }}"
           body: |
-            This PR was automatically generated to update `version.properties` and `app/.meta/version.json`
+            This PR was automatically generated to bump AniTrend version metadata.
+
+            - Previous version: `${{ steps.version.outputs.previous_version_display }}`
+            - New version: `${{ steps.version.outputs.next_version }}`
+            - Updated files:
+              - `gradle/version.properties`
+              - `app/.meta/version.json`
           branch: platform/update-version-meta-data
           labels: "skip-changelog"
           assignees: "wax911"
           reviewers: "wax911"
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"

--- a/docs/superpowers/specs/2026-06-12-version-updater-automerge-design.md
+++ b/docs/superpowers/specs/2026-06-12-version-updater-automerge-design.md
@@ -1,0 +1,70 @@
+## Title
+
+Enable reliable auto-merge for `version-updater.yml`
+
+## Context
+
+The `version-update` workflow currently creates a PR from `platform/update-version-meta-data` into `develop` using `peter-evans/create-pull-request@v8` with the default `GITHUB_TOKEN`. That token does not trigger downstream `on: pull_request` and `on: push` workflows for PRs created by the action, which prevents required checks from appearing consistently and blocks auto-merge.
+
+Related repository behavior already in place:
+
+- `release-drafter.yml` dispatches the `version-update-and-push` event.
+- `auto-approve.yml` already recognizes `platform/update-version-meta-data` and auto-approves PRs from that branch.
+- PRs are expected to target `develop`.
+
+## Decision
+
+Use a GitHub App token generated at runtime from `APP_ID` and `APP_PRIVATE_KEY`, then use that token for checkout, PR creation, and enabling auto-merge.
+
+This is preferred over using the default `GITHUB_TOKEN` plus a reopen workaround because the App token allows the created PR to trigger normal PR/push workflows and keeps the workflow deterministic.
+
+## Workflow Changes
+
+1. Add a token generation step using `actions/create-github-app-token`.
+2. Use the App token in `actions/checkout` so subsequent git operations are consistently authenticated with the same identity.
+3. Use the App token in `peter-evans/create-pull-request@v8`.
+4. Capture the previous and next version in the workflow so the PR title/body can describe the bump as `from -> to`.
+5. Add an auto-merge enablement step that only runs when the PR action creates or updates a PR.
+6. Keep the existing automation branch `platform/update-version-meta-data`, base branch `develop`, and `skip-changelog` label so current release automation continues to work.
+
+## Permissions
+
+Top-level workflow permissions should remain minimal.
+
+The version update job should keep or add only the permissions needed for:
+
+- updating contents
+- creating or updating pull requests
+
+If the auto-merge step uses the GitHub CLI or API with the App token, no broader repository policy changes are planned inside this workflow.
+
+## PR Metadata
+
+The PR should become more descriptive:
+
+- Title example: `platform: bump version 2.3.4 -> 2.3.5`
+- Body should state which generated files changed and explicitly mention the version transition.
+
+The commit message can remain automation-focused, but it should also include the bumped version when practical.
+
+## Validation Plan
+
+After implementation:
+
+1. Verify workflow YAML syntax is valid.
+2. Verify the workflow still targets `develop` and the automation branch name is unchanged.
+3. Verify the PR creation step now uses the App token.
+4. Verify the auto-merge step is conditional and uses the created PR number.
+5. Verify the resulting git diff is limited to the intended workflow changes.
+
+## Risks And Mitigations
+
+- **Missing app secrets**: the workflow will fail early when `APP_ID` or `APP_PRIVATE_KEY` is unavailable.
+- **Insufficient app permissions**: document the need for `contents: write`, `pull requests: write`, and workflow-related access if required for workflow-file PRs.
+- **Auto-merge still blocked by branch protection**: this change does not bypass protection rules; it ensures the expected checks can run so auto-merge can complete normally.
+
+## Non-Goals
+
+- Changing repository branch protection rules.
+- Renaming the automation branch.
+- Refactoring unrelated GitHub workflows.


### PR DESCRIPTION
# AniTrend Pull Request

## Description
- switches `version-updater.yml` from `GITHUB_TOKEN` to a GitHub App token generated from `APP_ID` and `APP_PRIVATE_KEY`
- ensures PRs created by the workflow can trigger downstream pull-request checks, which is required for reliable auto-merge
- enables auto-merge on the generated version bump PR after creation/update
- makes the generated version bump PR metadata descriptive, including the version transition as `from -> to`
- fixes `auto-approve.yml` to detect the automation PR by `github.head_ref`, so the version bump PR can still receive automatic approval

## Screenshots:
- Not applicable

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

## Verification
- validated both workflow files with Python YAML parsing
- confirmed the new App-token/automerge/version-metadata markers are present in `version-updater.yml`
- reviewed the final workflow diffs for `version-updater.yml` and `auto-approve.yml`
