### PR TITLE
refactor(buildSrc): close AGP 9 migration gaps

### DIFF
--- a/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/AndroidComponents.kt
+++ b/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/AndroidComponents.kt
@@ -111,7 +111,7 @@ private fun ApplicationExtension.configureBuildFlavours(logger: Logger) {
 }
 
 private fun ApplicationExtension.setUpWith(project: Project) {
-    compileSdkVersion(37)
+    compileSdk = 37
     defaultConfig {
         applicationId = "com.mxt.anitrend"
         minSdk = 23
@@ -120,7 +120,6 @@ private fun ApplicationExtension.setUpWith(project: Project) {
         versionName = project.props[PropertyTypes.VERSION]
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-        multiDexEnabled = true
     }
 
     project.createSigningConfiguration(this)
@@ -140,8 +139,8 @@ private fun ApplicationExtension.setUpWith(project: Project) {
                 "proguard-rules.pro",
             )
             if (releaseSigningConfig != null) {
-                project.logger.lifecycle("Applying signing configuration for to build type: $name")
-                (this as com.android.build.gradle.internal.dsl.BuildType).signingConfig = releaseSigningConfig
+                project.logger.lifecycle("Applying signing configuration to build type: $name")
+                signingConfig = releaseSigningConfig
             }
         }
 

--- a/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/PluginComponents.kt
+++ b/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/PluginComponents.kt
@@ -7,10 +7,9 @@ internal fun Project.configurePlugins() {
     plugins.apply("com.android.application")
     plugins.apply("com.diffplug.spotless")
     plugins.apply("co.anitrend.retrofit.graphql.codegen")
-    plugins.apply("kotlin-android")
     plugins.apply("kotlinx-serialization")
     plugins.apply("kotlin-parcelize")
-    plugins.apply("kotlin-kapt")
+    plugins.apply("com.android.legacy-kapt")
     plugins.apply("io.objectbox")
 
     tasks.matching { it.name.startsWith("objectbox") }.configureEach {

--- a/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/extensions/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/extensions/ProjectExtensions.kt
@@ -36,8 +36,6 @@ internal fun Project.baseExtension() = extensions.getByType<ApplicationExtension
 
 internal fun Project.androidComponents() = extensions.getByType<ApplicationAndroidComponentsExtension>()
 
-internal fun Project.baseAppExtension() = extensions.getByType<ApplicationExtension>()
-
 internal fun Project.containsAndroidPlugin(): Boolean =
     project.extensions.findByType(ApplicationExtension::class.java) != null
 
@@ -47,6 +45,6 @@ internal fun Project.spotlessExtension() = extensions.getByType<SpotlessExtensio
 
 internal fun Project.runIfAppModule(body: ApplicationExtension.() -> Unit) {
     if (containsAndroidPlugin()) {
-        body(baseAppExtension())
+        body(baseExtension())
     }
 }

--- a/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/plugins/LegacyKaptPlugin.kt
+++ b/buildSrc/src/main/java/com/mxt/anitrend/buildsrc/plugins/LegacyKaptPlugin.kt
@@ -1,0 +1,27 @@
+package com.mxt.anitrend.buildsrc.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * No-op plugin matching the [com.android.legacy-kapt] plugin ID that AGP 9.x
+ * expects when built-in Kotlin is enabled and KSP migration is not possible.
+ *
+ * AGP's [BuiltInKotlinServicesKt.initBuiltInKaptSupportIfRequired] registers a
+ * [PluginManager.withPlugin("com.android.legacy-kapt")] listener. When this
+ * plugin is applied, AGP calls [initBuiltInKaptSupport], which registers the
+ * [kapt] extension (and its Gradle configuration) from the already-initialised
+ * [KotlinBaseApiPlugin].
+ *
+ * The plugin body is intentionally empty; all kapt wiring is done by AGP's
+ * built-in Kotlin support upon detecting this plugin ID.
+ *
+ * Remove this descriptor and class once AGP ships its own
+ * `com.android.legacy-kapt` plugin descriptor, otherwise a duplicate plugin ID
+ * conflict will occur during dependency resolution.
+ */
+class LegacyKaptPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        // No-op: AGP's withPlugin callback handles all kapt setup.
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/com.android.legacy-kapt.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/com.android.legacy-kapt.properties
@@ -1,0 +1,1 @@
+implementation-class=com.mxt.anitrend.buildsrc.plugins.LegacyKaptPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,6 @@ kotlin.code.style=official
 
 # Faster Gradle builds by parallelizing tasks
 kotlin.parallel.tasks.in.project=true
-
-# KAPT 1.3.30 and higher also support incremental annotation processors
-kapt.incremental.apt=true
-
 # For tracking root causes for obseleteApi in gradle build
 # android.debug.obsoleteApi=true
 
@@ -41,5 +37,3 @@ org.gradle.configuration-cache=true
 # AGP & Gradle 8.0 backwards compatibility mode
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
-android.newDsl=false
-android.builtInKotlin=false


### PR DESCRIPTION
## Description
- enable AGP 9 built-in Kotlin by default and preserve kapt via the local `com.android.legacy-kapt` bridge
- remove the AGP new DSL opt-out and migrate remaining build logic to the public DSL
- drop dead multidex and duplicate buildSrc helper wiring

## Validation
- `./gradlew help --no-daemon`
- `./gradlew build --dry-run --no-daemon`
- `./gradlew :app:compileAppDebugKotlin --no-daemon`
- `./gradlew :app:assembleAppDebug --no-daemon`
- `./gradlew :app:assembleGithubDebug --no-daemon`
- `./gradlew :app:testGithubDebugUnitTest --no-daemon`

Closes #1004