### PR TITLE
fix(ui): complete Material 3 redesign refresh

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
@@ -32,12 +32,11 @@ class MediaLatestAdapter(context: Context) : RecyclerViewAdapter<MediaBase>(cont
         R.id.custom_rating_widget,
     )
 
-    override fun onCreateViewHolder(parent: ViewGroup, @RecyclerViewType viewType: Int): RecyclerViewHolder<MediaBase> =
-        if (viewType == KeyUtil.RECYCLER_TYPE_ANIME) {
-            LatestAnimeViewHolder(AdapterLatestAnimeBinding.inflate(LayoutInflater.from(parent.context), parent, false))
-        } else {
-            LatestMangaViewHolder(AdapterLatestMangaBinding.inflate(LayoutInflater.from(parent.context), parent, false))
-        }
+    override fun onCreateViewHolder(parent: ViewGroup, @RecyclerViewType viewType: Int): RecyclerViewHolder<MediaBase> = if (viewType == KeyUtil.RECYCLER_TYPE_ANIME) {
+        LatestAnimeViewHolder(AdapterLatestAnimeBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+    } else {
+        LatestMangaViewHolder(AdapterLatestMangaBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+    }
 
     @RecyclerViewType
     override fun getItemViewType(position: Int): Int = if (data[position].type == KeyUtil.ANIME) {

--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
@@ -20,6 +20,9 @@ import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.KeyUtil.RecyclerViewType
 
+/**
+ * Adapter for rendering the latest anime and manga media cards.
+ */
 class MediaLatestAdapter(context: Context) : RecyclerViewAdapter<MediaBase>(context) {
 
     private val cardInteractionIds = intArrayOf(
@@ -47,13 +50,18 @@ class MediaLatestAdapter(context: Context) : RecyclerViewAdapter<MediaBase>(cont
 
     override fun getFilter(): Filter? = null
 
+    /**
+     * View holder for the latest anime card layout.
+     */
     inner class LatestAnimeViewHolder(
         private val binding: AdapterLatestAnimeBinding,
     ) : RecyclerViewHolder<MediaBase>(binding.root) {
 
         init {
-            bindClickListeners(*cardInteractionIds)
-            bindLongClickListeners(*cardInteractionIds)
+            cardInteractionIds.forEach { viewId ->
+                bindClickListeners(viewId)
+                bindLongClickListeners(viewId)
+            }
         }
 
         override fun onBindViewHolder(model: MediaBase) {
@@ -76,13 +84,18 @@ class MediaLatestAdapter(context: Context) : RecyclerViewAdapter<MediaBase>(cont
         override fun onLongClick(v: View): Boolean = performLongClick(clickListener, data, itemView)
     }
 
+    /**
+     * View holder for the latest manga card layout.
+     */
     inner class LatestMangaViewHolder(
         private val binding: AdapterLatestMangaBinding,
     ) : RecyclerViewHolder<MediaBase>(binding.root) {
 
         init {
-            bindClickListeners(*cardInteractionIds)
-            bindLongClickListeners(*cardInteractionIds)
+            cardInteractionIds.forEach { viewId ->
+                bindClickListeners(viewId)
+                bindLongClickListeners(viewId)
+            }
         }
 
         override fun onBindViewHolder(model: MediaBase) {

--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/MediaLatestAdapter.kt
@@ -1,0 +1,108 @@
+package com.mxt.anitrend.adapter.recycler.index
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Filter
+import com.bumptech.glide.Glide
+import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.recycler.RecyclerViewAdapter
+import com.mxt.anitrend.base.custom.recycler.RecyclerViewHolder
+import com.mxt.anitrend.base.custom.view.image.AspectImageView
+import com.mxt.anitrend.base.custom.view.text.AiringTextView
+import com.mxt.anitrend.base.custom.view.text.SeriesYearTypeTextView
+import com.mxt.anitrend.base.custom.view.widget.SeriesStatusWidget
+import com.mxt.anitrend.binding.setAverageRating
+import com.mxt.anitrend.databinding.AdapterLatestAnimeBinding
+import com.mxt.anitrend.databinding.AdapterLatestMangaBinding
+import com.mxt.anitrend.model.entity.base.MediaBase
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.KeyUtil.RecyclerViewType
+
+class MediaLatestAdapter(context: Context) : RecyclerViewAdapter<MediaBase>(context) {
+
+    private val cardInteractionIds = intArrayOf(
+        R.id.container,
+        R.id.series_image,
+        R.id.series_status,
+        R.id.series_airing,
+        R.id.series_title,
+        R.id.series_year_type,
+        R.id.custom_rating_widget,
+    )
+
+    override fun onCreateViewHolder(parent: ViewGroup, @RecyclerViewType viewType: Int): RecyclerViewHolder<MediaBase> =
+        if (viewType == KeyUtil.RECYCLER_TYPE_ANIME) {
+            LatestAnimeViewHolder(AdapterLatestAnimeBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        } else {
+            LatestMangaViewHolder(AdapterLatestMangaBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        }
+
+    @RecyclerViewType
+    override fun getItemViewType(position: Int): Int = if (data[position].type == KeyUtil.ANIME) {
+        KeyUtil.RECYCLER_TYPE_ANIME
+    } else {
+        KeyUtil.RECYCLER_TYPE_MANGA
+    }
+
+    override fun getFilter(): Filter? = null
+
+    inner class LatestAnimeViewHolder(
+        private val binding: AdapterLatestAnimeBinding,
+    ) : RecyclerViewHolder<MediaBase>(binding.root) {
+
+        init {
+            bindClickListeners(*cardInteractionIds)
+            bindLongClickListeners(*cardInteractionIds)
+        }
+
+        override fun onBindViewHolder(model: MediaBase) {
+            AspectImageView.setImage(binding.seriesImage, model.coverImage)
+            SeriesStatusWidget.setStatus(binding.seriesStatus, model)
+            AiringTextView.setAiring(binding.seriesAiring, model)
+            SeriesYearTypeTextView.htmlText(binding.seriesYearType, model)
+            binding.customRatingWidget.setAverageRating(model)
+            binding.seriesTitle.setTitle(model)
+        }
+
+        override fun onViewRecycled() {
+            Glide.with(context).clear(binding.seriesImage)
+        }
+
+        override fun onClick(v: View) {
+            performClick(clickListener, data, itemView)
+        }
+
+        override fun onLongClick(v: View): Boolean = performLongClick(clickListener, data, itemView)
+    }
+
+    inner class LatestMangaViewHolder(
+        private val binding: AdapterLatestMangaBinding,
+    ) : RecyclerViewHolder<MediaBase>(binding.root) {
+
+        init {
+            bindClickListeners(*cardInteractionIds)
+            bindLongClickListeners(*cardInteractionIds)
+        }
+
+        override fun onBindViewHolder(model: MediaBase) {
+            AspectImageView.setImage(binding.seriesImage, model.coverImage)
+            SeriesStatusWidget.setStatus(binding.seriesStatus, model)
+            SeriesYearTypeTextView.htmlText(binding.seriesYearType, model)
+            binding.customRatingWidget.setAverageRating(model)
+            binding.seriesTitle.setTitle(model)
+            binding.seriesAiring.text = binding.root.context.getString(R.string.label_latest_release)
+        }
+
+        override fun onViewRecycled() {
+            Glide.with(context).clear(binding.seriesImage)
+        }
+
+        override fun onClick(v: View) {
+            performClick(clickListener, data, itemView)
+        }
+
+        override fun onLongClick(v: View): Boolean = performLongClick(clickListener, data, itemView)
+    }
+}

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FuzzyDateWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FuzzyDateWidget.kt
@@ -37,17 +37,13 @@ constructor(
         onInit()
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    constructor(
-        context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int,
-        defStyleRes: Int,
-    ) : this(context, attrs, defStyleAttr)
-
     override fun onInit() {
         binding = WidgetFuzzyDateBinding.inflate(context.getLayoutInflater(), this, true)
+        isClickable = true
+        isFocusable = true
+        setOnClickListener(this)
         binding.fuzzyDateInputLayout.setOnClickListener(this)
+        binding.fuzzyDateText.setOnClickListener(this)
     }
 
     fun setDate(fuzzyDate: FuzzyDate?) {

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FuzzyDateWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FuzzyDateWidget.kt
@@ -1,10 +1,8 @@
 package com.mxt.anitrend.base.custom.view.widget
 
-import android.annotation.TargetApi
 import android.app.DatePickerDialog
 import android.content.Context
 import android.content.DialogInterface
-import android.os.Build
 import android.util.AttributeSet
 import android.view.View
 import android.widget.DatePicker

--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -555,7 +555,7 @@ private val mediaFeatureModule = module {
     viewModel { MediaRelationViewModel(mediaRepository = get()) }
     viewModel { MediaStaffViewModel(mediaRepository = get()) }
     viewModel { MediaStatsViewModel(mediaRepository = get()) }
-    viewModel { MediaViewModel(mediaRepository = get(), baseRepository = get()) }
+    viewModel { MediaViewModel(mediaRepository = get(), baseRepository = get(), browseRepository = get()) }
     viewModel { MediaSearchViewModel(searchRepository = get()) }
     viewModel { MediaFavouritesViewModel(userRepository = get()) }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.view.View
 import android.view.Window
 import android.view.WindowManager
 import android.widget.Toast

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
@@ -10,6 +10,7 @@ import android.view.WindowManager
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
@@ -63,6 +64,7 @@ class GiphyPreviewActivity :
 
         binding = ActivityGiphyPreviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        binding.previewClose.setOnClickListener { finish() }
 
         val args = fromIntent(intent)
         if (args != null) {
@@ -78,6 +80,7 @@ class GiphyPreviewActivity :
                 R.drawable.ic_warning_white_18dp,
                 Toast.LENGTH_SHORT,
             ).show()
+            showStatus(R.string.layout_empty_response)
         }
 
         binding.previewCredits.setImageResource(
@@ -94,7 +97,12 @@ class GiphyPreviewActivity :
         model: Any,
         target: Target<Drawable>,
         isFirstResource: Boolean,
-    ): Boolean = false
+    ): Boolean {
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            showStatus(R.string.text_unknown_error)
+        }
+        return false
+    }
 
     override fun onResourceReady(
         resource: Drawable,
@@ -104,8 +112,15 @@ class GiphyPreviewActivity :
         isFirstResource: Boolean,
     ): Boolean {
         if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-            binding.previewProgress.visibility = View.GONE
+            binding.previewLoadingContainer.isVisible = false
+            binding.previewStatusCard.isVisible = false
         }
         return false
+    }
+
+    private fun showStatus(messageRes: Int) {
+        binding.previewLoadingContainer.isVisible = false
+        binding.previewStatusMessage.setText(messageRes)
+        binding.previewStatusCard.isVisible = true
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
@@ -2,15 +2,26 @@ package com.mxt.anitrend.view.activity.base
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.FirebaseApp
 import com.mxt.anitrend.R
+import com.mxt.anitrend.databinding.FragmentSettingsM3Binding
+import com.mxt.anitrend.databinding.ItemSettingsRowSwitchBinding
+import com.mxt.anitrend.databinding.ItemSettingsRowValueBinding
+import com.mxt.anitrend.databinding.ItemSettingsSectionCardBinding
 import com.mxt.anitrend.databinding.SettingsActivityBinding
 import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.extension.applyConfiguredTheme
@@ -26,7 +37,6 @@ import timber.log.Timber
 class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
         val settings = KoinExt.get(Settings::class.java)
         val themeRes = when (settings.theme) {
             KeyUtil.THEME_DARK -> R.style.AppThemeDark
@@ -41,30 +51,37 @@ class SettingsActivity : AppCompatActivity() {
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        supportFragmentManager
-            .beginTransaction()
-            .replace(R.id.settings, SettingsFragment())
-            .commit()
+        if (savedInstanceState == null) {
+            val fragment: Fragment =
+                if (settings.experimentalSettingsScreen) {
+                    MaterialSettingsFragment()
+                } else {
+                    SettingsFragment()
+                }
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings, fragment)
+                .commit()
+        }
     }
 
     class SettingsFragment :
         PreferenceFragmentCompat(),
         SharedPreferences.OnSharedPreferenceChangeListener {
+
         private val settings by inject<Settings>()
         private val scheduler by inject<JobSchedulerUtil>()
         private val presenter by inject<BasePresenter>()
+
+        private val sideEffectHandler by lazy(LazyThreadSafetyMode.NONE) {
+            SettingsPreferenceChangeHandler(settings, scheduler, presenter)
+        }
 
         override fun onCreatePreferences(
             savedInstanceState: Bundle?,
             rootKey: String?,
         ) {
-            val resId =
-                if (settings.experimentalSettingsScreen) {
-                    R.xml.root_preferences_experimental
-                } else {
-                    R.xml.root_preferences
-                }
-            setPreferencesFromResource(resId, rootKey)
+            setPreferencesFromResource(R.xml.root_preferences, rootKey)
             findPreference<PreferenceCategory>(getString(R.string.pref_key_privacy))?.isVisible =
                 FirebaseApp.getApps(requireContext()).isNotEmpty()
         }
@@ -79,66 +96,480 @@ class SettingsActivity : AppCompatActivity() {
             super.onPause()
         }
 
-        private fun requireRestartNotice(fragmentActivity: FragmentActivity) {
-            DialogUtil
-                .createDefaultDialog(fragmentActivity)
-                .setPositiveButton(R.string.Ok) { d, _ -> d.dismiss() }
-                .setMessage(R.string.text_application_restart_required)
-                .show()
+        override fun onSharedPreferenceChanged(
+            preferences: SharedPreferences?,
+            key: String?,
+        ) {
+            activity?.let { sideEffectHandler.handle(it, key) }
+        }
+    }
+
+    class MaterialSettingsFragment :
+        Fragment(),
+        SharedPreferences.OnSharedPreferenceChangeListener {
+
+        private var binding: FragmentSettingsM3Binding? = null
+
+        private val settings by inject<Settings>()
+        private val scheduler by inject<JobSchedulerUtil>()
+        private val presenter by inject<BasePresenter>()
+
+        private val sideEffectHandler by lazy(LazyThreadSafetyMode.NONE) {
+            SettingsPreferenceChangeHandler(settings, scheduler, presenter)
+        }
+
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?,
+        ): View {
+            binding = FragmentSettingsM3Binding.inflate(inflater, container, false)
+            return binding!!.root
+        }
+
+        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+            super.onViewCreated(view, savedInstanceState)
+        }
+
+        override fun onResume() {
+            super.onResume()
+            settings.registerOnSharedPreferenceChangeListener(this)
+            renderSections()
+        }
+
+        override fun onPause() {
+            settings.unregisterOnSharedPreferenceChangeListener(this)
+            super.onPause()
+        }
+
+        override fun onDestroyView() {
+            binding = null
+            super.onDestroyView()
         }
 
         override fun onSharedPreferenceChanged(
             preferences: SharedPreferences?,
             key: String?,
         ) {
-            activity?.apply {
-                when (key) {
-                    getString(R.string.pref_key_experimental_markdown),
-                    getString(R.string.pref_key_experimental_about_screen),
-                    getString(R.string.pref_key_experimental_settings_screen),
-                    getString(R.string.pref_key_experimental_initial_screens),
-                    getString(R.string.pref_key_display_adult_content),
-                    getString(R.string.pref_key_crash_reports),
-                    getString(R.string.pref_key_usage_analytics),
-                    getString(R.string.pref_key_list_view_style),
-                    -> {
-                        requireRestartNotice(this)
-                    }
-                    getString(R.string.pref_key_selected_language) -> {
-                        val locales = LocaleListCompat.forLanguageTags(settings.userLanguage)
-                        AppCompatDelegate.setApplicationLocales(locales)
-                    }
-                    getString(R.string.pref_key_startup_page) -> {
-                        if (!settings.isAuthenticated) {
-                            NotifyUtil.makeText(this, R.string.info_login_req, Toast.LENGTH_SHORT).show()
-                        } else {
-                            requireRestartNotice(this)
-                        }
-                    }
-                    getString(R.string.pref_key_app_theme) -> {
-                        applyConfiguredTheme()
-                    }
-                    getString(R.string.pref_key_sync_frequency) -> {
-                        scheduler.cancelNotificationJob(applicationContext)
-                        scheduler.cancelTagJob(applicationContext)
-                        scheduler.cancelGenreJob(applicationContext)
-                        scheduler.scheduleNotificationJob(applicationContext)
-                        scheduler.scheduleGenreJob(applicationContext)
-                        scheduler.scheduleTagJob(applicationContext)
-                    }
-                    getString(R.string.pref_key_new_message_notifications) -> {
-                        if (settings.isNotificationEnabled) {
-                            scheduler.scheduleNotificationJob(applicationContext)
-                        } else {
-                            scheduler.cancelNotificationJob(applicationContext)
-                        }
-                    }
-                    getString(R.string.pref_key_update_channel) -> {
-                        presenter.database.remoteVersion = null
-                    }
-                    else -> Timber.i("$key not registered in this sharedPreferenceChange listener")
-                }
+            activity?.let { sideEffectHandler.handle(it, key) }
+            if (view != null) {
+                renderSections()
             }
         }
+
+        private fun renderSections() {
+            val binding = binding ?: return
+            val context = requireContext()
+            val sectionHost = binding.settingsSections
+            sectionHost.removeAllViews()
+
+            buildSections(
+                isFirebaseVisible = FirebaseApp.getApps(context).isNotEmpty(),
+                isUpdateChannelVisible = resources.getBoolean(R.bool.display_update_channel_pref),
+                isAdultContentVisible = resources.getBoolean(R.bool.display_adult_content_pref),
+            ).forEach { section ->
+                val sectionBinding = ItemSettingsSectionCardBinding.inflate(layoutInflater, sectionHost, false)
+                sectionBinding.sectionTitle.setText(section.titleRes)
+                sectionBinding.sectionSummary.setText(section.summaryRes)
+
+                val visibleRows = section.rows.filter { it.visible }
+                visibleRows.forEachIndexed { index, row ->
+                    when (row) {
+                        is SettingsRow.Choice -> bindChoiceRow(sectionBinding.sectionContent, row)
+                        is SettingsRow.Info -> bindInfoRow(sectionBinding.sectionContent, row)
+                        is SettingsRow.Toggle -> bindToggleRow(sectionBinding.sectionContent, row)
+                    }
+                    if (index < visibleRows.lastIndex) {
+                        addDivider(sectionBinding.sectionContent)
+                    }
+                }
+
+                sectionHost.addView(sectionBinding.root)
+            }
+        }
+
+        private fun bindChoiceRow(
+            container: LinearLayout,
+            row: SettingsRow.Choice,
+        ) {
+            val rowBinding = ItemSettingsRowValueBinding.inflate(layoutInflater, container, false)
+            val context = rowBinding.root.context
+            val labels = context.resources.getStringArray(row.entriesRes)
+            val values = context.resources.getStringArray(row.valuesRes)
+            val preferenceKey = context.getString(row.keyRes)
+            val currentValue = settings.getString(preferenceKey, row.defaultValue) ?: row.defaultValue
+
+            rowBinding.rowTitle.setText(row.titleRes)
+            rowBinding.rowSummary.apply {
+                if (row.summaryRes != null) {
+                    setText(row.summaryRes)
+                    visibility = View.VISIBLE
+                } else {
+                    visibility = View.GONE
+                }
+            }
+            rowBinding.rowValue.text = labels[values.indexOf(currentValue).coerceAtLeast(0)]
+            rowBinding.rowChevron.visibility = if (row.enabled) View.VISIBLE else View.GONE
+            rowBinding.root.isEnabled = row.enabled
+            rowBinding.root.alpha = if (row.enabled) 1f else 0.6f
+
+            if (row.enabled) {
+                rowBinding.root.setOnClickListener {
+                    MaterialAlertDialogBuilder(context)
+                        .setTitle(row.titleRes)
+                        .setSingleChoiceItems(labels, values.indexOf(currentValue).coerceAtLeast(0)) { dialog, which ->
+                            settings.edit { putString(preferenceKey, values[which]) }
+                            dialog.dismiss()
+                        }.setNegativeButton(R.string.Cancel, null)
+                        .show()
+                }
+            }
+
+            container.addView(rowBinding.root)
+        }
+
+        private fun bindToggleRow(
+            container: LinearLayout,
+            row: SettingsRow.Toggle,
+        ) {
+            val rowBinding = ItemSettingsRowSwitchBinding.inflate(layoutInflater, container, false)
+            val context = rowBinding.root.context
+            val preferenceKey = context.getString(row.keyRes)
+            val checked = settings.getBoolean(preferenceKey, row.defaultValue)
+
+            rowBinding.rowTitle.setText(row.titleRes)
+            rowBinding.rowSummary.apply {
+                val summaryRes = row.summaryRes(checked)
+                if (summaryRes != null) {
+                    setText(summaryRes)
+                    visibility = View.VISIBLE
+                } else {
+                    visibility = View.GONE
+                }
+            }
+            rowBinding.rowSwitch.isChecked = checked
+            rowBinding.rowSwitch.isEnabled = row.enabled
+            rowBinding.root.isEnabled = row.enabled
+            rowBinding.root.alpha = if (row.enabled) 1f else 0.6f
+
+            if (row.enabled) {
+                rowBinding.root.setOnClickListener {
+                    rowBinding.rowSwitch.isChecked = !rowBinding.rowSwitch.isChecked
+                }
+                rowBinding.rowSwitch.setOnCheckedChangeListener { _, isChecked ->
+                    settings.edit { putBoolean(preferenceKey, isChecked) }
+                }
+            }
+
+            container.addView(rowBinding.root)
+        }
+
+        private fun bindInfoRow(
+            container: LinearLayout,
+            row: SettingsRow.Info,
+        ) {
+            val rowBinding = ItemSettingsRowValueBinding.inflate(layoutInflater, container, false)
+            rowBinding.rowTitle.setText(row.titleRes)
+            rowBinding.rowSummary.setText(row.summaryRes)
+            rowBinding.rowSummary.visibility = View.VISIBLE
+            rowBinding.rowValue.visibility = View.GONE
+            rowBinding.rowChevron.visibility = View.GONE
+            rowBinding.root.isEnabled = false
+            rowBinding.root.alpha = 0.6f
+            container.addView(rowBinding.root)
+        }
+
+        private fun addDivider(container: LinearLayout) {
+            val divider = layoutInflater.inflate(R.layout.item_settings_divider, container, false)
+            container.addView(divider)
+        }
+
+        private fun buildSections(
+            isFirebaseVisible: Boolean,
+            isUpdateChannelVisible: Boolean,
+            isAdultContentVisible: Boolean,
+        ): List<SettingsSection> = listOf(
+            SettingsSection(
+                titleRes = R.string.pref_header_customize,
+                summaryRes = R.string.pref_header_customize_summary,
+                rows = listOf(
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_app_theme,
+                        titleRes = R.string.pref_title_app_theme,
+                        entriesRes = R.array.pref_selected_theme_titles,
+                        valuesRes = R.array.pref_selected_theme_values,
+                        defaultValue = KeyUtil.THEME_LIGHT,
+                    ),
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_selected_language,
+                        titleRes = R.string.pref_title_language,
+                        summaryRes = R.string.pref_title_language_summary,
+                        entriesRes = R.array.pref_selected_language_titles,
+                        valuesRes = R.array.pref_selected_language_values,
+                        defaultValue = "en",
+                    ),
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_list_view_style,
+                        titleRes = R.string.pref_title_list_view_style,
+                        entriesRes = R.array.pref_selected_list_view_style_titles,
+                        valuesRes = R.array.pref_selected_list_view_style_values,
+                        defaultValue = "0",
+                    ),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_appearance,
+                summaryRes = R.string.pref_header_appearance_summary,
+                rows = listOf(
+                    SettingsRow.Info(R.string.pref_title_accent_color, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_font_scale, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_list_density, R.string.pref_summary_placeholder),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_content,
+                summaryRes = R.string.pref_header_content_summary,
+                rows = listOf(
+                    SettingsRow.Info(R.string.pref_title_autoplay, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_spoiler_behavior, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_title_language, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_score_format, R.string.pref_summary_placeholder),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_general,
+                summaryRes = R.string.pref_header_general_summary,
+                rows = listOf(
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_startup_page,
+                        titleRes = R.string.pref_title_startup_page,
+                        entriesRes = R.array.pref_titles_menu_entries,
+                        valuesRes = R.array.pref_values_menu_entries,
+                        defaultValue = "3",
+                    ),
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_update_channel,
+                        titleRes = R.string.pref_title_update_channel,
+                        entriesRes = R.array.pref_titles_channel_entries,
+                        valuesRes = R.array.pref_values_channel_entries,
+                        defaultValue = "master",
+                        rowVisible = isUpdateChannelVisible,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_display_adult_content,
+                        titleRes = R.string.pref_title_display_adult_content,
+                        summaryRes = R.string.pref_summary_display_adult_content,
+                        defaultValue = false,
+                        rowVisible = isAdultContentVisible,
+                    ),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_experimental,
+                summaryRes = R.string.pref_header_experimental_summary,
+                rows = listOf(
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_experimental_markdown,
+                        titleRes = R.string.pref_title_experimental_markdown,
+                        summaryRes = R.string.pref_summary_experimental_markdown,
+                        defaultValue = false,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_experimental_about_screen,
+                        titleRes = R.string.pref_title_experimental_about_screen,
+                        summaryRes = R.string.pref_summary_experimental_about_screen,
+                        defaultValue = false,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_experimental_settings_screen,
+                        titleRes = R.string.pref_title_experimental_settings_screen,
+                        summaryRes = R.string.pref_summary_experimental_settings_screen,
+                        defaultValue = false,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_experimental_initial_screens,
+                        titleRes = R.string.pref_title_experimental_initial_screens,
+                        summaryRes = R.string.pref_summary_experimental_initial_screens,
+                        defaultValue = false,
+                    ),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_notifications,
+                summaryRes = R.string.pref_header_notifications_summary,
+                rows = listOf(
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_new_message_notifications,
+                        titleRes = R.string.pref_title_new_message_notifications,
+                        defaultValue = true,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_clear_notification_on_dismiss,
+                        titleRes = R.string.pref_title_clear_notification_on_dismiss,
+                        summaryRes = R.string.pref_summary_clear_notification_on_dismiss,
+                        defaultValue = false,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_notification_work_around,
+                        titleRes = R.string.pref_title_notification_work_around,
+                        summaryRes = R.string.pref_summary_notification_work_around,
+                        defaultValue = false,
+                        enabled = false,
+                    ),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_data_sync,
+                summaryRes = R.string.pref_header_data_sync_summary,
+                rows = listOf(
+                    SettingsRow.Choice(
+                        keyRes = R.string.pref_key_sync_frequency,
+                        titleRes = R.string.pref_title_sync_frequency,
+                        entriesRes = R.array.pref_sync_frequency_titles,
+                        valuesRes = R.array.pref_sync_frequency_values,
+                        defaultValue = "15",
+                    ),
+                ),
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_privacy,
+                summaryRes = R.string.pref_header_privacy_summary,
+                rows = listOf(
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_crash_reports,
+                        titleRes = R.string.pref_title_crash_reports,
+                        summaryOnRes = R.string.pref_crash_reports_summary_on,
+                        summaryOffRes = R.string.pref_crash_reports_summary_off,
+                        defaultValue = true,
+                    ),
+                    SettingsRow.Toggle(
+                        keyRes = R.string.pref_key_usage_analytics,
+                        titleRes = R.string.pref_title_usage_analytics,
+                        summaryOnRes = R.string.pref_usage_analytics_summary_on,
+                        summaryOffRes = R.string.pref_usage_analytics_summary_off,
+                        defaultValue = false,
+                    ),
+                ),
+                visible = isFirebaseVisible,
+            ),
+            SettingsSection(
+                titleRes = R.string.pref_header_accessibility,
+                summaryRes = R.string.pref_header_accessibility_summary,
+                rows = listOf(
+                    SettingsRow.Info(R.string.pref_title_reduce_motion, R.string.pref_summary_placeholder),
+                    SettingsRow.Info(R.string.pref_title_high_contrast, R.string.pref_summary_placeholder),
+                ),
+            ),
+        ).filter { it.visible }
+    }
+
+    private data class SettingsSection(
+        val titleRes: Int,
+        val summaryRes: Int,
+        val rows: List<SettingsRow>,
+        val visible: Boolean = true,
+    )
+
+    private sealed class SettingsRow(val visible: Boolean) {
+        data class Choice(
+            val keyRes: Int,
+            val titleRes: Int,
+            val entriesRes: Int,
+            val valuesRes: Int,
+            val defaultValue: String,
+            val summaryRes: Int? = null,
+            val enabled: Boolean = true,
+            val rowVisible: Boolean = true,
+        ) : SettingsRow(rowVisible)
+
+        data class Toggle(
+            val keyRes: Int,
+            val titleRes: Int,
+            val defaultValue: Boolean,
+            val summaryRes: Int? = null,
+            val summaryOnRes: Int? = null,
+            val summaryOffRes: Int? = null,
+            val enabled: Boolean = true,
+            val rowVisible: Boolean = true,
+        ) : SettingsRow(rowVisible) {
+            fun summaryRes(checked: Boolean): Int? = when {
+                checked && summaryOnRes != null -> summaryOnRes
+                !checked && summaryOffRes != null -> summaryOffRes
+                else -> summaryRes
+            }
+        }
+
+        data class Info(
+            val titleRes: Int,
+            val summaryRes: Int,
+            val rowVisible: Boolean = true,
+        ) : SettingsRow(rowVisible)
+    }
+}
+
+private class SettingsPreferenceChangeHandler(
+    private val settings: Settings,
+    private val scheduler: JobSchedulerUtil,
+    private val presenter: BasePresenter,
+) {
+
+    fun handle(
+        fragmentActivity: FragmentActivity,
+        key: String?,
+    ) {
+        when (key) {
+            fragmentActivity.getString(R.string.pref_key_experimental_markdown),
+            fragmentActivity.getString(R.string.pref_key_experimental_about_screen),
+            fragmentActivity.getString(R.string.pref_key_experimental_settings_screen),
+            fragmentActivity.getString(R.string.pref_key_experimental_initial_screens),
+            fragmentActivity.getString(R.string.pref_key_display_adult_content),
+            fragmentActivity.getString(R.string.pref_key_crash_reports),
+            fragmentActivity.getString(R.string.pref_key_usage_analytics),
+            fragmentActivity.getString(R.string.pref_key_list_view_style),
+            -> {
+                requireRestartNotice(fragmentActivity)
+            }
+            fragmentActivity.getString(R.string.pref_key_selected_language) -> {
+                val locales = LocaleListCompat.forLanguageTags(settings.userLanguage)
+                AppCompatDelegate.setApplicationLocales(locales)
+            }
+            fragmentActivity.getString(R.string.pref_key_startup_page) -> {
+                if (!settings.isAuthenticated) {
+                    NotifyUtil.makeText(fragmentActivity, R.string.info_login_req, Toast.LENGTH_SHORT).show()
+                } else {
+                    requireRestartNotice(fragmentActivity)
+                }
+            }
+            fragmentActivity.getString(R.string.pref_key_app_theme) -> {
+                fragmentActivity.applyConfiguredTheme()
+            }
+            fragmentActivity.getString(R.string.pref_key_sync_frequency) -> {
+                scheduler.cancelNotificationJob(fragmentActivity.applicationContext)
+                scheduler.cancelTagJob(fragmentActivity.applicationContext)
+                scheduler.cancelGenreJob(fragmentActivity.applicationContext)
+                scheduler.scheduleNotificationJob(fragmentActivity.applicationContext)
+                scheduler.scheduleGenreJob(fragmentActivity.applicationContext)
+                scheduler.scheduleTagJob(fragmentActivity.applicationContext)
+            }
+            fragmentActivity.getString(R.string.pref_key_new_message_notifications) -> {
+                if (settings.isNotificationEnabled) {
+                    scheduler.scheduleNotificationJob(fragmentActivity.applicationContext)
+                } else {
+                    scheduler.cancelNotificationJob(fragmentActivity.applicationContext)
+                }
+            }
+            fragmentActivity.getString(R.string.pref_key_update_channel) -> {
+                presenter.database.remoteVersion = null
+            }
+            else -> Timber.i("$key not registered in this sharedPreferenceChange listener")
+        }
+    }
+
+    private fun requireRestartNotice(fragmentActivity: FragmentActivity) {
+        DialogUtil
+            .createDefaultDialog(fragmentActivity)
+            .setPositiveButton(R.string.Ok) { d, _ -> d.dismiss() }
+            .setMessage(R.string.text_application_restart_required)
+            .show()
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
@@ -104,6 +104,9 @@ class SettingsActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Material 3 settings screen backed by the existing shared preference store.
+     */
     class MaterialSettingsFragment :
         Fragment(),
         SharedPreferences.OnSharedPreferenceChangeListener {
@@ -125,10 +128,6 @@ class SettingsActivity : AppCompatActivity() {
         ): View {
             binding = FragmentSettingsM3Binding.inflate(inflater, container, false)
             return binding!!.root
-        }
-
-        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-            super.onViewCreated(view, savedInstanceState)
         }
 
         override fun onResume() {
@@ -288,179 +287,11 @@ class SettingsActivity : AppCompatActivity() {
             isFirebaseVisible: Boolean,
             isUpdateChannelVisible: Boolean,
             isAdultContentVisible: Boolean,
-        ): List<SettingsSection> = listOf(
-            SettingsSection(
-                titleRes = R.string.pref_header_customize,
-                summaryRes = R.string.pref_header_customize_summary,
-                rows = listOf(
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_app_theme,
-                        titleRes = R.string.pref_title_app_theme,
-                        entriesRes = R.array.pref_selected_theme_titles,
-                        valuesRes = R.array.pref_selected_theme_values,
-                        defaultValue = KeyUtil.THEME_LIGHT,
-                    ),
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_selected_language,
-                        titleRes = R.string.pref_title_language,
-                        summaryRes = R.string.pref_title_language_summary,
-                        entriesRes = R.array.pref_selected_language_titles,
-                        valuesRes = R.array.pref_selected_language_values,
-                        defaultValue = "en",
-                    ),
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_list_view_style,
-                        titleRes = R.string.pref_title_list_view_style,
-                        entriesRes = R.array.pref_selected_list_view_style_titles,
-                        valuesRes = R.array.pref_selected_list_view_style_values,
-                        defaultValue = "0",
-                    ),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_appearance,
-                summaryRes = R.string.pref_header_appearance_summary,
-                rows = listOf(
-                    SettingsRow.Info(R.string.pref_title_accent_color, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_font_scale, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_list_density, R.string.pref_summary_placeholder),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_content,
-                summaryRes = R.string.pref_header_content_summary,
-                rows = listOf(
-                    SettingsRow.Info(R.string.pref_title_autoplay, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_spoiler_behavior, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_title_language, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_score_format, R.string.pref_summary_placeholder),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_general,
-                summaryRes = R.string.pref_header_general_summary,
-                rows = listOf(
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_startup_page,
-                        titleRes = R.string.pref_title_startup_page,
-                        entriesRes = R.array.pref_titles_menu_entries,
-                        valuesRes = R.array.pref_values_menu_entries,
-                        defaultValue = "3",
-                    ),
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_update_channel,
-                        titleRes = R.string.pref_title_update_channel,
-                        entriesRes = R.array.pref_titles_channel_entries,
-                        valuesRes = R.array.pref_values_channel_entries,
-                        defaultValue = "master",
-                        rowVisible = isUpdateChannelVisible,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_display_adult_content,
-                        titleRes = R.string.pref_title_display_adult_content,
-                        summaryRes = R.string.pref_summary_display_adult_content,
-                        defaultValue = false,
-                        rowVisible = isAdultContentVisible,
-                    ),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_experimental,
-                summaryRes = R.string.pref_header_experimental_summary,
-                rows = listOf(
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_experimental_markdown,
-                        titleRes = R.string.pref_title_experimental_markdown,
-                        summaryRes = R.string.pref_summary_experimental_markdown,
-                        defaultValue = false,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_experimental_about_screen,
-                        titleRes = R.string.pref_title_experimental_about_screen,
-                        summaryRes = R.string.pref_summary_experimental_about_screen,
-                        defaultValue = false,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_experimental_settings_screen,
-                        titleRes = R.string.pref_title_experimental_settings_screen,
-                        summaryRes = R.string.pref_summary_experimental_settings_screen,
-                        defaultValue = false,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_experimental_initial_screens,
-                        titleRes = R.string.pref_title_experimental_initial_screens,
-                        summaryRes = R.string.pref_summary_experimental_initial_screens,
-                        defaultValue = false,
-                    ),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_notifications,
-                summaryRes = R.string.pref_header_notifications_summary,
-                rows = listOf(
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_new_message_notifications,
-                        titleRes = R.string.pref_title_new_message_notifications,
-                        defaultValue = true,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_clear_notification_on_dismiss,
-                        titleRes = R.string.pref_title_clear_notification_on_dismiss,
-                        summaryRes = R.string.pref_summary_clear_notification_on_dismiss,
-                        defaultValue = false,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_notification_work_around,
-                        titleRes = R.string.pref_title_notification_work_around,
-                        summaryRes = R.string.pref_summary_notification_work_around,
-                        defaultValue = false,
-                        enabled = false,
-                    ),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_data_sync,
-                summaryRes = R.string.pref_header_data_sync_summary,
-                rows = listOf(
-                    SettingsRow.Choice(
-                        keyRes = R.string.pref_key_sync_frequency,
-                        titleRes = R.string.pref_title_sync_frequency,
-                        entriesRes = R.array.pref_sync_frequency_titles,
-                        valuesRes = R.array.pref_sync_frequency_values,
-                        defaultValue = "15",
-                    ),
-                ),
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_privacy,
-                summaryRes = R.string.pref_header_privacy_summary,
-                rows = listOf(
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_crash_reports,
-                        titleRes = R.string.pref_title_crash_reports,
-                        summaryOnRes = R.string.pref_crash_reports_summary_on,
-                        summaryOffRes = R.string.pref_crash_reports_summary_off,
-                        defaultValue = true,
-                    ),
-                    SettingsRow.Toggle(
-                        keyRes = R.string.pref_key_usage_analytics,
-                        titleRes = R.string.pref_title_usage_analytics,
-                        summaryOnRes = R.string.pref_usage_analytics_summary_on,
-                        summaryOffRes = R.string.pref_usage_analytics_summary_off,
-                        defaultValue = false,
-                    ),
-                ),
-                visible = isFirebaseVisible,
-            ),
-            SettingsSection(
-                titleRes = R.string.pref_header_accessibility,
-                summaryRes = R.string.pref_header_accessibility_summary,
-                rows = listOf(
-                    SettingsRow.Info(R.string.pref_title_reduce_motion, R.string.pref_summary_placeholder),
-                    SettingsRow.Info(R.string.pref_title_high_contrast, R.string.pref_summary_placeholder),
-                ),
-            ),
-        ).filter { it.visible }
+        ): List<SettingsSection> = MaterialSettingsSections.build(
+            isFirebaseVisible = isFirebaseVisible,
+            isUpdateChannelVisible = isUpdateChannelVisible,
+            isAdultContentVisible = isAdultContentVisible,
+        )
     }
 
     private data class SettingsSection(
@@ -504,6 +335,208 @@ class SettingsActivity : AppCompatActivity() {
             val summaryRes: Int,
             val rowVisible: Boolean = true,
         ) : SettingsRow(rowVisible)
+    }
+
+    private object MaterialSettingsSections {
+
+        fun build(
+            isFirebaseVisible: Boolean,
+            isUpdateChannelVisible: Boolean,
+            isAdultContentVisible: Boolean,
+        ): List<SettingsSection> = listOf(
+            customizeSection(),
+            appearanceSection(),
+            contentSection(),
+            generalSection(isUpdateChannelVisible, isAdultContentVisible),
+            experimentalSection(),
+            notificationsSection(),
+            dataSyncSection(),
+            privacySection(isFirebaseVisible),
+            accessibilitySection(),
+        ).filter { it.visible }
+
+        private fun customizeSection() = SettingsSection(
+            titleRes = R.string.pref_header_customize,
+            summaryRes = R.string.pref_header_customize_summary,
+            rows = listOf(
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_app_theme,
+                    titleRes = R.string.pref_title_app_theme,
+                    entriesRes = R.array.pref_selected_theme_titles,
+                    valuesRes = R.array.pref_selected_theme_values,
+                    defaultValue = KeyUtil.THEME_LIGHT,
+                ),
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_selected_language,
+                    titleRes = R.string.pref_title_language,
+                    summaryRes = R.string.pref_title_language_summary,
+                    entriesRes = R.array.pref_selected_language_titles,
+                    valuesRes = R.array.pref_selected_language_values,
+                    defaultValue = "en",
+                ),
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_list_view_style,
+                    titleRes = R.string.pref_title_list_view_style,
+                    entriesRes = R.array.pref_selected_list_view_style_titles,
+                    valuesRes = R.array.pref_selected_list_view_style_values,
+                    defaultValue = "0",
+                ),
+            ),
+        )
+
+        private fun appearanceSection() = SettingsSection(
+            titleRes = R.string.pref_header_appearance,
+            summaryRes = R.string.pref_header_appearance_summary,
+            rows = listOf(
+                SettingsRow.Info(R.string.pref_title_accent_color, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_font_scale, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_list_density, R.string.pref_summary_placeholder),
+            ),
+        )
+
+        private fun contentSection() = SettingsSection(
+            titleRes = R.string.pref_header_content,
+            summaryRes = R.string.pref_header_content_summary,
+            rows = listOf(
+                SettingsRow.Info(R.string.pref_title_autoplay, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_spoiler_behavior, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_title_language, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_score_format, R.string.pref_summary_placeholder),
+            ),
+        )
+
+        private fun generalSection(
+            isUpdateChannelVisible: Boolean,
+            isAdultContentVisible: Boolean,
+        ) = SettingsSection(
+            titleRes = R.string.pref_header_general,
+            summaryRes = R.string.pref_header_general_summary,
+            rows = listOf(
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_startup_page,
+                    titleRes = R.string.pref_title_startup_page,
+                    entriesRes = R.array.pref_titles_menu_entries,
+                    valuesRes = R.array.pref_values_menu_entries,
+                    defaultValue = "3",
+                ),
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_update_channel,
+                    titleRes = R.string.pref_title_update_channel,
+                    entriesRes = R.array.pref_titles_channel_entries,
+                    valuesRes = R.array.pref_values_channel_entries,
+                    defaultValue = "master",
+                    rowVisible = isUpdateChannelVisible,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_display_adult_content,
+                    titleRes = R.string.pref_title_display_adult_content,
+                    summaryRes = R.string.pref_summary_display_adult_content,
+                    defaultValue = false,
+                    rowVisible = isAdultContentVisible,
+                ),
+            ),
+        )
+
+        private fun experimentalSection() = SettingsSection(
+            titleRes = R.string.pref_header_experimental,
+            summaryRes = R.string.pref_header_experimental_summary,
+            rows = listOf(
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_experimental_markdown,
+                    titleRes = R.string.pref_title_experimental_markdown,
+                    summaryRes = R.string.pref_summary_experimental_markdown,
+                    defaultValue = false,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_experimental_about_screen,
+                    titleRes = R.string.pref_title_experimental_about_screen,
+                    summaryRes = R.string.pref_summary_experimental_about_screen,
+                    defaultValue = false,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_experimental_settings_screen,
+                    titleRes = R.string.pref_title_experimental_settings_screen,
+                    summaryRes = R.string.pref_summary_experimental_settings_screen,
+                    defaultValue = false,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_experimental_initial_screens,
+                    titleRes = R.string.pref_title_experimental_initial_screens,
+                    summaryRes = R.string.pref_summary_experimental_initial_screens,
+                    defaultValue = false,
+                ),
+            ),
+        )
+
+        private fun notificationsSection() = SettingsSection(
+            titleRes = R.string.pref_header_notifications,
+            summaryRes = R.string.pref_header_notifications_summary,
+            rows = listOf(
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_new_message_notifications,
+                    titleRes = R.string.pref_title_new_message_notifications,
+                    defaultValue = true,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_clear_notification_on_dismiss,
+                    titleRes = R.string.pref_title_clear_notification_on_dismiss,
+                    summaryRes = R.string.pref_summary_clear_notification_on_dismiss,
+                    defaultValue = false,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_notification_work_around,
+                    titleRes = R.string.pref_title_notification_work_around,
+                    summaryRes = R.string.pref_summary_notification_work_around,
+                    defaultValue = false,
+                    enabled = false,
+                ),
+            ),
+        )
+
+        private fun dataSyncSection() = SettingsSection(
+            titleRes = R.string.pref_header_data_sync,
+            summaryRes = R.string.pref_header_data_sync_summary,
+            rows = listOf(
+                SettingsRow.Choice(
+                    keyRes = R.string.pref_key_sync_frequency,
+                    titleRes = R.string.pref_title_sync_frequency,
+                    entriesRes = R.array.pref_sync_frequency_titles,
+                    valuesRes = R.array.pref_sync_frequency_values,
+                    defaultValue = "15",
+                ),
+            ),
+        )
+
+        private fun privacySection(isFirebaseVisible: Boolean) = SettingsSection(
+            titleRes = R.string.pref_header_privacy,
+            summaryRes = R.string.pref_header_privacy_summary,
+            rows = listOf(
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_crash_reports,
+                    titleRes = R.string.pref_title_crash_reports,
+                    summaryOnRes = R.string.pref_crash_reports_summary_on,
+                    summaryOffRes = R.string.pref_crash_reports_summary_off,
+                    defaultValue = true,
+                ),
+                SettingsRow.Toggle(
+                    keyRes = R.string.pref_key_usage_analytics,
+                    titleRes = R.string.pref_title_usage_analytics,
+                    summaryOnRes = R.string.pref_usage_analytics_summary_on,
+                    summaryOffRes = R.string.pref_usage_analytics_summary_off,
+                    defaultValue = false,
+                ),
+            ),
+            visible = isFirebaseVisible,
+        )
+
+        private fun accessibilitySection() = SettingsSection(
+            titleRes = R.string.pref_header_accessibility,
+            summaryRes = R.string.pref_header_accessibility_summary,
+            rows = listOf(
+                SettingsRow.Info(R.string.pref_title_reduce_motion, R.string.pref_summary_placeholder),
+                SettingsRow.Info(R.string.pref_title_high_contrast, R.string.pref_summary_placeholder),
+            ),
+        )
     }
 }
 

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
@@ -162,7 +162,7 @@ class SettingsActivity : AppCompatActivity() {
             val sectionHost = binding.settingsSections
             sectionHost.removeAllViews()
 
-            buildSections(
+            MaterialSettingsSections.build(
                 isFirebaseVisible = FirebaseApp.getApps(context).isNotEmpty(),
                 isUpdateChannelVisible = resources.getBoolean(R.bool.display_update_channel_pref),
                 isAdultContentVisible = resources.getBoolean(R.bool.display_adult_content_pref),
@@ -282,16 +282,6 @@ class SettingsActivity : AppCompatActivity() {
             val divider = layoutInflater.inflate(R.layout.item_settings_divider, container, false)
             container.addView(divider)
         }
-
-        private fun buildSections(
-            isFirebaseVisible: Boolean,
-            isUpdateChannelVisible: Boolean,
-            isAdultContentVisible: Boolean,
-        ): List<SettingsSection> = MaterialSettingsSections.build(
-            isFirebaseVisible = isFirebaseVisible,
-            isUpdateChannelVisible = isUpdateChannelVisible,
-            isAdultContentVisible = isAdultContentVisible,
-        )
     }
 
     private data class SettingsSection(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaLatestList.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaLatestList.kt
@@ -5,6 +5,8 @@ import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.mxt.anitrend.R
+import com.mxt.anitrend.adapter.recycler.index.MediaLatestAdapter
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.container.body.PageContainer
@@ -34,6 +36,8 @@ class MediaLatestList : MediaBrowseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         isFilterableEnabled = false
+        mAdapter = MediaLatestAdapter(requireContext())
+        mColumnSize = R.integer.single_list_x1
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
@@ -2,6 +2,7 @@ package com.mxt.anitrend.view.sheet
 
 import android.app.Dialog
 import android.os.Bundle
+import android.view.ContextThemeWrapper
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
@@ -24,7 +25,6 @@ import com.mxt.anitrend.base.custom.view.widget.FuzzyDateWidget
 import com.mxt.anitrend.base.custom.view.widget.ProgressWidget
 import com.mxt.anitrend.base.custom.view.widget.ScoreWidget
 import com.mxt.anitrend.coordinator.WidgetMutationCoordinator
-import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.graphql.generated.FuzzyDateInput
 import com.mxt.anitrend.graphql.generated.MediaListStatus
 import com.mxt.anitrend.model.entity.anilist.MediaList
@@ -36,6 +36,9 @@ import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.media.MediaListUtil
 import com.mxt.anitrend.util.media.MediaUtil
 import timber.log.Timber
+import androidx.core.view.isVisible
+import androidx.core.view.isNotEmpty
+import org.koin.android.ext.android.inject
 
 /**
  * M3 BottomSheetDialogFragment for managing media list entries.
@@ -54,6 +57,8 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
 
     private val mediaListStatuses =
         arrayOf(KeyUtil.CURRENT, KeyUtil.PLANNING, KeyUtil.COMPLETED, KeyUtil.DROPPED, KeyUtil.PAUSED, KeyUtil.REPEATING)
+
+    private val coordinator by inject<WidgetMutationCoordinator>()
 
     private lateinit var mediaBase: MediaBase
     private lateinit var mediaListModel: MediaList
@@ -281,7 +286,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
     private fun populateCustomListsAndAdvancedScores() {
         val model = mediaListModel
         val mediaListOptions = runCatching {
-            koinOf<WidgetMutationCoordinator>().databaseHelper.currentUser?.mediaListOptions
+            coordinator.databaseHelper.currentUser?.mediaListOptions
         }.getOrNull() ?: return
 
         val typeOptions = (if (isAnime) mediaListOptions.animeList else mediaListOptions.mangaList) ?: return
@@ -299,10 +304,15 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
             for (listName in availableCustomLists) {
                 if (listName.isEmpty()) continue
                 val isEnabled = existingCustomLists.any { it.name == listName && it.isEnabled }
-                val chip = Chip(requireContext()).apply {
+                val chip = Chip(
+                    ContextThemeWrapper(requireContext(), R.style.Widget_AniTrend_ManageSheet_CustomListChip),
+                    null,
+                    com.google.android.material.R.attr.chipStyle,
+                ).apply {
                     text = listName
                     isChecked = isEnabled
                     isCheckable = true
+                    isCheckedIconVisible = true
                 }
                 customListsChipGroup.addView(chip)
             }
@@ -410,7 +420,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
 
         // Collect advanced scores from sliders
         val collectedAdvancedScores: Map<String, Float>? =
-            if (advancedScoresContainer.visibility == View.VISIBLE && advancedScoreSliders.isNotEmpty()) {
+            if (advancedScoresContainer.isVisible && advancedScoreSliders.isNotEmpty()) {
                 advancedScoreSliders.associate { (category, slider) ->
                     category to slider.value
                 }
@@ -449,7 +459,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
 
         // Build enabled custom list names directly from chips
         val enabledCustomListNames: List<String?>? =
-            if (customListsContainer.visibility == View.VISIBLE && customListsChipGroup.childCount > 0) {
+            if (customListsContainer.isVisible && customListsChipGroup.isNotEmpty()) {
                 (0 until customListsChipGroup.childCount)
                     .mapNotNull { customListsChipGroup.getChildAt(it) as? Chip }
                     .filter { it.isChecked }
@@ -463,7 +473,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
         val progressDialog = NotifyUtil.createProgressDialog(ctx, R.string.text_processing_request)
         progressDialog.show()
 
-        koinOf<WidgetMutationCoordinator>().saveMediaListEntry(
+        coordinator.saveMediaListEntry(
             id = params.intValue(KeyUtil.arg_id),
             mediaId = params.longValue(KeyUtil.arg_mediaId),
             status = params.enumValue<MediaListStatus>(KeyUtil.arg_listStatus),
@@ -528,7 +538,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
         val progressDialog = NotifyUtil.createProgressDialog(ctx, R.string.text_processing_request)
         progressDialog.show()
 
-        koinOf<WidgetMutationCoordinator>().deleteMediaListEntry(mediaListModel.id) { result ->
+        coordinator.deleteMediaListEntry(mediaListModel.id) { result ->
             try {
                 progressDialog.dismiss()
 
@@ -573,7 +583,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
      * Falls back to [KeyUtil.POINT_100] if the user data cannot be resolved.
      */
     private fun resolveScoreFormat(): String = runCatching {
-        koinOf<WidgetMutationCoordinator>().databaseHelper.currentUser?.mediaListOptions?.scoreFormat
+        coordinator.databaseHelper.currentUser?.mediaListOptions?.scoreFormat
     }.getOrNull() ?: KeyUtil.POINT_100
 
     // ----------------------------------------------------------------------------

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
@@ -6,10 +6,12 @@ import com.mxt.anitrend.graphql.generated.MediaListSort
 import com.mxt.anitrend.graphql.generated.MediaListStatus
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.graphql.generated.ScoreFormat
+import com.mxt.anitrend.model.entity.anilist.MediaList
 import com.mxt.anitrend.model.entity.anilist.MediaListCollection
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.BrowseMutation
 import com.mxt.anitrend.repository.BrowseRepository
+import com.mxt.anitrend.util.CompatUtil
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,8 +39,10 @@ class AiringListViewModel(
     init {
         viewModelScope.launch {
             browseRepository.mutationEvents.collect { event ->
-                if (event is BrowseMutation.MediaListSaved || event is BrowseMutation.MediaListDeleted) {
-                    reloadIfPossible()
+                when (event) {
+                    is BrowseMutation.MediaListSaved -> onMediaListSaved(event.entry)
+                    is BrowseMutation.MediaListDeleted -> reloadIfPossible()
+                    else -> Unit
                 }
             }
         }
@@ -96,5 +100,102 @@ class AiringListViewModel(
             statusIn = lastStatusIn,
             scoreFormat = lastScoreFormat,
         )
+    }
+
+    internal fun onMediaListSaved(entry: MediaList) {
+        val current = (_state.value as? UiState.Success)?.content ?: return
+        val matchesFilters = matchesLoadedFilters(entry)
+        var didChange = false
+        val updatedCollections = current.pageData.toMutableList()
+
+        current.pageData.forEachIndexed { index, collection ->
+            val existingEntries = collection.entries.orEmpty()
+            val existingIndex = existingEntries.indexOfFirst { item ->
+                item.id == entry.id || item.mediaId == entry.mediaId
+            }
+
+            if (existingIndex == -1 && !matchesFilters) {
+                return@forEachIndexed
+            }
+
+            val updatedEntries = existingEntries.toMutableList()
+            when {
+                existingIndex >= 0 && matchesFilters -> updatedEntries[existingIndex].mergeFrom(entry)
+                existingIndex >= 0 -> updatedEntries.removeAt(existingIndex)
+                matchesFilters && shouldAppendToCollection(collection, entry) -> updatedEntries.add(entry)
+                else -> return@forEachIndexed
+            }
+
+            updatedCollections[index] = collection.copyWithEntries(updatedEntries)
+            didChange = true
+        }
+
+        if (!didChange) {
+            return
+        }
+
+        _state.value = UiState.Success(
+            PageContainer<MediaListCollection>().apply {
+                if (current.hasPageInfo()) {
+                    pageInfo = current.pageInfo
+                }
+                pageData = updatedCollections
+            },
+        )
+    }
+
+    private fun matchesLoadedFilters(entry: MediaList): Boolean {
+        val loadedTypeName = lastType?.name
+        val loadedStatusIn = lastStatusIn
+        val matchesType = loadedTypeName?.let { CompatUtil.equals(entry.media.type, it) } ?: true
+        val matchesStatus = loadedStatusIn?.let { CompatUtil.equals(entry.status, it) } ?: true
+        return matchesType && matchesStatus
+    }
+
+    private fun shouldAppendToCollection(
+        collection: MediaListCollection,
+        entry: MediaList,
+    ): Boolean = collection.status?.let { status ->
+        entry.status?.let { entryStatus -> CompatUtil.equals(status, entryStatus) }
+    } ?: (lastStatusIn?.let { loadedStatus ->
+        entry.status?.let { entryStatus -> CompatUtil.equals(entryStatus, loadedStatus) }
+    } ?: true)
+
+    private fun MediaListCollection.copyWithEntries(entries: List<MediaList>): MediaListCollection =
+        apply {
+            setEntries(entries)
+        }
+
+    private fun MediaListCollection.setEntries(entries: List<MediaList>) {
+        entriesField.set(this, entries)
+    }
+
+    private fun MediaList.mergeFrom(entry: MediaList) {
+        id = entry.id
+        mediaId = entry.mediaId
+        status = entry.status
+        score = entry.score
+        scoreRaw = entry.scoreRaw
+        progress = entry.progress
+        progressVolumes = entry.progressVolumes
+        repeat = entry.repeat
+        priority = entry.priority
+        notes = entry.notes
+        isHidden = entry.isHidden
+        isHiddenFromStatusLists = entry.isHiddenFromStatusLists
+        advancedScores = entry.advancedScores
+        customLists = entry.customLists
+        startedAt = entry.startedAt
+        completedAt = entry.completedAt
+        updatedAt = entry.updatedAt
+        createdAt = entry.createdAt
+        media = entry.media
+    }
+
+    companion object {
+        private val entriesField =
+            MediaListCollection::class.java.getDeclaredField("entries").apply {
+                isAccessible = true
+            }
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
@@ -157,14 +157,15 @@ class AiringListViewModel(
         entry: MediaList,
     ): Boolean = collection.status?.let { status ->
         entry.status?.let { entryStatus -> CompatUtil.equals(status, entryStatus) }
-    } ?: (lastStatusIn?.let { loadedStatus ->
-        entry.status?.let { entryStatus -> CompatUtil.equals(entryStatus, loadedStatus) }
-    } ?: true)
+    } ?: (
+        lastStatusIn?.let { loadedStatus ->
+            entry.status?.let { entryStatus -> CompatUtil.equals(entryStatus, loadedStatus) }
+        } ?: true
+        )
 
-    private fun MediaListCollection.copyWithEntries(entries: List<MediaList>): MediaListCollection =
-        apply {
-            setEntries(entries)
-        }
+    private fun MediaListCollection.copyWithEntries(entries: List<MediaList>): MediaListCollection = apply {
+        setEntries(entries)
+    }
 
     private fun MediaListCollection.setEntries(entries: List<MediaList>) {
         entriesField.set(this, entries)

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/AiringListViewModel.kt
@@ -108,14 +108,14 @@ class AiringListViewModel(
         var didChange = false
         val updatedCollections = current.pageData.toMutableList()
 
-        current.pageData.forEachIndexed { index, collection ->
+        for ((index, collection) in current.pageData.withIndex()) {
             val existingEntries = collection.entries.orEmpty()
             val existingIndex = existingEntries.indexOfFirst { item ->
                 item.id == entry.id || item.mediaId == entry.mediaId
             }
 
             if (existingIndex == -1 && !matchesFilters) {
-                return@forEachIndexed
+                continue
             }
 
             val updatedEntries = existingEntries.toMutableList()
@@ -123,7 +123,7 @@ class AiringListViewModel(
                 existingIndex >= 0 && matchesFilters -> updatedEntries[existingIndex].mergeFrom(entry)
                 existingIndex >= 0 -> updatedEntries.removeAt(existingIndex)
                 matchesFilters && shouldAppendToCollection(collection, entry) -> updatedEntries.add(entry)
-                else -> return@forEachIndexed
+                else -> continue
             }
 
             updatedCollections[index] = collection.copyWithEntries(updatedEntries)
@@ -193,6 +193,7 @@ class AiringListViewModel(
         media = entry.media
     }
 
+    /** Reflection handle used to update collection entries in place. */
     companion object {
         private val entriesField =
             MediaListCollection::class.java.getDeclaredField("entries").apply {

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/MediaListViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/MediaListViewModel.kt
@@ -56,10 +56,14 @@ class MediaListViewModel(
     init {
         viewModelScope.launch {
             browseRepository.mutationEvents.collect { event ->
-                if (currentItems.isNotEmpty() &&
-                    (event is BrowseMutation.MediaListSaved || event is BrowseMutation.MediaListDeleted)
-                ) {
-                    load(lastUserId, lastUserName, lastMediaType, lastStatusIn)
+                when (event) {
+                    is BrowseMutation.MediaListSaved -> onMediaListSaved(event.entry)
+                    is BrowseMutation.MediaListDeleted -> {
+                        if (currentItems.isNotEmpty()) {
+                            load(lastUserId, lastUserName, lastMediaType, lastStatusIn)
+                        }
+                    }
+                    else -> Unit
                 }
             }
         }
@@ -116,19 +120,7 @@ class MediaListViewModel(
                 } else {
                     emptyList()
                 }
-                val mediaListSort = settings.mediaListSort ?: KeyUtil.PROGRESS
-                val sorted = if (MediaListUtil.isTitleSort(mediaListSort)) {
-                    sortMediaListByTitle(entries, settings.sortOrder)
-                } else {
-                    entries
-                }
-                currentItems = sorted
-                currentPageInfo = pageInfo
-                _state.value = UiState.Success(
-                    items = sorted,
-                    pageInfo = pageInfo,
-                    isEmpty = content.isEmpty,
-                )
+                emitSuccess(entries, pageInfo, content.isEmpty)
             }.onFailure { throwable ->
                 Timber.e(throwable, "MediaListViewModel load failed")
                 _state.value = UiState.Error(
@@ -165,6 +157,82 @@ class MediaListViewModel(
             userName?.let { userRepository.cachedCurrentUser?.name == it }
                 ?: (userId != 0L && userRepository.cachedCurrentUser?.id == userId)
             )
+
+    internal fun onMediaListSaved(entry: MediaList) {
+        val current = _state.value as? UiState.Success ?: return
+        val existingIndex = currentItems.indexOfFirst { item ->
+            item.id == entry.id || item.mediaId == entry.mediaId
+        }
+        val matchesFilters = matchesLoadedFilters(entry)
+        if (existingIndex == -1 && !matchesFilters) {
+            return
+        }
+
+        val updatedItems = currentItems.toMutableList()
+        when {
+            existingIndex >= 0 && matchesFilters -> updatedItems[existingIndex].mergeFrom(entry)
+            existingIndex >= 0 -> updatedItems.removeAt(existingIndex)
+            matchesFilters -> updatedItems.add(entry)
+        }
+
+        emitSuccess(
+            items = updatedItems,
+            pageInfo = current.pageInfo,
+            isEmpty = updatedItems.isEmpty(),
+        )
+    }
+
+    private fun matchesLoadedFilters(entry: MediaList): Boolean {
+        val loadedMediaType = lastMediaType
+        val loadedStatusIn = lastStatusIn
+        val matchesMediaType =
+            loadedMediaType?.let { CompatUtil.equals(entry.media.type, it) } ?: true
+        val matchesStatus =
+            loadedStatusIn?.let { CompatUtil.equals(entry.status, it) } ?: true
+        return matchesMediaType && matchesStatus
+    }
+
+    private fun emitSuccess(
+        items: List<MediaList>,
+        pageInfo: PageInfo?,
+        isEmpty: Boolean,
+    ) {
+        val mediaListSort = settings.mediaListSort ?: KeyUtil.PROGRESS
+        val sorted = if (MediaListUtil.isTitleSort(mediaListSort)) {
+            sortMediaListByTitle(items, settings.sortOrder)
+        } else {
+            items
+        }
+        currentItems = sorted
+        currentPageInfo = pageInfo
+        _state.value = UiState.Success(
+            items = sorted,
+            pageInfo = pageInfo,
+            isEmpty = isEmpty,
+        )
+    }
+
+    private fun MediaList.mergeFrom(entry: MediaList) {
+        id = entry.id
+        mediaId = entry.mediaId
+        status = entry.status
+        score = entry.score
+        scoreRaw = entry.scoreRaw
+        progress = entry.progress
+        progressVolumes = entry.progressVolumes
+        repeat = entry.repeat
+        priority = entry.priority
+        notes = entry.notes
+        isHidden = entry.isHidden
+        isHiddenFromStatusLists = entry.isHiddenFromStatusLists
+        advancedScores = entry.advancedScores
+        customLists = entry.customLists
+        startedAt = entry.startedAt
+        completedAt = entry.completedAt
+        updatedAt = entry.updatedAt
+        createdAt = entry.createdAt
+        media = entry.media
+    }
 
     companion object {
         fun sortMediaListByTitle(

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/MediaViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/MediaViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.repository.BaseRepository
+import com.mxt.anitrend.repository.BrowseMutation
+import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.repository.MediaRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +19,7 @@ import timber.log.Timber
 class MediaViewModel(
     private val mediaRepository: MediaRepository,
     private val baseRepository: BaseRepository,
+    private val browseRepository: BrowseRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
@@ -30,6 +33,18 @@ class MediaViewModel(
     val state: StateFlow<UiState> = _state.asStateFlow()
 
     private var loadedOnce = false
+
+    init {
+        viewModelScope.launch {
+            browseRepository.mutationEvents.collect { event ->
+                when (event) {
+                    is BrowseMutation.MediaListSaved -> onMediaListSaved(event.entry)
+                    is BrowseMutation.MediaListDeleted -> onMediaListDeleted(event.id)
+                    else -> Unit
+                }
+            }
+        }
+    }
 
     /**
      * Loads the media by its AniList ID. Safe to call multiple times -- skips
@@ -80,5 +95,23 @@ class MediaViewModel(
         studioId: Int?,
     ): Result<Unit> = withContext(ioDispatcher) {
         baseRepository.toggleFavourite(animeId, mangaId, characterId, staffId, studioId)
+    }
+
+    internal fun onMediaListSaved(entry: com.mxt.anitrend.model.entity.anilist.MediaList) {
+        val current = _state.value as? UiState.Success ?: return
+        if (current.media.id != entry.mediaId) {
+            return
+        }
+        current.media.mediaListEntry = entry
+        _state.value = UiState.Success(current.media)
+    }
+
+    internal fun onMediaListDeleted(id: Long) {
+        val current = _state.value as? UiState.Success ?: return
+        if (current.media.mediaListEntry?.id != id) {
+            return
+        }
+        current.media.mediaListEntry = null
+        _state.value = UiState.Success(current.media)
     }
 }

--- a/app/src/main/res/color/manage_sheet_chip_background.xml
+++ b/app/src/main/res/color/manage_sheet_chip_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorSecondaryContainer" android:state_checked="true" />
+    <item android:color="?attr/colorSurfaceContainerHighest" />
+</selector>

--- a/app/src/main/res/color/manage_sheet_chip_stroke.xml
+++ b/app/src/main/res/color/manage_sheet_chip_stroke.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorSecondary" android:state_checked="true" />
+    <item android:color="?attr/colorOutline" />
+</selector>

--- a/app/src/main/res/color/manage_sheet_chip_text.xml
+++ b/app/src/main/res/color/manage_sheet_chip_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnSecondaryContainer" android:state_checked="true" />
+    <item android:color="?attr/colorOnSurface" />
+</selector>

--- a/app/src/main/res/drawable/bg_feed_media_context.xml
+++ b/app/src/main/res/drawable/bg_feed_media_context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainer" />
+    <corners android:radius="12dp" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/colorOutlineVariant" />
+</shape>

--- a/app/src/main/res/drawable/bg_feed_section_surface.xml
+++ b/app/src/main/res/drawable/bg_feed_section_surface.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainerLow" />
+    <corners android:radius="12dp" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/colorOutlineVariant" />
+</shape>

--- a/app/src/main/res/layout/activity_giphy_preview.xml
+++ b/app/src/main/res/layout/activity_giphy_preview.xml
@@ -5,27 +5,121 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?android:colorBackground"
     android:fitsSystemWindows="true">
 
     <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/preview_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:contentDescription="@null"
         tools:src="@drawable/reg_bg" />
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:id="@+id/preview_progress"
-        android:layout_width="@dimen/avatar_size"
-        android:layout_height="@dimen/avatar_size"
+    <FrameLayout
+        android:id="@+id/preview_loading_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/preview_progress"
+            android:layout_width="@dimen/avatar_size"
+            android:layout_height="@dimen/avatar_size"
+            android:layout_gravity="center"
+            android:indeterminate="true"
+            app:indicatorColor="?colorAccent" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/preview_top_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/gradient_shadow_inverted"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/xl_margin"
+        android:paddingTop="@dimen/xl_margin"
+        android:paddingBottom="@dimen/lg_margin">
+
+        <ImageButton
+            android:id="@+id/preview_close"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/Close"
+            android:padding="@dimen/lg_margin"
+            android:src="@drawable/ic_close_grey_600_24dp"
+            android:tint="@android:color/white" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/lg_margin"
+            android:layout_weight="1"
+            android:text="@string/title_giphy_preview"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="@android:color/white" />
+    </LinearLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/preview_status_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:indeterminate="true"
-        app:indicatorColor="?colorAccent"/>
+        android:layout_margin="@dimen/spacing_xs"
+        android:visibility="gone"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="0dp"
+        app:strokeColor="?attr/colorOutlineVariant"
+        app:strokeWidth="1dp"
+        tools:visibility="visible">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/preview_status_icon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_broken_image_white_48dp"
+                android:tint="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/preview_status_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:text="@string/title_preview_unavailable"
+                android:textAppearance="?attr/textAppearanceTitleMedium"
+                android:textColor="?attr/colorOnSurface" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/preview_status_message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/md_margin"
+                android:gravity="center"
+                android:text="@string/layout_empty_response"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="No data to display" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <com.mxt.anitrend.base.custom.view.image.WideImageView
         android:id="@+id/preview_credits"
         android:layout_width="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
         android:layout_height="50dp"
+        android:layout_gravity="center_horizontal|bottom"
+        android:layout_marginBottom="@dimen/spacing_xs"
+        android:background="@drawable/gradient_shadow"
+        android:paddingHorizontal="@dimen/xl_margin"
+        android:paddingVertical="@dimen/lg_margin"
         tools:src="@drawable/powered_by_giphy_dark"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_image_preview.xml
+++ b/app/src/main/res/layout/activity_image_preview.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <RelativeLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
         <com.github.chrisbanes.photoview.PhotoView
@@ -22,14 +23,15 @@
             android:id="@+id/toolbar_preview_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:background="@color/toolbar_transparent"
+            android:background="@drawable/gradient_shadow_inverted"
             android:minHeight="?attr/actionBarSize"
-            android:theme="@style/ImagePreviewToolbar">
+            android:paddingHorizontal="@dimen/lg_margin"
+            android:theme="@style/ImagePreviewToolbar"
+            app:contentInsetStartWithNavigation="0dp"
+            app:titleMarginStart="0dp">
 
         </androidx.appcompat.widget.Toolbar>
 
-    </RelativeLayout>
+    </FrameLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/adapter_feed_message.xml
+++ b/app/src/main/res/layout/adapter_feed_message.xml
@@ -6,144 +6,162 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/lg_margin">
+    android:layout_marginHorizontal="@dimen/lg_margin"
+    android:layout_marginTop="@dimen/lg_margin"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:background="@drawable/bg_feed_section_surface"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="@dimen/lg_margin">
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <com.mxt.anitrend.base.custom.view.image.AvatarImageView
+                android:id="@+id/messenger_avatar"
+                android:layout_width="@dimen/avatar_ripple_radius"
+                android:layout_height="@dimen/avatar_ripple_radius"
+                tools:src="@drawable/ic_player" />
+
+            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                android:id="@+id/recipient_user_name"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_marginStart="@dimen/lg_margin"
+                android:layout_weight="1"
+                android:textStyle="bold"
+                tools:text="wax911" />
 
-                <com.mxt.anitrend.base.custom.view.image.AvatarImageView
-                    android:id="@+id/messenger_avatar"
-                    android:layout_width="@dimen/avatar_ripple_radius"
-                    android:layout_height="@dimen/avatar_ripple_radius"
-                    tools:src="@drawable/ic_player" />
+            <Space
+                android:layout_width="@dimen/lg_margin"
+                android:layout_height="wrap_content" />
 
-                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                    android:id="@+id/recipient_user_name"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    tools:text="wax911" />
-
-                <Space
-                    android:layout_width="@dimen/lg_margin"
-                    android:layout_height="wrap_content" />
-
-                <com.mxt.anitrend.base.custom.view.image.AppCompatTintImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:tint="?colorAccent"
-                    app:srcCompat="@drawable/ic_compare_arrows_white_24dp"/>
-
-                <Space
-                    android:layout_width="@dimen/lg_margin"
-                    android:layout_height="wrap_content" />
-
-                <com.mxt.anitrend.base.custom.view.image.AvatarImageView
-                    android:id="@+id/recipient_avatar"
-                    android:layout_width="@dimen/avatar_ripple_radius"
-                    android:layout_height="@dimen/avatar_ripple_radius"
-                    tools:src="@drawable/ic_player" />
-
-                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                    android:id="@+id/messenger_user_name"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_weight="1"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    tools:text="wax911" />
-
-                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                    android:id="@+id/feed_time"
-                    android:layout_weight="1.2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center|end"
-                    android:textAlignment="viewEnd"
-                    tools:text="5 days ago" />
-
-            </LinearLayout>
-
-            <androidx.legacy.widget.Space
+            <com.mxt.anitrend.base.custom.view.image.AppCompatTintImageView
                 android:layout_width="wrap_content"
-                android:layout_height="@dimen/lg_margin" />
+                android:layout_height="wrap_content"
+                app:srcCompat="@drawable/ic_compare_arrows_white_24dp"
+                app:tint="?colorAccent" />
+
+            <Space
+                android:layout_width="@dimen/lg_margin"
+                android:layout_height="wrap_content" />
+
+            <com.mxt.anitrend.base.custom.view.image.AvatarImageView
+                android:id="@+id/recipient_avatar"
+                android:layout_width="@dimen/avatar_ripple_radius"
+                android:layout_height="@dimen/avatar_ripple_radius"
+                tools:src="@drawable/ic_player" />
+
+            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                android:id="@+id/messenger_user_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:layout_weight="1"
+                android:textStyle="bold"
+                tools:text="wax911" />
+
+            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                android:id="@+id/feed_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                tools:text="5 days ago" />
+
+        </LinearLayout>
+
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_feed_section_surface"
+            android:orientation="vertical"
+            android:padding="@dimen/lg_margin">
 
             <com.mxt.anitrend.base.custom.view.widget.StatusContentWidget
                 android:id="@+id/widget_status"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content" />
 
             <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
                 android:id="@+id/widget_status_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/md_margin"
+                android:paddingTop="@dimen/md_margin"
+                android:paddingBottom="@dimen/sm_margin"
                 tools:text="@string/text_error_login" />
-
-            <androidx.legacy.widget.Space
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/md_margin" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="bottom">
-
-                <com.mxt.anitrend.base.custom.view.widget.UsersWidget
-                    android:id="@+id/widget_users"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:foreground="?selectableItemBackground" />
-
-                <Space
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
-
-                <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
-                    android:id="@+id/widget_favourite"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-
-                <com.mxt.anitrend.base.custom.view.widget.CommentWidget
-                    android:id="@+id/widget_comment"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textStyle="bold"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?selectableItemBackground"
-                    tools:text=" 0"/>
-
-                <com.mxt.anitrend.base.custom.view.widget.StatusEditWidget
-                    android:id="@+id/widget_edit"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:foreground="?selectableItemBackground" />
-
-                <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
-                    android:id="@+id/widget_delete"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
 
         </LinearLayout>
 
-    </com.mxt.anitrend.base.custom.view.container.CardViewBase>
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.mxt.anitrend.base.custom.view.widget.UsersWidget
+                android:id="@+id/widget_users"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
+                android:id="@+id/widget_favourite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.mxt.anitrend.base.custom.view.widget.CommentWidget
+                android:id="@+id/widget_comment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground"
+                android:textStyle="bold"
+                tools:text=" 0" />
+
+            <com.mxt.anitrend.base.custom.view.widget.StatusEditWidget
+                android:id="@+id/widget_edit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground" />
+
+            <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
+                android:id="@+id/widget_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.mxt.anitrend.base.custom.view.container.CardViewBase>

--- a/app/src/main/res/layout/adapter_feed_progress.xml
+++ b/app/src/main/res/layout/adapter_feed_progress.xml
@@ -3,158 +3,174 @@
 <com.mxt.anitrend.base.custom.view.container.CardViewBase xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:clickable="true"
-    android:focusable="true"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/lg_margin"
-    android:foreground="?selectableItemBackground">
+    android:layout_marginHorizontal="@dimen/lg_margin"
+    android:layout_marginTop="@dimen/lg_margin"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.mxt.anitrend.base.custom.view.image.AvatarImageView
+                android:id="@+id/user_avatar"
+                android:layout_width="@dimen/avatar_ripple_radius"
+                android:layout_height="@dimen/avatar_ripple_radius"
+                tools:src="@drawable/ic_player" />
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <com.mxt.anitrend.base.custom.view.image.AvatarImageView
-                    android:id="@+id/user_avatar"
-                    android:layout_width="@dimen/avatar_ripple_radius"
-                    android:layout_height="@dimen/avatar_ripple_radius"
-                    tools:src="@drawable/ic_player" />
+                android:layout_marginStart="@dimen/lg_margin"
+                android:layout_weight="1"
+                android:orientation="vertical">
 
                 <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
                     android:id="@+id/user_name"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_weight="1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
+                    android:textStyle="bold"
                     tools:text="wax911" />
 
                 <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
                     android:id="@+id/feed_time"
-                    android:layout_weight="1.8"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center|end"
-                    android:textAlignment="viewEnd"
+                    android:layout_marginTop="@dimen/sm_margin"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                     tools:text="25 minutes ago" />
-
-            </LinearLayout>
-
-            <androidx.legacy.widget.Space
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/lg_margin" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:baselineAligned="false">
-
-                <RelativeLayout
-                    android:layout_weight="1"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:paddingStart="@dimen/md_margin"
-                    android:paddingEnd="@dimen/md_margin">
-
-                    <LinearLayout
-                        android:orientation="vertical"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                        <com.mxt.anitrend.base.custom.view.text.FeedHeadlineTextView
-                            android:id="@+id/feed_headline"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            tools:text="plans to read: Aggressive Restuko" />
-
-                        <androidx.legacy.widget.Space
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/xl_margin" />
-
-                        <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                            android:id="@+id/media_title_english"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            tools:text="Aggressive Restuko" />
-
-                        <androidx.legacy.widget.Space
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/lg_margin" />
-
-                        <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                            android:id="@+id/media_title_original"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textIsSelectable="true"
-                            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-                            tools:text="アグレッシブ烈子"
-                            />
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_alignParentBottom="true"
-                        android:layout_alignParentEnd="true"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="bottom">
-
-                        <com.mxt.anitrend.base.custom.view.widget.UsersWidget
-                            android:id="@+id/widget_users"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:clickable="true"
-                            android:focusable="true"
-                            android:foreground="?selectableItemBackground" />
-
-                        <Space
-                            android:layout_width="0dp"
-                            android:layout_height="0dp"
-                            android:layout_weight="1" />
-
-                        <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
-                            android:id="@+id/widget_favourite"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"/>
-
-                        <com.mxt.anitrend.base.custom.view.widget.CommentWidget
-                            android:id="@+id/widget_comment"
-                            android:layout_marginStart="@dimen/lg_margin"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textStyle="bold"
-                            android:clickable="true"
-                            android:focusable="true"
-                            android:foreground="?selectableItemBackground"
-                            tools:text=" 2"/>
-
-                        <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
-                            android:id="@+id/widget_delete"
-                            android:layout_marginStart="@dimen/lg_margin"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content" />
-
-                    </LinearLayout>
-
-                </RelativeLayout>
-
-                <com.mxt.anitrend.base.custom.view.image.AspectImageView
-                    android:id="@+id/series_image"
-                    android:layout_width="@dimen/series_image_xs"
-                    android:layout_height="wrap_content"
-                    tools:src="@sample/gintama" />
-
             </LinearLayout>
 
         </LinearLayout>
 
-    </com.mxt.anitrend.base.custom.view.container.CardViewBase>
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_feed_media_context"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="@dimen/lg_margin">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/mg_margin"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.mxt.anitrend.base.custom.view.text.FeedHeadlineTextView
+                    android:id="@+id/feed_headline"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="plans to read: Aggressive Restuko" />
+
+                <androidx.legacy.widget.Space
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/lg_margin" />
+
+                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                    android:id="@+id/media_title_english"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    tools:text="Aggressive Restuko" />
+
+                <androidx.legacy.widget.Space
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/md_margin" />
+
+                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                    android:id="@+id/media_title_original"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                    android:textIsSelectable="true"
+                    tools:text="アグレッシブ烈子" />
+
+            </LinearLayout>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="@dimen/series_image_xs"
+                android:layout_height="wrap_content"
+                app:cardBackgroundColor="?attr/colorSurfaceContainerHighest"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                app:strokeColor="?attr/colorOutlineVariant"
+                app:strokeWidth="1dp">
+
+                <com.mxt.anitrend.base.custom.view.image.AspectImageView
+                    android:id="@+id/series_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:src="@sample/gintama" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.mxt.anitrend.base.custom.view.widget.UsersWidget
+                android:id="@+id/widget_users"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
+                android:id="@+id/widget_favourite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.mxt.anitrend.base.custom.view.widget.CommentWidget
+                android:id="@+id/widget_comment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground"
+                android:textStyle="bold"
+                tools:text=" 2" />
+
+            <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
+                android:id="@+id/widget_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.mxt.anitrend.base.custom.view.container.CardViewBase>

--- a/app/src/main/res/layout/adapter_feed_slide.xml
+++ b/app/src/main/res/layout/adapter_feed_slide.xml
@@ -2,29 +2,28 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:foregroundGravity="center"
+    tools:layout_height="wrap_content">
+
+    <com.mxt.anitrend.base.custom.view.image.WideImageView
+        android:id="@+id/feed_status_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:layout_height="wrap_content">
+        android:background="?selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        tools:layout_height="@dimen/wide_image_md"
+        tools:scaleType="centerCrop"
+        tools:src="@sample/darling" />
 
-        <com.mxt.anitrend.base.custom.view.image.WideImageView
-            android:id="@+id/feed_status_image"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clickable="true"
-            android:focusable="true"
-            android:background="?selectableItemBackground"
-            tools:layout_height="@dimen/wide_image_md"
-            tools:scaleType="centerCrop"
-            tools:src="@sample/darling"/>
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/feed_play_back"
-            android:layout_gravity="center"
-            android:layout_width="95dp"
-            android:layout_height="95dp"
-            android:padding="@dimen/xl_margin"
-            android:background="@drawable/bubble_background"
-            app:srcCompat="@drawable/ic_play_circle_outline_white_24dp" />
-
-
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/feed_play_back"
+        android:layout_width="88dp"
+        android:layout_height="88dp"
+        android:layout_gravity="center"
+        android:background="@drawable/bubble_background"
+        android:padding="@dimen/xl_margin"
+        app:srcCompat="@drawable/ic_play_circle_outline_white_24dp" />
 </FrameLayout>

--- a/app/src/main/res/layout/adapter_feed_status.xml
+++ b/app/src/main/res/layout/adapter_feed_status.xml
@@ -6,116 +6,140 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/lg_margin">
+    android:layout_marginHorizontal="@dimen/lg_margin"
+    android:layout_marginTop="@dimen/lg_margin"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?selectableItemBackground"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.mxt.anitrend.base.custom.view.image.AvatarImageView
+                android:id="@+id/user_avatar"
+                android:layout_width="@dimen/avatar_ripple_radius"
+                android:layout_height="@dimen/avatar_ripple_radius"
+                tools:src="@drawable/ic_player" />
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <com.mxt.anitrend.base.custom.view.image.AvatarImageView
-                    android:id="@+id/user_avatar"
-                    android:layout_width="@dimen/avatar_ripple_radius"
-                    android:layout_height="@dimen/avatar_ripple_radius"
-                    tools:src="@drawable/ic_player" />
+                android:layout_marginStart="@dimen/lg_margin"
+                android:layout_weight="1"
+                android:orientation="vertical">
 
                 <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
                     android:id="@+id/user_name"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_weight="1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
+                    android:textStyle="bold"
                     tools:text="wax911" />
 
                 <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
                     android:id="@+id/feed_time"
-                    android:layout_weight="1.8"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center|end"
-                    android:textAlignment="viewEnd"
+                    android:layout_marginTop="@dimen/sm_margin"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                     tools:text="5 days ago" />
-
             </LinearLayout>
 
-            <androidx.legacy.widget.Space
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/lg_margin" />
+        </LinearLayout>
+
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_feed_section_surface"
+            android:orientation="vertical"
+            android:padding="@dimen/lg_margin">
 
             <com.mxt.anitrend.base.custom.view.widget.StatusContentWidget
                 android:id="@+id/widget_status"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content" />
 
             <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
                 android:id="@+id/widget_status_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/md_margin"
+                android:paddingTop="@dimen/md_margin"
+                android:paddingBottom="@dimen/sm_margin"
                 tools:text="@string/text_error_login" />
-
-            <androidx.legacy.widget.Space
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/md_margin" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="bottom">
-
-                <com.mxt.anitrend.base.custom.view.widget.UsersWidget
-                    android:id="@+id/widget_users"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="?selectableItemBackground" />
-
-                <Space
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
-
-                <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
-                    android:id="@+id/widget_favourite"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-
-                <com.mxt.anitrend.base.custom.view.widget.CommentWidget
-                    android:id="@+id/widget_comment"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textStyle="bold"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?selectableItemBackground"
-                    tools:text=" 0"/>
-
-                <com.mxt.anitrend.base.custom.view.widget.StatusEditWidget
-                    android:id="@+id/widget_edit"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:foreground="?selectableItemBackground" />
-
-                <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
-                    android:id="@+id/widget_delete"
-                    android:layout_marginStart="@dimen/lg_margin"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
 
         </LinearLayout>
 
-    </com.mxt.anitrend.base.custom.view.container.CardViewBase>
+        <androidx.legacy.widget.Space
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/mg_margin" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.mxt.anitrend.base.custom.view.widget.UsersWidget
+                android:id="@+id/widget_users"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <com.mxt.anitrend.base.custom.view.widget.FavouriteWidget
+                android:id="@+id/widget_favourite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.mxt.anitrend.base.custom.view.widget.CommentWidget
+                android:id="@+id/widget_comment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground"
+                android:textStyle="bold"
+                tools:text=" 0" />
+
+            <com.mxt.anitrend.base.custom.view.widget.StatusEditWidget
+                android:id="@+id/widget_edit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?selectableItemBackground" />
+
+            <com.mxt.anitrend.base.custom.view.widget.StatusDeleteWidget
+                android:id="@+id/widget_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/lg_margin" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.mxt.anitrend.base.custom.view.container.CardViewBase>

--- a/app/src/main/res/layout/adapter_latest_anime.xml
+++ b/app/src/main/res/layout/adapter_latest_anime.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/lg_margin"
+    android:layout_marginTop="@dimen/lg_margin"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?selectableItemBackground"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.mxt.anitrend.base.custom.view.widget.SeriesStatusWidget
+            android:id="@+id/series_status"
+            android:layout_width="6dp"
+            android:layout_height="match_parent"
+            tools:background="@color/colorStateBlue" />
+
+        <com.mxt.anitrend.base.custom.view.image.AspectImageView
+            android:id="@+id/series_image"
+            android:layout_width="104dp"
+            android:layout_height="wrap_content"
+            tools:src="@sample/gintama" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top"
+                android:orientation="horizontal">
+
+                <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
+                    android:id="@+id/series_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                    tools:text="Gintama" />
+
+                <com.mxt.anitrend.base.custom.view.text.RatingTextView
+                    android:id="@+id/custom_rating_widget"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/lg_margin" />
+            </LinearLayout>
+
+            <com.mxt.anitrend.base.custom.view.text.AiringTextView
+                android:id="@+id/series_airing"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:background="?attr/colorSecondaryContainer"
+                android:paddingHorizontal="@dimen/lg_margin"
+                android:paddingVertical="@dimen/md_margin"
+                android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+                tools:text="Episode 31 in 4 days" />
+
+            <com.mxt.anitrend.base.custom.view.text.SeriesYearTypeTextView
+                android:id="@+id/series_year_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                tools:text="2015 • TV" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/adapter_latest_manga.xml
+++ b/app/src/main/res/layout/adapter_latest_manga.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/lg_margin"
+    android:layout_marginTop="@dimen/lg_margin"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?selectableItemBackground"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.mxt.anitrend.base.custom.view.widget.SeriesStatusWidget
+            android:id="@+id/series_status"
+            android:layout_width="6dp"
+            android:layout_height="match_parent"
+            tools:background="@color/colorStateOrange" />
+
+        <com.mxt.anitrend.base.custom.view.image.AspectImageView
+            android:id="@+id/series_image"
+            android:layout_width="104dp"
+            android:layout_height="wrap_content"
+            tools:src="@sample/gintama" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top"
+                android:orientation="horizontal">
+
+                <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
+                    android:id="@+id/series_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                    tools:text="Oyasumi Punpun" />
+
+                <com.mxt.anitrend.base.custom.view.text.RatingTextView
+                    android:id="@+id/custom_rating_widget"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/lg_margin" />
+            </LinearLayout>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/series_airing"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:background="?attr/colorSecondaryContainer"
+                android:paddingHorizontal="@dimen/lg_margin"
+                android:paddingVertical="@dimen/md_margin"
+                android:text="@string/label_latest_release"
+                android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+                android:textColor="?attr/colorOnSecondaryContainer" />
+
+            <com.mxt.anitrend.base.custom.view.text.SeriesYearTypeTextView
+                android:id="@+id/series_year_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                tools:text="2010 • Manga" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/adapter_review.xml
+++ b/app/src/main/res/layout/adapter_review.xml
@@ -3,93 +3,123 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:clickable="true"
-    android:focusable="true"
-    android:foreground="?selectableItemBackground"
     android:layout_margin="@dimen/lg_margin"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:cardPreventCornerOverlap="false"
-    app:cardBackgroundColor="?cardColor"
-    app:cardElevation="@dimen/sm_margin"
-    app:cardCornerRadius="@dimen/lg_margin">
-
-        <com.mxt.anitrend.base.custom.view.image.WideImageView
-            android:id="@+id/series_image"
-            android:clickable="true"
-            android:focusable="true"
-            android:background="?selectableItemBackground"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:scaleType="centerCrop"
-            tools:layout_height="@dimen/wide_image_md"
-            tools:src="@sample/darling" />
-
-        <FrameLayout
-            android:background="@color/colorTransparent"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-        <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-            android:id="@+id/review_user_name"
-            android:layout_gravity="top|end"
-            android:layout_margin="@dimen/md_margin"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/white"
-            android:padding="@dimen/lg_margin"
-            android:textStyle="bold"
-            tools:text="By: Diama" />
-
-        <com.mxt.anitrend.base.custom.view.widget.CustomRatingBar
-            android:layout_gravity="top|start"
-            android:id="@+id/series_rating"
-            android:layout_margin="@dimen/md_margin"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:theme="@style/SmallRating"
-            android:padding="@dimen/lg_margin"
-            tools:rating="1" />
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardElevation="0dp"
+    app:cardCornerRadius="20dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
 
         <LinearLayout
-            android:layout_marginBottom="35dp"
-            android:layout_gravity="bottom"
-            android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/lg_margin">
+            android:orientation="vertical">
 
-            <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
-                android:textColor="@color/white"
-                android:padding="@dimen/md_margin"
-                android:id="@+id/series_title"
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.mxt.anitrend.base.custom.view.image.WideImageView
+                    android:id="@+id/series_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    tools:layout_height="@dimen/wide_image_md"
+                    tools:scaleType="centerCrop"
+                    tools:src="@sample/darling" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@drawable/gradient_shadow" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/spacing_xs">
+
+                    <com.mxt.anitrend.base.custom.view.widget.CustomRatingBar
+                        android:id="@+id/series_rating"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:theme="@style/SmallRating"
+                        tools:rating="1" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/review_user_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/lg_margin"
+                        android:background="@drawable/bubble_background"
+                        android:paddingHorizontal="@dimen/lg_margin"
+                        android:paddingVertical="@dimen/md_margin"
+                        android:textAppearance="?attr/textAppearanceLabelLarge"
+                        android:textColor="@color/white"
+                        tools:text="By: Diama" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:gravity="bottom"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/spacing_xs">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
+                            android:id="@+id/series_title"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/white"
+                            tools:text="Boku no Hero Academia" />
+                    </LinearLayout>
+
+                    <com.mxt.anitrend.base.custom.view.widget.VoteWidget
+                        android:id="@+id/review_vote"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/lg_margin" />
+                </LinearLayout>
+            </FrameLayout>
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="Boku no Hero Accademia" />
+                android:orientation="vertical"
+                android:padding="@dimen/spacing_xs">
 
-            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                android:id="@+id/review_summary"
-                android:textColor="@color/white"
-                android:padding="@dimen/md_margin"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:text="One of the best Shonene shows you can ever ask for I also want..." />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/review_summary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="3"
+                    android:textAppearance="?attr/textAppearanceBodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    tools:text="One of the best shounen shows you can ever ask for. It balances spectacle, warmth, and momentum beautifully." />
 
-            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                android:id="@+id/review_read_more"
-                android:padding="@dimen/md_margin"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/white"
-                android:textStyle="bold"
-                android:text="@string/text_read_more" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/review_read_more"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/lg_margin"
+                    android:paddingVertical="@dimen/md_margin"
+                    android:text="@string/text_read_more"
+                    android:textAppearance="?attr/textAppearanceLabelLarge"
+                    android:textColor="?attr/colorPrimary" />
+            </LinearLayout>
 
         </LinearLayout>
-
-        <com.mxt.anitrend.base.custom.view.widget.VoteWidget
-            android:id="@+id/review_vote"
-            android:layout_gravity="bottom|start"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/lg_margin"/>
-    </com.google.android.material.card.MaterialCardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/adapter_series_review.xml
+++ b/app/src/main/res/layout/adapter_series_review.xml
@@ -1,48 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<com.mxt.anitrend.base.custom.view.container.CardViewBase xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:clickable="true"
-    android:focusable="true"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/lg_margin"
-    android:foreground="?selectableItemBackground">
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:gravity="center_vertical"
                 android:orientation="horizontal">
 
                 <com.mxt.anitrend.base.custom.view.image.AvatarImageView
                     android:id="@+id/user_avatar"
-                    android:layout_width="@dimen/avatar_ripple_radius"
-                    android:layout_height="@dimen/avatar_ripple_radius"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:focusable="true"
                     tools:src="@drawable/ic_player" />
 
-                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                    android:id="@+id/user_name"
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/lg_margin"
                     android:layout_weight="1"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    tools:text="wax911" />
+                    android:orientation="vertical">
 
-                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                    android:id="@+id/review_date"
-                    android:layout_weight="1.8"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center|end"
-                    android:textAlignment="viewEnd"
-                    tools:text="Oct 28 2017" />
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/user_name"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?attr/textAppearanceTitleSmall"
+                        android:textColor="?attr/colorOnSurface"
+                        tools:text="wax911" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/review_date"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/md_margin"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        tools:text="Oct 28 2017" />
+                </LinearLayout>
 
             </LinearLayout>
 
@@ -52,83 +67,81 @@
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:baselineAligned="false">
 
-                <RelativeLayout
+                <LinearLayout
                     android:layout_weight="1"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="@dimen/spacing_small">
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/spacing_small"
+                    android:orientation="vertical">
+
+                    <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/series_title"
+                        android:textSize="16sp"
+                        android:ellipsize="end"
+                        tools:text="Gintama." />
+
+                    <androidx.legacy.widget.Space
+                        android:layout_width="wrap_content"
+                        android:layout_height="@dimen/lg_margin" />
+
+                    <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
+                        android:id="@+id/review_summary"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="4"
+                        android:textStyle="italic"
+                        tools:text="Amazing show with a well thought out plot" />
+
+                    <androidx.legacy.widget.Space
+                        android:layout_width="wrap_content"
+                        android:layout_height="@dimen/lg_margin" />
+
+                    <com.mxt.anitrend.base.custom.view.widget.CustomRatingBar
+                        android:id="@+id/series_rating"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:theme="@style/SmallRating" />
 
                     <LinearLayout
-                        android:orientation="vertical"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_small"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                        <com.mxt.anitrend.base.custom.view.text.SeriesTitleView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:id="@+id/series_title"
-                            android:textSize="16sp"
-                            android:ellipsize="end"
-                            tools:text="Gintama." />
-
-                        <androidx.legacy.widget.Space
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/lg_margin" />
-
-                        <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
-                            android:id="@+id/review_summary"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textStyle="italic"
-                            android:maxLines="2"
-                            tools:text="Amazing show with a well thought out plot" />
-
-                        <androidx.legacy.widget.Space
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/lg_margin" />
-
-                        <com.mxt.anitrend.base.custom.view.widget.CustomRatingBar
-                            android:id="@+id/series_rating"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:theme="@style/SmallRating" />
-
-                        <androidx.legacy.widget.Space
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/spacing_medium" />
-
-                        <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                        <com.google.android.material.textview.MaterialTextView
                             android:id="@+id/review_read_more"
-                            android:padding="6dp"
-                            android:textStyle="bold"
-                            android:layout_width="wrap_content"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:text="@string/text_read_more" />
+                            android:layout_weight="1"
+                            android:paddingVertical="@dimen/md_margin"
+                            android:text="@string/text_read_more"
+                            android:textAppearance="?attr/textAppearanceLabelLarge"
+                            android:textColor="?attr/colorPrimary" />
 
+                        <com.mxt.anitrend.base.custom.view.widget.VoteWidget
+                            android:id="@+id/review_vote"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
                     </LinearLayout>
 
-                    <com.mxt.anitrend.base.custom.view.widget.VoteWidget
-                        android:id="@+id/review_vote"
-                        android:layout_alignParentBottom="true"
-                        android:layout_alignParentEnd="true"
-                        android:layout_marginTop="@dimen/lg_margin"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-
-                </RelativeLayout>
+                </LinearLayout>
 
                 <com.mxt.anitrend.base.custom.view.image.AspectImageView
                     android:id="@+id/series_image"
-                    android:layout_width="@dimen/series_image_xs"
+                    android:layout_width="88dp"
                     android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
                     tools:src="@sample/gintama" />
 
             </LinearLayout>
 
         </LinearLayout>
 
-    </com.mxt.anitrend.base.custom.view.container.CardViewBase>
+    </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_about_m3.xml
+++ b/app/src/main/res/layout/fragment_about_m3.xml
@@ -12,14 +12,16 @@
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
         android:orientation="vertical"
-        android:padding="@dimen/xl_margin">
+        android:paddingHorizontal="@dimen/spacing_xs"
+        android:paddingTop="@dimen/spacing_xs"
+        android:paddingBottom="@dimen/spacing_sm">
 
         <!-- App Icon -->
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/about_app_icon"
             android:layout_width="96dp"
             android:layout_height="96dp"
-            android:layout_marginBottom="16dp"
+            android:layout_marginBottom="@dimen/lg_margin"
             android:src="@mipmap/ic_launcher"
             app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Circle" />
 
@@ -28,7 +30,8 @@
             android:id="@+id/about_app_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
+            android:layout_marginTop="@dimen/lg_margin"
+            android:layout_marginBottom="@dimen/md_margin"
             android:gravity="center"
             android:text="@string/app_name"
             android:textAppearance="?attr/textAppearanceTitleLarge" />
@@ -39,7 +42,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
             android:textColor="?attr/colorOnSurfaceVariant"
             tools:text="Version 5.0.0" />
 
@@ -47,9 +50,9 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
-            app:cardCornerRadius="12dp"
+            android:layout_marginTop="@dimen/spacing_xs"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="20dp"
             app:cardElevation="0dp"
             app:strokeColor="?attr/colorOutlineVariant"
             app:strokeWidth="1dp">
@@ -58,14 +61,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingHorizontal="@dimen/xl_margin"
-                android:paddingVertical="@dimen/mg_margin">
+                android:paddingHorizontal="@dimen/spacing_xs"
+                android:paddingVertical="@dimen/spacing_xs">
 
                 <!-- Section Header -->
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
+                    android:layout_marginBottom="@dimen/md_margin"
                     android:text="@string/text_about_general_information"
                     android:textAppearance="?attr/textAppearanceTitleSmall"
                     android:textColor="?attr/colorPrimary" />
@@ -74,7 +77,7 @@
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="12dp"
+                    android:layout_marginBottom="@dimen/lg_margin"
                     android:text="@string/app_description"
                     android:textAppearance="?attr/textAppearanceBodyMedium"
                     android:textColor="?attr/colorOnSurfaceVariant" />
@@ -85,6 +88,7 @@
                     android:layout_height="wrap_content"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -114,6 +118,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -130,6 +135,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_rate_play_store"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
 
                 <!-- Follow on Twitter -->
@@ -142,6 +154,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -158,6 +171,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_follow_twitter"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
@@ -167,8 +187,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/lg_margin"
-            app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
-            app:cardCornerRadius="12dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="20dp"
             app:cardElevation="0dp"
             app:strokeColor="?attr/colorOutlineVariant"
             app:strokeWidth="1dp">
@@ -177,14 +197,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingHorizontal="@dimen/xl_margin"
-                android:paddingVertical="@dimen/mg_margin">
+                android:paddingHorizontal="@dimen/spacing_xs"
+                android:paddingVertical="@dimen/spacing_xs">
 
                 <!-- Section Header -->
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
+                    android:layout_marginBottom="@dimen/md_margin"
                     android:text="@string/text_about_additional_information"
                     android:textAppearance="?attr/textAppearanceTitleSmall"
                     android:textColor="?attr/colorPrimary" />
@@ -199,6 +219,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -215,6 +236,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_github"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
 
                 <!-- Website -->
@@ -227,6 +255,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -243,6 +272,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_website"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
 
                 <!-- What's New -->
@@ -255,6 +291,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -271,6 +308,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_what_is_new"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
 
                 <!-- FAQ -->
@@ -283,6 +327,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -299,6 +344,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_frequently_asked_questions"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
@@ -308,8 +360,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/lg_margin"
-            app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
-            app:cardCornerRadius="12dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="20dp"
             app:cardElevation="0dp"
             app:strokeColor="?attr/colorOutlineVariant"
             app:strokeWidth="1dp">
@@ -318,14 +370,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingHorizontal="@dimen/xl_margin"
-                android:paddingVertical="@dimen/mg_margin">
+                android:paddingHorizontal="@dimen/spacing_xs"
+                android:paddingVertical="@dimen/spacing_xs">
 
                 <!-- Section Header -->
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
+                    android:layout_marginBottom="@dimen/md_margin"
                     android:text="@string/text_about_legal_information"
                     android:textAppearance="?attr/textAppearanceTitleSmall"
                     android:textColor="?attr/colorPrimary" />
@@ -340,6 +392,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -356,6 +409,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_terms_and_conditions"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
 
                 <!-- Code of Conduct -->
@@ -368,6 +428,7 @@
                     android:foreground="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
+                    android:minHeight="56dp"
                     android:paddingVertical="@dimen/lg_margin">
 
                     <androidx.appcompat.widget.AppCompatImageView
@@ -384,6 +445,13 @@
                         android:layout_weight="1"
                         android:text="@string/text_about_code_of_conduct"
                         android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_link_white_24dp"
+                        android:tint="?attr/colorOnSurfaceVariant" />
                 </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_settings_m3.xml
+++ b/app/src/main/res/layout/fragment_settings_m3.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:id="@+id/settings_sections"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceContainerLowest"
+        android:orientation="vertical"
+        android:padding="@dimen/spacing_xs" />
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_settings_divider.xml
+++ b/app/src/main/res/layout/item_settings_divider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.divider.MaterialDivider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/item_settings_row_switch.xml
+++ b/app/src/main/res/layout/item_settings_row_switch.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="64dp"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/lg_margin">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/row_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurface" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/row_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/md_margin"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+    </LinearLayout>
+
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/row_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="false"
+        android:focusable="false" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_settings_row_value.xml
+++ b/app/src/main/res/layout/item_settings_row_value.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="64dp"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/lg_margin">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/row_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurface" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/row_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/md_margin"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+    </LinearLayout>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/row_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/lg_margin"
+        android:textAppearance="?attr/textAppearanceLabelLarge"
+        android:textColor="?attr/colorPrimary" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/row_chevron"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginStart="@dimen/md_margin"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_link_white_24dp"
+        android:tint="?attr/colorOnSurfaceVariant" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_settings_section_card.xml
+++ b/app/src/main/res/layout/item_settings_section_card.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/lg_margin"
+    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/spacing_xs">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/section_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="?attr/colorOnSurface" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/section_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/md_margin"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <LinearLayout
+            android:id="@+id/section_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/lg_margin"
+            android:orientation="vertical" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fitsSystemWindows="true"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurfaceContainerLowest">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
@@ -13,6 +14,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurfaceContainer"
             app:layout_scrollFlags="enterAlways|exitUntilCollapsed" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/sheet_series_manage_m3.xml
+++ b/app/src/main/res/layout/sheet_series_manage_m3.xml
@@ -392,6 +392,8 @@
                             android:id="@+id/sheet_manage_custom_lists_chips"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            app:chipSpacingHorizontal="@dimen/lg_margin"
+                            app:chipSpacingVertical="@dimen/lg_margin"
                             app:singleSelection="false" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/widget_status.xml
+++ b/app/src/main/res/layout/widget_status.xml
@@ -6,32 +6,35 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-        <FrameLayout
-            android:visibility="gone"
-            android:id="@+id/widget_slide_holder"
+    <FrameLayout
+        android:id="@+id/widget_slide_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_feed_media_context"
+        android:clipToPadding="false"
+        android:descendantFocusability="afterDescendants"
+        android:padding="@dimen/lg_margin"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:visibility="visible">
+
+        <com.mxt.anitrend.base.custom.recycler.StatefulRecyclerView
+            android:id="@+id/widget_status_recycler"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.mxt.anitrend.base.custom.view.text.PageIndicator
+            android:id="@+id/widget_status_indicator"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:descendantFocusability="afterDescendants"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            tools:visibility="visible">
+            android:layout_gravity="top|end"
+            android:layout_marginTop="@dimen/lg_margin"
+            android:layout_marginEnd="@dimen/lg_margin"
+            tools:text="2 / 5" />
 
-            <com.mxt.anitrend.base.custom.recycler.StatefulRecyclerView
-                android:id="@+id/widget_status_recycler"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+    </FrameLayout>
 
-            <com.mxt.anitrend.base.custom.view.text.PageIndicator
-                android:id="@+id/widget_status_indicator"
-                android:layout_gravity="top|end"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/lg_margin"
-                android:layout_marginEnd="@dimen/xl_margin"
-                tools:text="2 / 5" />
-
-        </FrameLayout>
-
-        <androidx.legacy.widget.Space
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/md_margin" />
-    </LinearLayout>
+    <androidx.legacy.widget.Space
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/md_margin" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,6 +741,9 @@
     <string name="image_preview_download">Download</string>
     <string name="image_preview_share">Share</string>
     <string name="image_preview_link">Original Link</string>
+    <string name="title_giphy_preview">Giphy preview</string>
+    <string name="title_preview_unavailable">Preview unavailable</string>
+    <string name="label_latest_release">Latest release</string>
 
     <!-- Image Preview error strings -->
     <string name="image_preview_error_character_image">The character image doesn\'t exist!</string>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -369,4 +369,21 @@
         <item name="android:textColor">?attr/colorOnSurfaceVariant</item>
     </style>
 
+    <style name="Widget.AniTrend.ManageSheet.CustomListChip" parent="Widget.Material3.Chip.Filter">
+        <item name="android:textColor">@color/manage_sheet_chip_text</item>
+        <item name="checkedIcon">@drawable/ic_check_circle_white_24dp</item>
+        <item name="checkedIconEnabled">true</item>
+        <item name="checkedIconTint">?attr/colorOnSecondaryContainer</item>
+        <item name="chipBackgroundColor">@color/manage_sheet_chip_background</item>
+        <item name="chipCornerRadius">18dp</item>
+        <item name="chipEndPadding">12dp</item>
+        <item name="chipMinHeight">40dp</item>
+        <item name="chipStartPadding">12dp</item>
+        <item name="chipStrokeColor">@color/manage_sheet_chip_stroke</item>
+        <item name="chipStrokeWidth">1dp</item>
+        <item name="ensureMinTouchTargetSize">true</item>
+        <item name="rippleColor">?attr/colorSecondaryContainer</item>
+        <item name="shapeAppearanceOverlay">@style/ShapeAppearance.Material3.Corner.Full</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences_experimental.xml
+++ b/app/src/main/res/xml/root_preferences_experimental.xml
@@ -14,6 +14,12 @@
   ~ limitations under the License.
   -->
 
+<!--
+  Superseded by SettingsActivity.MaterialSettingsFragment.buildSections().
+  Kept as a reference map for the experimental M3 settings structure while the
+  legacy PreferenceFragment fallback still uses root_preferences.xml.
+-->
+
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/AiringListViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/AiringListViewModelTest.kt
@@ -4,13 +4,16 @@ import com.mxt.anitrend.graphql.generated.MediaListSort
 import com.mxt.anitrend.graphql.generated.MediaListStatus
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.graphql.generated.ScoreFormat
+import com.mxt.anitrend.model.api.retro.anilist.BrowseService
+import com.mxt.anitrend.model.entity.anilist.MediaList
 import com.mxt.anitrend.model.entity.anilist.MediaListCollection
+import com.mxt.anitrend.model.entity.anilist.meta.CustomList
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import com.mxt.anitrend.repository.BrowseMutation
 import com.mxt.anitrend.repository.BrowseRepository
+import com.mxt.anitrend.util.KeyUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -23,6 +26,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -34,10 +38,7 @@ class AiringListViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        browseRepository = mock(BrowseRepository::class.java)
-        doReturn(MutableSharedFlow<BrowseMutation>())
-            .`when`(browseRepository)
-            .mutationEvents
+        browseRepository = spy(BrowseRepository(mock(BrowseService::class.java), testDispatcher))
     }
 
     @After
@@ -140,4 +141,80 @@ class AiringListViewModelTest {
         val state = vm.state.value as AiringListViewModel.UiState.Error
         assertEquals("Airing failed", state.message)
     }
+
+    @Test
+    fun `saved media list event patches airing content without reload`() = runTest {
+        val initialEntry = MediaList().apply {
+            id = 1L
+            mediaId = 100L
+            status = KeyUtil.CURRENT
+            media.id = 100L
+            media.type = KeyUtil.ANIME
+            media.status = KeyUtil.RELEASING
+        }
+        val savedEntry = MediaList().apply {
+            id = 1L
+            mediaId = 100L
+            status = KeyUtil.CURRENT
+            progress = 7
+            customLists = listOf(CustomList(name = "Watch Party", isEnabled = true))
+            media.id = 100L
+            media.type = KeyUtil.ANIME
+            media.status = KeyUtil.RELEASING
+        }
+        doReturn(Result.success(pageContainer(initialEntry)))
+            .`when`(browseRepository)
+            .getMediaListCollection(
+                userId = 10L,
+                type = MediaType.ANIME,
+                forceSingleCompletedList = true,
+                sort = listOf(MediaListSort.UPDATED_TIME_DESC),
+                statusIn = listOf(MediaListStatus.CURRENT),
+                scoreFormat = ScoreFormat.POINT_10,
+            )
+
+        val vm = AiringListViewModel(browseRepository = browseRepository)
+
+        vm.load(
+            type = MediaType.ANIME,
+            userId = 10,
+            sort = "UPDATED_TIME_DESC",
+            statusIn = "CURRENT",
+            scoreFormat = ScoreFormat.POINT_10,
+        )
+        advanceUntilIdle()
+        vm.onMediaListSaved(savedEntry)
+
+        val state = vm.state.value as AiringListViewModel.UiState.Success
+        val updatedEntry = state.content.pageData.single().entries.orEmpty().single()
+        assertEquals(7, updatedEntry.progress)
+        assertEquals("Watch Party", updatedEntry.customLists?.single()?.name)
+        verify(browseRepository).getMediaListCollection(
+            userId = 10L,
+            type = MediaType.ANIME,
+            forceSingleCompletedList = true,
+            sort = listOf(MediaListSort.UPDATED_TIME_DESC),
+            statusIn = listOf(MediaListStatus.CURRENT),
+            scoreFormat = ScoreFormat.POINT_10,
+        )
+    }
+
+    private fun pageContainer(entry: MediaList): PageContainer<MediaListCollection> =
+        PageContainer<MediaListCollection>().apply {
+            pageData = listOf(
+                newMediaListCollection(
+                    status = KeyUtil.CURRENT,
+                    entries = listOf(entry),
+                ),
+            )
+        }
+
+    private fun newMediaListCollection(
+        status: String,
+        entries: List<MediaList>,
+    ): MediaListCollection =
+        mock(MediaListCollection::class.java).apply {
+            this.status = status
+            doReturn(entries).`when`(this).entries
+        }
 }

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/AiringListViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/AiringListViewModelTest.kt
@@ -199,22 +199,20 @@ class AiringListViewModelTest {
         )
     }
 
-    private fun pageContainer(entry: MediaList): PageContainer<MediaListCollection> =
-        PageContainer<MediaListCollection>().apply {
-            pageData = listOf(
-                newMediaListCollection(
-                    status = KeyUtil.CURRENT,
-                    entries = listOf(entry),
-                ),
-            )
-        }
+    private fun pageContainer(entry: MediaList): PageContainer<MediaListCollection> = PageContainer<MediaListCollection>().apply {
+        pageData = listOf(
+            newMediaListCollection(
+                status = KeyUtil.CURRENT,
+                entries = listOf(entry),
+            ),
+        )
+    }
 
     private fun newMediaListCollection(
         status: String,
         entries: List<MediaList>,
-    ): MediaListCollection =
-        mock(MediaListCollection::class.java).apply {
-            this.status = status
-            doReturn(entries).`when`(this).entries
-        }
+    ): MediaListCollection = mock(MediaListCollection::class.java).apply {
+        this.status = status
+        doReturn(entries).`when`(this).entries
+    }
 }

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/FeedListViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/FeedListViewModelTest.kt
@@ -1,0 +1,211 @@
+package com.mxt.anitrend.viewmodel
+
+import com.mxt.anitrend.graphql.generated.LikeableType
+import com.mxt.anitrend.model.entity.anilist.FeedList
+import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.repository.BaseMutation
+import com.mxt.anitrend.repository.BaseRepository
+import com.mxt.anitrend.repository.FeedMutation
+import com.mxt.anitrend.repository.FeedRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeedListViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var feedRepository: FeedRepository
+    private lateinit var baseRepository: BaseRepository
+    private lateinit var feedMutations: MutableSharedFlow<FeedMutation>
+    private lateinit var baseMutations: MutableSharedFlow<BaseMutation>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        feedRepository = mock(FeedRepository::class.java)
+        baseRepository = mock(BaseRepository::class.java)
+        feedMutations = MutableSharedFlow(extraBufferCapacity = 1)
+        baseMutations = MutableSharedFlow(extraBufferCapacity = 1)
+        doReturn(feedMutations)
+            .`when`(feedRepository)
+            .mutationEvents
+        doReturn(baseMutations)
+            .`when`(baseRepository)
+            .mutationEvents
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `feed saved prepends new feed to current page`() = runTest {
+        val existing = feed(id = 1L, text = "old")
+        val inserted = feed(id = 2L, text = "new")
+        val viewModel = viewModelWithPage(existing)
+
+        feedMutations.tryEmit(FeedMutation.FeedSaved(inserted))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertTrue(state.replaceExisting)
+        assertEquals(listOf(2L, 1L), state.content.pageData.map { it.id })
+        assertSame(inserted, state.content.pageData.first())
+    }
+
+    @Test
+    fun `feed deleted removes matching feed from current page`() = runTest {
+        val keep = feed(id = 1L)
+        val remove = feed(id = 2L)
+        val viewModel = viewModelWithPage(keep, remove)
+
+        feedMutations.tryEmit(FeedMutation.FeedDeleted(remove.id))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertTrue(state.replaceExisting)
+        assertEquals(listOf(1L), state.content.pageData.map { it.id })
+    }
+
+    @Test
+    fun `feed saved replaces existing feed in place`() = runTest {
+        val original = feed(id = 5L, text = "before")
+        val updated = feed(id = 5L, text = "after")
+        val sibling = feed(id = 6L, text = "keep")
+        val viewModel = viewModelWithPage(original, sibling)
+
+        feedMutations.tryEmit(FeedMutation.FeedSaved(updated))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertTrue(state.replaceExisting)
+        assertEquals(listOf(5L, 6L), state.content.pageData.map { it.id })
+        assertSame(updated, state.content.pageData.first())
+    }
+
+    @Test
+    fun `like toggled updates likes for matching activity feed`() = runTest {
+        val feed = feed(id = 7L)
+        val likes = listOf(user(id = 99L, name = "max"))
+        val viewModel = viewModelWithPage(feed)
+
+        baseMutations.tryEmit(
+            BaseMutation.LikeToggled(
+                users = likes,
+                targetId = feed.id,
+                targetType = LikeableType.ACTIVITY,
+            ),
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertTrue(state.replaceExisting)
+        assertSame(likes, state.content.pageData.first().likes)
+    }
+
+    @Test
+    fun `like toggled ignores non activity targets`() = runTest {
+        val originalLikes = listOf(user(id = 1L, name = "before"))
+        val feed = feed(id = 7L).apply { likes = originalLikes }
+        val otherLikes = listOf(user(id = 99L, name = "after"))
+        val viewModel = viewModelWithPage(feed)
+
+        baseMutations.tryEmit(
+            BaseMutation.LikeToggled(
+                users = otherLikes,
+                targetId = feed.id,
+                targetType = LikeableType.ACTIVITY_REPLY,
+            ),
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertEquals(listOf(7L), state.content.pageData.map { it.id })
+        assertSame(originalLikes, state.content.pageData.first().likes)
+    }
+
+    @Test
+    fun `apply returned feed updates existing feed and ignores missing feed`() = runTest {
+        val original = feed(id = 3L, text = "before")
+        val updated = feed(id = 3L, text = "after")
+        val missing = feed(id = 4L, text = "missing")
+        val viewModel = viewModelWithPage(original)
+
+        viewModel.applyReturnedFeed(updated)
+        advanceUntilIdle()
+
+        var state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertTrue(state.replaceExisting)
+        assertEquals(listOf(3L), state.content.pageData.map { it.id })
+        assertSame(updated, state.content.pageData.first())
+
+        viewModel.applyReturnedFeed(missing)
+        advanceUntilIdle()
+
+        state = viewModel.state.value as FeedListViewModel.UiState.Success
+        assertEquals(listOf(3L), state.content.pageData.map { it.id })
+        assertSame(updated, state.content.pageData.first())
+    }
+
+    private suspend fun viewModelWithPage(vararg feeds: FeedList): FeedListViewModel {
+        val page = PageContainer<FeedList>().apply { pageData = feeds.toList() }
+        doReturn(Result.success(page))
+            .`when`(feedRepository)
+            .getFeedList(
+                page = 1,
+                perPage = 20,
+                id = null,
+                isFollowing = null,
+                userId = null,
+                type = null,
+                isMixed = null,
+                asHtml = false,
+            )
+
+        return FeedListViewModel(
+            feedRepository = feedRepository,
+            baseRepository = baseRepository,
+            ioDispatcher = testDispatcher,
+        ).also {
+            it.load(
+                page = 1,
+                pageLimit = 20,
+                isFollowing = null,
+                type = null,
+                isMixed = null,
+            )
+        }
+    }
+
+    private fun feed(
+        id: Long,
+        text: String? = null,
+    ) = FeedList(
+        id = id,
+        text = text,
+        type = "TEXT",
+    )
+
+    private fun user(
+        id: Long,
+        name: String,
+    ) = UserBase(name = name).apply {
+        this.id = id
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaDetailViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package com.mxt.anitrend.viewmodel
 
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.model.entity.anilist.FeedList
+import com.mxt.anitrend.model.api.retro.anilist.BrowseService
 import com.mxt.anitrend.model.entity.anilist.Media
 import com.mxt.anitrend.model.entity.anilist.edge.CharacterEdge
 import com.mxt.anitrend.model.entity.anilist.edge.MediaEdge
@@ -13,6 +14,8 @@ import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.BaseMutation
 import com.mxt.anitrend.repository.BaseRepository
+import com.mxt.anitrend.repository.BrowseMutation
+import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.repository.MediaRepository
 import com.mxt.anitrend.util.KeyUtil
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +31,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -36,12 +40,14 @@ class MediaDetailViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var mediaRepository: MediaRepository
     private lateinit var baseRepository: BaseRepository
+    private lateinit var browseRepository: BrowseRepository
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         mediaRepository = mock(MediaRepository::class.java)
         baseRepository = mock(BaseRepository::class.java)
+        browseRepository = spy(BrowseRepository(mock(BrowseService::class.java), testDispatcher))
         doReturn(MutableSharedFlow<BaseMutation>())
             .`when`(baseRepository)
             .mutationEvents
@@ -61,6 +67,7 @@ class MediaDetailViewModelTest {
         val viewModel = MediaViewModel(
             mediaRepository = mediaRepository,
             baseRepository = baseRepository,
+            browseRepository = browseRepository,
             ioDispatcher = testDispatcher,
         )
 

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaDetailViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaDetailViewModelTest.kt
@@ -14,7 +14,6 @@ import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.BaseMutation
 import com.mxt.anitrend.repository.BaseRepository
-import com.mxt.anitrend.repository.BrowseMutation
 import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.repository.MediaRepository
 import com.mxt.anitrend.util.KeyUtil

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaListViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaListViewModelTest.kt
@@ -1,0 +1,167 @@
+package com.mxt.anitrend.viewmodel
+
+import com.mxt.anitrend.fixture.MediaListFixtures.aMediaList
+import com.mxt.anitrend.graphql.generated.MediaListSort
+import com.mxt.anitrend.graphql.generated.MediaListStatus
+import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.graphql.generated.ScoreFormat
+import com.mxt.anitrend.model.api.retro.anilist.BrowseService
+import com.mxt.anitrend.model.entity.anilist.MediaList
+import com.mxt.anitrend.model.entity.anilist.MediaListCollection
+import com.mxt.anitrend.model.entity.anilist.User
+import com.mxt.anitrend.model.entity.anilist.meta.CustomList
+import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.repository.BrowseRepository
+import com.mxt.anitrend.repository.UserRepository
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.Settings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MediaListViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var browseRepository: BrowseRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var settings: Settings
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        browseRepository = spy(BrowseRepository(mock(BrowseService::class.java), testDispatcher))
+        userRepository = mock(UserRepository::class.java)
+        settings = mock(Settings::class.java)
+        doReturn(KeyUtil.PROGRESS)
+            .`when`(settings)
+            .mediaListSort
+        doReturn(KeyUtil.DESC)
+            .`when`(settings)
+            .sortOrder
+        doReturn(true)
+            .`when`(settings)
+            .isAuthenticated
+        doReturn(
+            User().apply {
+                id = 42L
+                name = "max"
+                mediaListOptions.scoreFormat = ScoreFormat.POINT_100.name
+            },
+        ).`when`(userRepository).cachedCurrentUser
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `saved media list event patches current items without reload`() = runTest {
+        val initialEntry = aMediaList(id = 1L, mediaId = 100L)
+        val savedEntry = aMediaList(id = 1L, mediaId = 100L).apply {
+            customLists = listOf(CustomList(name = "Favorites", isEnabled = true))
+            progress = 9
+        }
+        doReturn(Result.success(pageContainer(initialEntry)))
+            .`when`(browseRepository)
+            .getMediaListCollection(
+                userId = 42L,
+                userName = null,
+                type = MediaType.ANIME,
+                forceSingleCompletedList = true,
+                sort = listOf(MediaListSort.PROGRESS_DESC),
+                statusIn = listOf(MediaListStatus.CURRENT),
+                scoreFormat = ScoreFormat.POINT_100,
+            )
+
+        val vm = MediaListViewModel(
+            browseRepository = browseRepository,
+            userRepository = userRepository,
+            settings = settings,
+            ioDispatcher = testDispatcher,
+        )
+
+        vm.load(userId = 42L, userName = null, mediaType = KeyUtil.ANIME, statusIn = KeyUtil.CURRENT)
+        advanceUntilIdle()
+        vm.onMediaListSaved(savedEntry)
+
+        val state = vm.state.value as MediaListViewModel.UiState.Success
+        assertEquals(9, state.items.single().progress)
+        assertEquals("Favorites", state.items.single().customLists?.single()?.name)
+        verify(browseRepository, times(1)).getMediaListCollection(
+            userId = 42L,
+            userName = null,
+            type = MediaType.ANIME,
+            forceSingleCompletedList = true,
+            sort = listOf(MediaListSort.PROGRESS_DESC),
+            statusIn = listOf(MediaListStatus.CURRENT),
+            scoreFormat = ScoreFormat.POINT_100,
+        )
+    }
+
+    @Test
+    fun `saved media list event removes item when status no longer matches loaded filter`() = runTest {
+        val initialEntry = aMediaList(id = 1L, mediaId = 100L)
+        val movedEntry = aMediaList(id = 1L, mediaId = 100L, status = KeyUtil.COMPLETED)
+        doReturn(Result.success(pageContainer(initialEntry)))
+            .`when`(browseRepository)
+            .getMediaListCollection(
+                userId = 42L,
+                userName = null,
+                type = MediaType.ANIME,
+                forceSingleCompletedList = true,
+                sort = listOf(MediaListSort.PROGRESS_DESC),
+                statusIn = listOf(MediaListStatus.CURRENT),
+                scoreFormat = ScoreFormat.POINT_100,
+            )
+
+        val vm = MediaListViewModel(
+            browseRepository = browseRepository,
+            userRepository = userRepository,
+            settings = settings,
+            ioDispatcher = testDispatcher,
+        )
+
+        vm.load(userId = 42L, userName = null, mediaType = KeyUtil.ANIME, statusIn = KeyUtil.CURRENT)
+        advanceUntilIdle()
+        vm.onMediaListSaved(movedEntry)
+
+        val state = vm.state.value as MediaListViewModel.UiState.Success
+        assertTrue(state.items.isEmpty())
+        assertTrue(state.isEmpty)
+    }
+
+    private fun pageContainer(vararg entries: MediaList): PageContainer<MediaListCollection> =
+        PageContainer<MediaListCollection>().apply {
+            pageData = listOf(
+                newMediaListCollection(
+                    status = KeyUtil.CURRENT,
+                    entries = entries.toList(),
+                ),
+            )
+        }
+
+    private fun newMediaListCollection(
+        status: String,
+        entries: List<MediaList>,
+    ): MediaListCollection =
+        mock(MediaListCollection::class.java).apply {
+            this.status = status
+            doReturn(entries).`when`(this).entries
+        }
+}

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaListViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaListViewModelTest.kt
@@ -146,22 +146,20 @@ class MediaListViewModelTest {
         assertTrue(state.isEmpty)
     }
 
-    private fun pageContainer(vararg entries: MediaList): PageContainer<MediaListCollection> =
-        PageContainer<MediaListCollection>().apply {
-            pageData = listOf(
-                newMediaListCollection(
-                    status = KeyUtil.CURRENT,
-                    entries = entries.toList(),
-                ),
-            )
-        }
+    private fun pageContainer(vararg entries: MediaList): PageContainer<MediaListCollection> = PageContainer<MediaListCollection>().apply {
+        pageData = listOf(
+            newMediaListCollection(
+                status = KeyUtil.CURRENT,
+                entries = entries.toList(),
+            ),
+        )
+    }
 
     private fun newMediaListCollection(
         status: String,
         entries: List<MediaList>,
-    ): MediaListCollection =
-        mock(MediaListCollection::class.java).apply {
-            this.status = status
-            doReturn(entries).`when`(this).entries
-        }
+    ): MediaListCollection = mock(MediaListCollection::class.java).apply {
+        this.status = status
+        doReturn(entries).`when`(this).entries
+    }
 }

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaViewModelTest.kt
@@ -1,20 +1,27 @@
 package com.mxt.anitrend.viewmodel
 
 import com.mxt.anitrend.model.entity.base.MediaBase
+import com.mxt.anitrend.model.api.retro.anilist.BrowseService
 import com.mxt.anitrend.repository.BaseRepository
+import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.repository.MediaRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MediaViewModelTest {
@@ -22,12 +29,14 @@ class MediaViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var mediaRepository: MediaRepository
     private lateinit var baseRepository: BaseRepository
+    private lateinit var browseRepository: BrowseRepository
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         mediaRepository = mock(MediaRepository::class.java)
         baseRepository = mock(BaseRepository::class.java)
+        browseRepository = spy(BrowseRepository(mock(BrowseService::class.java), testDispatcher))
     }
 
     @After
@@ -64,7 +73,12 @@ class MediaViewModelTest {
 
     @Test
     fun `initial state is Loading`() = runTest {
-        val vm = MediaViewModel(mediaRepository = mediaRepository, baseRepository = baseRepository, ioDispatcher = testDispatcher)
+        val vm = MediaViewModel(
+            mediaRepository = mediaRepository,
+            baseRepository = baseRepository,
+            browseRepository = browseRepository,
+            ioDispatcher = testDispatcher,
+        )
         assertTrue(vm.state.value is MediaViewModel.UiState.Loading)
     }
 
@@ -74,5 +88,61 @@ class MediaViewModelTest {
     fun `GraphQL error message is surfaced in Error state`() {
         val state = MediaViewModel.UiState.Error("Media not found")
         assertEquals("Media not found", state.message)
+    }
+
+    @Test
+    fun `saved media list event updates loaded media entry`() = runTest {
+        val media = MediaBase().apply { id = 100L }
+        val savedEntry = com.mxt.anitrend.model.entity.anilist.MediaList().apply {
+            id = 5L
+            mediaId = 100L
+        }
+        doReturn(Result.success(media))
+            .`when`(mediaRepository)
+            .getMediaBase(100L, null, false)
+
+        val vm = MediaViewModel(
+            mediaRepository = mediaRepository,
+            baseRepository = baseRepository,
+            browseRepository = browseRepository,
+            ioDispatcher = testDispatcher,
+        )
+
+        vm.load(mediaId = 100L, mediaType = null, showAdult = false)
+        advanceUntilIdle()
+        vm.onMediaListSaved(savedEntry)
+
+        val state = vm.state.value as MediaViewModel.UiState.Success
+        assertEquals(5L, state.media.mediaListEntry?.id)
+        verify(mediaRepository).getMediaBase(100L, null, false)
+    }
+
+    @Test
+    fun `deleted media list event clears loaded media entry`() = runTest {
+        val entry = com.mxt.anitrend.model.entity.anilist.MediaList().apply {
+            id = 9L
+            mediaId = 100L
+        }
+        val media = MediaBase().apply {
+            id = 100L
+            mediaListEntry = entry
+        }
+        doReturn(Result.success(media))
+            .`when`(mediaRepository)
+            .getMediaBase(100L, null, false)
+
+        val vm = MediaViewModel(
+            mediaRepository = mediaRepository,
+            baseRepository = baseRepository,
+            browseRepository = browseRepository,
+            ioDispatcher = testDispatcher,
+        )
+
+        vm.load(mediaId = 100L, mediaType = null, showAdult = false)
+        advanceUntilIdle()
+        vm.onMediaListDeleted(9L)
+
+        val state = vm.state.value as MediaViewModel.UiState.Success
+        assertNull(state.media.mediaListEntry)
     }
 }


### PR DESCRIPTION
## Description
- complete the phased Material 3 redesign across about, preview, settings, review, feed, latest episodes, and manage sheet surfaces
- preserve behavior on fragile screens while fixing date widget click handling in the manage sheet
- propagate saved media list mutation state to detail, list, and airing view models without relying on stale refetch consumers
- replace fragile Unsafe-based list test fixtures with mock-backed coverage for mutation propagation

## Verification
- ./gradlew :app:compileAppDebugKotlin --no-daemon
- ./gradlew :app:testAppDebugUnitTest --tests "com.mxt.anitrend.viewmodel.FeedListViewModelTest" :app:assembleAppDebug --no-daemon --no-configuration-cache
- ./gradlew :app:compileAppDebugKotlin :app:testAppDebugUnitTest --tests "com.mxt.anitrend.view.activity.base.GiphyPreviewActivityTest" --tests "com.mxt.anitrend.view.activity.base.ImagePreviewActivityTest" --tests "com.mxt.anitrend.view.sheet.ManageSheetLogicTest" --tests "com.mxt.anitrend.util.media.MediaListUtilTest" --tests "com.mxt.anitrend.viewmodel.MediaLatestViewModelTest" --tests "com.mxt.anitrend.viewmodel.BrowseReviewViewModelTest" --tests "com.mxt.anitrend.viewmodel.ReviewViewModelTest" --tests "com.mxt.anitrend.viewmodel.FeedListViewModelTest" --no-daemon
- ./gradlew :app:testAppDebugUnitTest --tests "com.mxt.anitrend.viewmodel.MediaViewModelTest" --tests "com.mxt.anitrend.viewmodel.MediaDetailViewModelTest" --tests "com.mxt.anitrend.viewmodel.MediaListViewModelTest" --tests "com.mxt.anitrend.viewmodel.AiringListViewModelTest" --no-daemon