### PR TITLE
refactor(architecture): migrate fragments to Koin ownership

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/AnimePageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/AnimePageAdapter.kt
@@ -1,11 +1,16 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
+import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.view.fragment.detail.MediaFeedFragment
 import com.mxt.anitrend.view.fragment.detail.MediaOverviewFragment
@@ -29,17 +34,27 @@ class AnimePageAdapter(
         setPagerTitles(R.array.anime_page_titles)
     }
 
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(MediaOverviewFragment::class.java, Bundle(params)),
+            FragmentItem(MediaRelationFragment::class.java, Bundle(params)),
+            FragmentItem(MediaRecommendationsFragment::class.java, Bundle(params)),
+            FragmentItem(MediaStatsFragment::class.java, Bundle(params)),
+            FragmentItem(MediaCharacterFragment::class.java, Bundle(params)),
+            FragmentItem(MediaStaffFragment::class.java, Bundle(params)),
+            FragmentItem(
+                MediaFeedFragment::class.java,
+                Bundle(params).apply {
+                    putLong(KeyUtil.arg_mediaId, params.getLong(KeyUtil.arg_id))
+                    putBoolean(KeyUtil.arg_isFollowing, true)
+                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
+                },
+            ),
+            FragmentItem(ReviewFragment::class.java, Bundle(params)),
+        )
+    }
+
     override fun getItemCount(): Int = if (isAuthenticated) super.getItemCount() else super.getItemCount() - 2
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> MediaOverviewFragment.newInstance(params)
-        1 -> MediaRelationFragment.newInstance(params)
-        2 -> MediaRecommendationsFragment.newInstance(params)
-        3 -> MediaStatsFragment.newInstance(params)
-        4 -> MediaCharacterFragment.newInstance(params)
-        5 -> MediaStaffFragment.newInstance(params)
-        6 -> MediaFeedFragment.newInstance(params)
-        7 -> ReviewFragment.newInstance(params)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
-    }
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/CharacterPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/CharacterPageAdapter.kt
@@ -1,10 +1,14 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.detail.CharacterOverviewFragment
 import com.mxt.anitrend.view.fragment.group.CharacterActorsFragment
@@ -21,11 +25,28 @@ class CharacterPageAdapter(
         setPagerTitles(R.array.character_page_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> CharacterOverviewFragment.newInstance(params)
-        1 -> MediaFormatFragment.newInstance(params, KeyUtil.ANIME, KeyUtil.CHARACTER_MEDIA_REQ)
-        2 -> MediaFormatFragment.newInstance(params, KeyUtil.MANGA, KeyUtil.CHARACTER_MEDIA_REQ)
-        3 -> CharacterActorsFragment.newInstance(params)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(CharacterOverviewFragment::class.java, Bundle(params)),
+            FragmentItem(
+                MediaFormatFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                    putInt(KeyUtil.arg_request_type, KeyUtil.CHARACTER_MEDIA_REQ)
+                },
+                "MediaFormatFragmentAnime",
+            ),
+            FragmentItem(
+                MediaFormatFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
+                    putInt(KeyUtil.arg_request_type, KeyUtil.CHARACTER_MEDIA_REQ)
+                },
+                "MediaFormatFragmentManga",
+            ),
+            FragmentItem(CharacterActorsFragment::class.java, Bundle(params)),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/FavouritePageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/FavouritePageAdapter.kt
@@ -1,10 +1,14 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.favourite.CharacterFavouriteFragment
 import com.mxt.anitrend.view.fragment.favourite.MediaFavouriteFragment
@@ -22,12 +26,27 @@ class FavouritePageAdapter(
         setPagerTitles(R.array.favorites_page_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> MediaFavouriteFragment.newInstance(params, KeyUtil.ANIME)
-        1 -> CharacterFavouriteFragment.newInstance(params)
-        2 -> MediaFavouriteFragment.newInstance(params, KeyUtil.MANGA)
-        3 -> StaffFavouriteFragment.newInstance(params)
-        4 -> StudioFavouriteFragment.newInstance(params)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                MediaFavouriteFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                },
+                "MediaFavouriteFragmentAnime",
+            ),
+            FragmentItem(CharacterFavouriteFragment::class.java, Bundle(params)),
+            FragmentItem(
+                MediaFavouriteFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
+                },
+                "MediaFavouriteFragmentManga",
+            ),
+            FragmentItem(StaffFavouriteFragment::class.java, Bundle(params)),
+            FragmentItem(StudioFavouriteFragment::class.java, Bundle(params)),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/MangaPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/MangaPageAdapter.kt
@@ -1,11 +1,16 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
+import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.view.fragment.detail.MediaFeedFragment
 import com.mxt.anitrend.view.fragment.detail.MediaOverviewFragment
@@ -29,17 +34,27 @@ class MangaPageAdapter(
         setPagerTitles(R.array.manga_page_titles)
     }
 
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(MediaOverviewFragment::class.java, Bundle(params)),
+            FragmentItem(MediaRelationFragment::class.java, Bundle(params)),
+            FragmentItem(MediaRecommendationsFragment::class.java, Bundle(params)),
+            FragmentItem(MediaStatsFragment::class.java, Bundle(params)),
+            FragmentItem(MediaCharacterFragment::class.java, Bundle(params)),
+            FragmentItem(MediaStaffFragment::class.java, Bundle(params)),
+            FragmentItem(
+                MediaFeedFragment::class.java,
+                Bundle(params).apply {
+                    putLong(KeyUtil.arg_mediaId, params.getLong(KeyUtil.arg_id))
+                    putBoolean(KeyUtil.arg_isFollowing, true)
+                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
+                },
+            ),
+            FragmentItem(ReviewFragment::class.java, Bundle(params)),
+        )
+    }
+
     override fun getItemCount(): Int = if (isAuthenticated) super.getItemCount() else super.getItemCount() - 2
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> MediaOverviewFragment.newInstance(params)
-        1 -> MediaRelationFragment.newInstance(params)
-        2 -> MediaRecommendationsFragment.newInstance(params)
-        3 -> MediaStatsFragment.newInstance(params)
-        4 -> MediaCharacterFragment.newInstance(params)
-        5 -> MediaStaffFragment.newInstance(params)
-        6 -> MediaFeedFragment.newInstance(params)
-        7 -> ReviewFragment.newInstance(params)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
-    }
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/MessagePageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/MessagePageAdapter.kt
@@ -1,10 +1,14 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.detail.MessageFeedFragment
 
@@ -19,9 +23,24 @@ class MessagePageAdapter(
         setPagerTitles(R.array.messages_page_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> MessageFeedFragment.newInstance(params, KeyUtil.MESSAGE_TYPE_INBOX)
-        1 -> MessageFeedFragment.newInstance(params, KeyUtil.MESSAGE_TYPE_OUTBOX)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                MessageFeedFragment::class.java,
+                Bundle(params).apply {
+                    putInt(KeyUtil.arg_message_type, KeyUtil.MESSAGE_TYPE_INBOX)
+                },
+                "MessageFeedFragmentInbox",
+            ),
+            FragmentItem(
+                MessageFeedFragment::class.java,
+                Bundle(params).apply {
+                    putInt(KeyUtil.arg_message_type, KeyUtil.MESSAGE_TYPE_OUTBOX)
+                },
+                "MessageFeedFragmentOutbox",
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/ProfilePageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/ProfilePageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.detail.UserFeedFragment
 import com.mxt.anitrend.view.fragment.detail.UserOverviewFragment
@@ -21,22 +24,27 @@ class ProfilePageAdapter(
         setPagerTitles(R.array.profile_page_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> UserOverviewFragment.newInstance(params)
-        1 ->
-            UserFeedFragment.newInstance(
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(UserOverviewFragment::class.java, Bundle(params)),
+            FragmentItem(
+                UserFeedFragment::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_type, KeyUtil.MEDIA_LIST)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        2 ->
-            UserFeedFragment.newInstance(
+                "UserFeedFragmentMediaList",
+            ),
+            FragmentItem(
+                UserFeedFragment::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_type, KeyUtil.TEXT)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+                "UserFeedFragmentText",
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/StaffPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/detail/StaffPageAdapter.kt
@@ -1,11 +1,15 @@
 package com.mxt.anitrend.adapter.pager.detail
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.view.fragment.detail.StaffOverviewFragment
@@ -26,20 +30,42 @@ class StaffPageAdapter(
         setPagerTitles(R.array.staff_page_titles)
     }
 
+    private val staffOverviewFragment by lazy(LAZY_MODE_UNSAFE) {
+        FragmentItem(StaffOverviewFragment::class.java, Bundle(params))
+    }
+
+    private val mediaAnimeRoleFragment by lazy(LAZY_MODE_UNSAFE) {
+        FragmentItem(
+            MediaAnimeRoleFragment::class.java,
+            Bundle(params).apply {
+                putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                putInt(KeyUtil.arg_request_type, KeyUtil.STAFF_CHARACTERS_REQ)
+            },
+        )
+    }
+
+    private val mediaFormatFragment by lazy(LAZY_MODE_UNSAFE) {
+        FragmentItem(
+            MediaFormatFragment::class.java,
+            Bundle(params).apply {
+                putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
+                putInt(KeyUtil.arg_request_type, KeyUtil.STAFF_MEDIA_REQ)
+            },
+        )
+    }
+
+    private val mediaStaffRoleFragment by lazy(LAZY_MODE_UNSAFE) {
+        FragmentItem(MediaStaffRoleFragment::class.java, Bundle(params))
+    }
+
     override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> StaffOverviewFragment.newInstance(params)
-        1 ->
-            MediaAnimeRoleFragment
-                .newInstance(params, KeyUtil.ANIME, KeyUtil.STAFF_CHARACTERS_REQ)
-                .apply { setFilterable(isAuthenticated) }
-        2 ->
-            MediaFormatFragment
-                .newInstance(params, KeyUtil.MANGA, KeyUtil.STAFF_MEDIA_REQ)
-                .apply { setFilterable(isAuthenticated) }
-        3 ->
-            MediaStaffRoleFragment
-                .newInstance(params)
-                .apply { setFilterable(isAuthenticated) }
+        0 -> staffOverviewFragment.fragmentByTagOrNew(fragmentActivity)
+        1 -> mediaAnimeRoleFragment.fragmentByTagOrNew(fragmentActivity)
+            .apply { setFilterable(isAuthenticated) }
+        2 -> mediaFormatFragment.fragmentByTagOrNew(fragmentActivity)
+            .apply { setFilterable(isAuthenticated) }
+        3 -> mediaStaffRoleFragment.fragmentByTagOrNew(fragmentActivity)
+            .apply { setFilterable(isAuthenticated) }
         else -> throw IndexOutOfBoundsException("Invalid position: $position")
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/AiringPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/AiringPageAdapter.kt
@@ -1,12 +1,18 @@
 package com.mxt.anitrend.adapter.pager.index
 
 import android.content.Context
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.BuildConfig
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.model.entity.anilist.ExternalLink
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
+import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.AiringListFragment
 import com.mxt.anitrend.view.fragment.list.WatchListFragment
 
@@ -21,12 +27,23 @@ class AiringPageAdapter(
         setPagerTitles(R.array.airing_title)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> AiringListFragment.newInstance()
-        1 -> {
-            val externalLinks = arrayListOf(ExternalLink(BuildConfig.FEEDS_LINK, null))
-            WatchListFragment.newInstance(externalLinks, false)
-        }
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(AiringListFragment::class.java),
+            FragmentItem(
+                WatchListFragment::class.java,
+                Bundle().apply {
+                    putParcelableArrayList(
+                        KeyUtil.arg_list_model,
+                        ArrayList<Parcelable>(
+                            arrayListOf(ExternalLink(BuildConfig.FEEDS_LINK, null)),
+                        ),
+                    )
+                    putBoolean(KeyUtil.arg_popular, false)
+                },
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/FeedPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/FeedPageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.FeedListFragment
 
@@ -20,33 +23,39 @@ class FeedPageAdapter(
         setPagerTitles(R.array.feed_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 ->
-            FeedListFragment.newInstance(
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                FeedListFragment::class.java,
                 Bundle(params).apply {
                     putBoolean(KeyUtil.arg_isFollowing, true)
                     putString(KeyUtil.arg_type, KeyUtil.MEDIA_LIST)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        1 ->
-            FeedListFragment.newInstance(
+                "FeedListFragmentMediaList",
+            ),
+            FragmentItem(
+                FeedListFragment::class.java,
                 Bundle(params).apply {
                     putBoolean(KeyUtil.arg_isFollowing, true)
                     putString(KeyUtil.arg_type, KeyUtil.TEXT)
                     putBoolean(KeyUtil.arg_asHtml, false)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        2 ->
-            FeedListFragment.newInstance(
+                "FeedListFragmentText",
+            ),
+            FragmentItem(
+                FeedListFragment::class.java,
                 Bundle(params).apply {
                     putBoolean(KeyUtil.arg_isFollowing, false)
                     putBoolean(KeyUtil.arg_isMixed, true)
                     putBoolean(KeyUtil.arg_asHtml, false)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+                "FeedListFragmentMixed",
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/HubPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/HubPageAdapter.kt
@@ -1,12 +1,18 @@
 package com.mxt.anitrend.adapter.pager.index
 
 import android.content.Context
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.BuildConfig
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.model.entity.anilist.ExternalLink
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
+import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.SuggestionListFragment
 import com.mxt.anitrend.view.fragment.list.WatchListFragment
 
@@ -21,12 +27,30 @@ class HubPageAdapter(
         setPagerTitles(R.array.hub_title)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> SuggestionListFragment.newInstance(params)
-        1 -> {
-            val externalLinks = arrayListOf(ExternalLink(BuildConfig.FEEDS_LINK, null))
-            WatchListFragment.newInstance(externalLinks, true)
-        }
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                SuggestionListFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                    putBoolean(KeyUtil.arg_onList, false)
+                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
+                },
+            ),
+            FragmentItem(
+                WatchListFragment::class.java,
+                Bundle().apply {
+                    putParcelableArrayList(
+                        KeyUtil.arg_list_model,
+                        ArrayList<Parcelable>(
+                            arrayListOf(ExternalLink(BuildConfig.FEEDS_LINK, null)),
+                        ),
+                    )
+                    putBoolean(KeyUtil.arg_popular, true)
+                },
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/MangaPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/MangaPageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.MediaBrowseFragment
 import com.mxt.anitrend.view.fragment.list.MediaLatestList
@@ -22,22 +25,25 @@ class MangaPageAdapter(
         setPagerTitles(R.array.manga_title)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 ->
-            MediaBrowseFragment.newInstance(
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                MediaBrowseFragment::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        1 ->
-            MediaLatestList.newInstance(
+            ),
+            FragmentItem(
+                MediaLatestList::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
                     putString(KeyUtil.arg_sort, KeyUtil.ID + KeyUtil.DESC)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/MediaListPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/MediaListPageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.MediaListFragment
 
@@ -31,14 +34,17 @@ class MediaListPageAdapter(
         setPagerTitles(R.array.media_list_status)
     }
 
-    override fun createFragment(position: Int): Fragment {
-        if (position !in mediaListStatuses.indices) {
-            throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems: List<FragmentItem<Fragment>> by lazy(LAZY_MODE_UNSAFE) {
+        mediaListStatuses.map { status ->
+            FragmentItem(
+                MediaListFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_statusIn, status)
+                },
+                "MediaListFragment$status",
+            )
         }
-        return MediaListFragment.newInstance(
-            Bundle(params).apply {
-                putString(KeyUtil.arg_statusIn, mediaListStatuses[position])
-            },
-        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/ReviewPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/ReviewPageAdapter.kt
@@ -1,10 +1,14 @@
 package com.mxt.anitrend.adapter.pager.index
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.detail.BrowseReviewFragment
 
@@ -20,9 +24,24 @@ class ReviewPageAdapter(
         setPagerTitles(R.array.reviews_title)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> BrowseReviewFragment.newInstance(KeyUtil.ANIME)
-        1 -> BrowseReviewFragment.newInstance(KeyUtil.MANGA)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                BrowseReviewFragment::class.java,
+                Bundle().apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                },
+                "BrowseReviewFragmentAnime",
+            ),
+            FragmentItem(
+                BrowseReviewFragment::class.java,
+                Bundle().apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
+                },
+                "BrowseReviewFragmentManga",
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/SearchPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/SearchPageAdapter.kt
@@ -1,11 +1,15 @@
 package com.mxt.anitrend.adapter.pager.index
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.view.fragment.search.CharacterSearchFragment
@@ -32,13 +36,28 @@ class SearchPageAdapter(
         )
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 -> MediaSearchFragment.newInstance(params, KeyUtil.ANIME)
-        1 -> MediaSearchFragment.newInstance(params, KeyUtil.MANGA)
-        2 -> StudioSearchFragment.newInstance(params)
-        3 -> StaffSearchFragment.newInstance(params)
-        4 -> CharacterSearchFragment.newInstance(params)
-        5 -> UserSearchFragment.newInstance(params)
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                MediaSearchFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
+                },
+                "MediaSearchFragmentAnime",
+            ),
+            FragmentItem(
+                MediaSearchFragment::class.java,
+                Bundle(params).apply {
+                    putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
+                },
+                "MediaSearchFragmentManga",
+            ),
+            FragmentItem(StudioSearchFragment::class.java, Bundle(params)),
+            FragmentItem(StaffSearchFragment::class.java, Bundle(params)),
+            FragmentItem(CharacterSearchFragment::class.java, Bundle(params)),
+            FragmentItem(UserSearchFragment::class.java, Bundle(params)),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/SeasonPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/SeasonPageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.MediaBrowseFragment
 
@@ -20,39 +23,19 @@ class SeasonPageAdapter(
         setPagerTitles(R.array.seasons_titles)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 ->
-            MediaBrowseFragment.newInstance(
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        arrayOf(KeyUtil.WINTER, KeyUtil.SPRING, KeyUtil.SUMMER, KeyUtil.FALL).map { season ->
+            FragmentItem<Fragment>(
+                MediaBrowseFragment::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
-                    putString(KeyUtil.arg_season, KeyUtil.WINTER)
+                    putString(KeyUtil.arg_season, season)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
+                "MediaBrowseFragment$season",
             )
-        1 ->
-            MediaBrowseFragment.newInstance(
-                Bundle(params).apply {
-                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
-                    putString(KeyUtil.arg_season, KeyUtil.SPRING)
-                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
-                },
-            )
-        2 ->
-            MediaBrowseFragment.newInstance(
-                Bundle(params).apply {
-                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
-                    putString(KeyUtil.arg_season, KeyUtil.SUMMER)
-                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
-                },
-            )
-        3 ->
-            MediaBrowseFragment.newInstance(
-                Bundle(params).apply {
-                    putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
-                    putString(KeyUtil.arg_season, KeyUtil.FALL)
-                    putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
-                },
-            )
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+        }
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/pager/index/TrendingPageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/pager/index/TrendingPageAdapter.kt
@@ -6,6 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.pager.BaseStatePageAdapter
+import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.MediaLatestList
 
@@ -20,31 +23,37 @@ class TrendingPageAdapter(
         setPagerTitles(R.array.trending_title)
     }
 
-    override fun createFragment(position: Int): Fragment = when (position) {
-        0 ->
-            MediaLatestList.newInstance(
+    private val fragmentItems by lazy(LAZY_MODE_UNSAFE) {
+        listOf<FragmentItem<Fragment>>(
+            FragmentItem(
+                MediaLatestList::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
                     putString(KeyUtil.arg_sort, KeyUtil.TRENDING + KeyUtil.DESC)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        1 ->
-            MediaLatestList.newInstance(
+                "MediaLatestListAnimeTrending",
+            ),
+            FragmentItem(
+                MediaLatestList::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
                     putString(KeyUtil.arg_sort, KeyUtil.TRENDING + KeyUtil.DESC)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        2 ->
-            MediaLatestList.newInstance(
+                "MediaLatestListMangaTrending",
+            ),
+            FragmentItem(
+                MediaLatestList::class.java,
                 Bundle(params).apply {
                     putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
                     putString(KeyUtil.arg_sort, KeyUtil.ID + KeyUtil.DESC)
                     putInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT)
                 },
-            )
-        else -> throw IndexOutOfBoundsException("Invalid position: $position")
+                "MediaLatestListAnimeLatest",
+            ),
+        )
     }
+
+    override fun createFragment(position: Int): Fragment = fragmentItems[position].fragmentByTagOrNew(fragmentActivity)
 }

--- a/app/src/main/java/com/mxt/anitrend/base/custom/pager/BaseStatePageAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/pager/BaseStatePageAdapter.kt
@@ -17,7 +17,7 @@ import com.mxt.anitrend.util.locale.LocaleUtil
  * Base page state adapter
  */
 abstract class BaseStatePageAdapter(
-    fragmentActivity: FragmentActivity,
+    protected val fragmentActivity: FragmentActivity,
     private val context: Context,
 ) : FragmentStateAdapter(fragmentActivity) {
     var params: Bundle = Bundle.EMPTY

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
@@ -125,7 +125,7 @@ constructor(
                 }
             }
             R.id.user_followers_container -> {
-                if (followers == null || followers?.total ?: 0 < 1) {
+                if (followers == null || (followers?.total ?: 0) < 1) {
                     NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
                 } else {
                     val manager = fragmentManager ?: return

--- a/app/src/main/java/com/mxt/anitrend/extension/ContextExt.kt
+++ b/app/src/main/java/com/mxt/anitrend/extension/ContextExt.kt
@@ -12,6 +12,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
+import android.content.ContextWrapper
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.annotation.*
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.ActivityCompat
@@ -25,7 +29,6 @@ import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.locale.LocaleUtil
 import timber.log.Timber
 import java.io.File
-
 /**
  * Exactly whether a device is low-RAM is ultimately up to the device configuration, but currently
  * it generally means something in the class of a 512MB device with about a 800x480 or less screen.
@@ -238,4 +241,33 @@ fun FragmentActivity.requestNotificationsPermission() {
             1,
         )
     }
+}
+
+/**
+ * Resolve [androidx.fragment.app.FragmentManager] from any context
+ *
+ * @throws NotImplementedError when a context type cannot be handled
+ */
+@Throws(NotImplementedError::class)
+fun Context.fragmentManager() = when (this) {
+    is FragmentActivity -> supportFragmentManager
+    is ContextWrapper -> (baseContext as FragmentActivity).supportFragmentManager
+    else -> throw NotImplementedError("This type of context: $this is not handled/supported")
+}
+
+@Throws(IllegalArgumentException::class)
+fun Context.requireLifecycleOwner(): LifecycleOwner = when (val context = this) {
+    is LifecycleOwner -> context
+    else -> throw IllegalArgumentException("$context is not a lifecycle owner")
+}
+
+fun Context.lifecycleOwner(): LifecycleOwner? = runCatching(::requireLifecycleOwner)
+    .getOrElse {
+        Timber.w(it)
+        null
+    }
+
+fun Context.lifecycleScope(): LifecycleCoroutineScope? {
+    val lifecycleOwner = lifecycleOwner()
+    return lifecycleOwner?.lifecycleScope
 }

--- a/app/src/main/java/com/mxt/anitrend/extension/InsetsExentions.kt
+++ b/app/src/main/java/com/mxt/anitrend/extension/InsetsExentions.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.mxt.anitrend.extension
+
+import android.view.ViewGroup
+import androidx.core.view.WindowInsetsCompat
+import com.mxt.anitrend.R
+
+/**
+ * Record the window's top inset so it can be applied when the bottom sheet is slide up
+ * to meet the top edge of the screen.
+ */
+fun ViewGroup.applySystemBarsWindowInsetsListener() {
+    setOnApplyWindowInsetsListener { view, windowInsets ->
+        val windowInsetsCompat = WindowInsetsCompat.toWindowInsetsCompat(windowInsets)
+        val systemBars = WindowInsetsCompat.Type.systemBars()
+        view.setTag(
+            R.id.tag_system_window_inset_top,
+            windowInsetsCompat.getInsets(systemBars),
+        )
+        windowInsets
+    }
+}

--- a/app/src/main/java/com/mxt/anitrend/extension/SupportExt.kt
+++ b/app/src/main/java/com/mxt/anitrend/extension/SupportExt.kt
@@ -1,5 +1,6 @@
 package com.mxt.anitrend.extension
 
+import android.content.res.Resources
 import java.util.*
 
 /**
@@ -67,3 +68,15 @@ fun String?.capitalizeWords(exceptions: List<String>? = null): String = when {
     }
     else -> String.empty()
 }
+
+val Float.dp: Float
+    get() = (this * Resources.getSystem().displayMetrics.density + 0.5f)
+
+val Int.dp: Int
+    get() = (this * Resources.getSystem().displayMetrics.density + 0.5f).toInt()
+
+val Float.px: Float
+    get() = (this / Resources.getSystem().displayMetrics.density + 0.5f)
+
+val Int.px: Int
+    get() = (this / Resources.getSystem().displayMetrics.density + 0.5f).toInt()

--- a/app/src/main/java/com/mxt/anitrend/initializer/injector/InjectorInitializer.kt
+++ b/app/src/main/java/com/mxt/anitrend/initializer/injector/InjectorInitializer.kt
@@ -9,6 +9,7 @@ import com.mxt.anitrend.koin.appModules
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.locale.LocaleUtil
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.fragment.koin.fragmentFactory
 import org.koin.core.context.startKoin
 import org.koin.core.logger.KOIN_TAG
 import org.koin.core.logger.Level
@@ -32,6 +33,7 @@ class InjectorInitializer : Initializer<Unit> {
             )
             logger(KoinLogger())
             workManagerFactory()
+            fragmentFactory()
             modules(appModules)
         }
     }

--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -95,6 +95,49 @@ import com.mxt.anitrend.util.ConfigurationUtil
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.NotificationUtil
 import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.base.SettingsActivity
+import com.mxt.anitrend.view.activity.base.SettingsActivity.MaterialSettingsFragment
+import com.mxt.anitrend.view.fragment.detail.AboutFragment
+import com.mxt.anitrend.view.fragment.detail.BrowseReviewFragment
+import com.mxt.anitrend.view.fragment.detail.ChangelogFragment
+import com.mxt.anitrend.view.fragment.detail.CharacterOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.CommentFragment
+import com.mxt.anitrend.view.fragment.detail.MediaFeedFragment
+import com.mxt.anitrend.view.fragment.detail.MediaOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.MediaStaffFragment
+import com.mxt.anitrend.view.fragment.detail.MediaStatsFragment
+import com.mxt.anitrend.view.fragment.detail.MessageFeedFragment
+import com.mxt.anitrend.view.fragment.detail.NotificationFragment
+import com.mxt.anitrend.view.fragment.detail.ReviewFragment
+import com.mxt.anitrend.view.fragment.detail.StaffOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.StudioMediaFragment
+import com.mxt.anitrend.view.fragment.detail.UserFeedFragment
+import com.mxt.anitrend.view.fragment.detail.UserOverviewFragment
+import com.mxt.anitrend.view.fragment.favourite.CharacterFavouriteFragment
+import com.mxt.anitrend.view.fragment.favourite.MediaFavouriteFragment
+import com.mxt.anitrend.view.fragment.favourite.StaffFavouriteFragment
+import com.mxt.anitrend.view.fragment.favourite.StudioFavouriteFragment
+import com.mxt.anitrend.view.fragment.group.CharacterActorsFragment
+import com.mxt.anitrend.view.fragment.group.MediaAnimeRoleFragment
+import com.mxt.anitrend.view.fragment.group.MediaCharacterFragment
+import com.mxt.anitrend.view.fragment.group.MediaFormatFragment
+import com.mxt.anitrend.view.fragment.group.MediaRecommendationsFragment
+import com.mxt.anitrend.view.fragment.group.MediaRelationFragment
+import com.mxt.anitrend.view.fragment.group.MediaStaffRoleFragment
+import com.mxt.anitrend.view.fragment.list.AiringListFragment
+import com.mxt.anitrend.view.fragment.list.FeedListFragment
+import com.mxt.anitrend.view.fragment.list.MediaBrowseFragment
+import com.mxt.anitrend.view.fragment.list.MediaLatestList
+import com.mxt.anitrend.view.fragment.list.MediaListFragment
+import com.mxt.anitrend.view.fragment.list.SuggestionListFragment
+import com.mxt.anitrend.view.fragment.list.WatchListFragment
+import com.mxt.anitrend.view.fragment.search.CharacterSearchFragment
+import com.mxt.anitrend.view.fragment.search.MediaSearchFragment
+import com.mxt.anitrend.view.fragment.search.StaffSearchFragment
+import com.mxt.anitrend.view.fragment.search.StudioSearchFragment
+import com.mxt.anitrend.view.fragment.search.UserSearchFragment
+import com.mxt.anitrend.view.fragment.youtube.YouTubeEmbedFragment
+import com.mxt.anitrend.view.sheet.BottomSheetGiphy
 import com.mxt.anitrend.viewmodel.AiringListViewModel
 import com.mxt.anitrend.viewmodel.BrowseReviewViewModel
 import com.mxt.anitrend.viewmodel.CharacterActorsViewModel
@@ -166,6 +209,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.fragment.dsl.fragment
 import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -551,7 +595,7 @@ private val repositoryModule = module {
     single { BrowseRepository(browseService = get(), mediaListStore = get(), reviewStore = get()) }
     single { CharacterRepository(characterService = get()) }
     single { StaffRepository(staffService = get()) }
-    single { StudioRepository(studioService = get()) }
+    single { StudioRepository(studioService = get(), settings = get()) }
     single { SearchRepository(searchService = get()) }
     single { FeedRepository(feedService = get(), feedStore = get()) }
     single { BaseRepository(baseService = get(), boxQuery = get(), feedStore = get()) }
@@ -587,7 +631,7 @@ private val mediaFeatureModule = module {
     viewModel { MediaBrowseViewModel(baseRepository = get(), browseRepository = get(), mediaListStore = get()) }
     viewModel { MediaLatestViewModel(browseRepository = get()) }
     viewModel { MediaListViewModel(browseRepository = get(), mediaListStore = get(), mutationRegistry = get(), userRepository = get(), settings = get(), requestSequence = get()) }
-    viewModel { MediaListMutationViewModel(saveMediaListEntryInteractor = get(), deleteMediaListEntryInteractor = get(), incrementMediaProgressInteractor = get(), mutationRegistry = get()) }
+    viewModel { MediaListMutationViewModel(saveMediaListEntryInteractor = get(), deleteMediaListEntryInteractor = get(), incrementMediaProgressInteractor = get(), mutationRegistry = get(), userRepository = get()) }
     viewModel { ReviewViewModel(browseRepository = get(), reviewStore = get(), requestSequence = get(), rateReviewInteractor = get()) }
     viewModel { SuggestionListViewModel(userRepository = get(), browseRepository = get()) }
     viewModel { MediaCharacterViewModel(mediaRepository = get()) }
@@ -712,6 +756,138 @@ private val utilityFeatureModule = module {
     }
 }
 
+private val fragmentModule = module {
+    fragment {
+        MaterialSettingsFragment()
+    }
+    fragment {
+        SettingsActivity.SettingsFragment()
+    }
+    fragment {
+        BottomSheetGiphy()
+    }
+    fragment {
+        AiringListFragment()
+    }
+    fragment {
+        WatchListFragment()
+    }
+    fragment {
+        FeedListFragment()
+    }
+    fragment {
+        SuggestionListFragment()
+    }
+    fragment {
+        MediaBrowseFragment()
+    }
+    fragment {
+        MediaLatestList()
+    }
+    fragment {
+        MediaListFragment()
+    }
+    fragment {
+        BrowseReviewFragment()
+    }
+    fragment {
+        MediaSearchFragment()
+    }
+    fragment {
+        StudioSearchFragment()
+    }
+    fragment {
+        StaffSearchFragment()
+    }
+    fragment {
+        CharacterSearchFragment()
+    }
+    fragment {
+        UserSearchFragment()
+    }
+    fragment {
+        MediaOverviewFragment()
+    }
+    fragment {
+        MediaRelationFragment()
+    }
+    fragment {
+        MediaRecommendationsFragment()
+    }
+    fragment {
+        MediaStatsFragment()
+    }
+    fragment {
+        MediaCharacterFragment()
+    }
+    fragment {
+        MediaStaffFragment()
+    }
+    fragment {
+        MediaFeedFragment()
+    }
+    fragment {
+        ReviewFragment()
+    }
+    fragment {
+        CharacterOverviewFragment()
+    }
+    fragment {
+        MediaFormatFragment()
+    }
+    fragment {
+        CharacterActorsFragment()
+    }
+    fragment {
+        StaffOverviewFragment()
+    }
+    fragment {
+        MediaAnimeRoleFragment()
+    }
+    fragment {
+        MediaStaffRoleFragment()
+    }
+    fragment {
+        UserOverviewFragment()
+    }
+    fragment {
+        UserFeedFragment()
+    }
+    fragment {
+        MessageFeedFragment()
+    }
+    fragment {
+        MediaFavouriteFragment()
+    }
+    fragment {
+        CharacterFavouriteFragment()
+    }
+    fragment {
+        StaffFavouriteFragment()
+    }
+    fragment {
+        StudioFavouriteFragment()
+    }
+    fragment {
+        ChangelogFragment()
+    }
+    fragment {
+        AboutFragment()
+    }
+    fragment {
+        CommentFragment()
+    }
+    fragment {
+        StudioMediaFragment()
+    }
+    fragment {
+        NotificationFragment()
+    }
+    fragment {
+        YouTubeEmbedFragment()
+    }
+}
+
 val appModules = module {
     includes(
         coroutineModule,
@@ -729,5 +905,6 @@ val appModules = module {
         staffFeatureModule,
         studioFeatureModule,
         utilityFeatureModule,
+        fragmentModule,
     )
 }

--- a/app/src/main/java/com/mxt/anitrend/repository/StudioRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/StudioRepository.kt
@@ -11,6 +11,7 @@ import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.mapper.toStudioEntity
 import com.mxt.anitrend.repository.mapper.toStudioMediaConnection
+import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.graphql.apiError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +21,7 @@ import com.mxt.anitrend.model.entity.base.StudioBase as StudioEntity
 
 class StudioRepository(
     private val studioService: StudioService,
+    private val settings: Settings,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractRepository(ioDispatcher) {
 
@@ -59,6 +61,8 @@ class StudioRepository(
             }
         }
     }
+
+    fun isAuthenticated() = settings.isAuthenticated
 
     private fun handleStudioMedia(body: GraphContainer<StudioMediaData>): ConnectionContainer<PageContainer<MediaEntity>> {
         val graphErrors = body.errors

--- a/app/src/main/java/com/mxt/anitrend/repository/UserRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/UserRepository.kt
@@ -71,6 +71,8 @@ class UserRepository(
             } else {
                 throw RuntimeException(response.apiError())
             }
+        }.onSuccess {
+            boxQuery.currentUser = it
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/ui/AbstractActionProvider.kt
+++ b/app/src/main/java/com/mxt/anitrend/ui/AbstractActionProvider.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.mxt.anitrend.ui
+
+import android.R
+import android.content.Context
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.view.ActionProvider
+import androidx.core.view.setPadding
+import com.mxt.anitrend.extension.dp
+import com.mxt.anitrend.extension.getDrawableFromAttr
+
+abstract class AbstractActionProvider(
+    context: Context,
+) : ActionProvider(context) {
+    protected val actionImageView =
+        AppCompatImageView(context).apply {
+            background = context.getDrawableFromAttr(
+                R.attr.selectableItemBackgroundBorderless,
+            )
+            isClickable = true
+            isFocusable = true
+            setPadding(2.dp)
+        }
+
+    protected val container =
+        FrameLayout(context).apply {
+            layoutParams =
+                FrameLayout.LayoutParams(
+                    ViewGroup.MarginLayoutParams.WRAP_CONTENT,
+                    ViewGroup.MarginLayoutParams.WRAP_CONTENT,
+                )
+            setPadding(10.dp)
+        }
+
+    /**
+     * Factory for creating the [androidx.core.view.ActionProvider] view
+     *
+     * @param forItem Optional menu item to create view for
+     */
+    protected abstract fun createWidget(forItem: MenuItem? = null): View
+
+    /**
+     * Factory method called by the Android framework to create new action views.
+     * This method returns a new action view for the given MenuItem.
+     *
+     * If your ActionProvider implementation overrides the deprecated no-argument overload
+     * [onCreateActionView], overriding this method for devices running API 16 or later
+     * is recommended but optional. The default implementation calls [onCreateActionView]
+     * for compatibility with applications written for older platform versions.
+     *
+     * @param forItem MenuItem to create the action view for
+     * @return the new action view
+     */
+    override fun onCreateActionView(forItem: MenuItem) = createWidget(forItem)
+
+    /**
+     * Factory method for creating new action views.
+     *
+     * @return A new action view.
+     */
+    override fun onCreateActionView() = createWidget()
+}

--- a/app/src/main/java/com/mxt/anitrend/ui/UiExtensions.kt
+++ b/app/src/main/java/com/mxt/anitrend/ui/UiExtensions.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2020 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.mxt.anitrend.ui
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.annotation.IdRes
+import androidx.fragment.app.*
+import androidx.lifecycle.ViewModel
+import com.mxt.anitrend.extension.fragmentManager
+import com.mxt.anitrend.ui.model.FragmentItem
+import org.koin.androidx.fragment.android.KoinFragmentFactory
+import org.koin.androidx.viewmodel.ext.android.getViewModel
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * Get given dependency, from either local scope or global scope
+ *
+ * @param qualifier - bean qualifier / optional
+ * @param parameters - injection parameters
+ */
+inline fun <reified T : Any> KoinScopeComponent.get(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+): T = runCatching {
+    scope.get<T>(qualifier, parameters)
+}.getOrElse {
+    getKoin().get(qualifier, parameters)
+}
+
+/**
+ * Inject lazily, by both local and global scope
+ *
+ * @param qualifier - bean qualifier / optional
+ * @param parameters - injection parameters
+ */
+inline fun <reified T : Any> KoinScopeComponent.inject(
+    qualifier: Qualifier? = null,
+    lazyMode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+    noinline parameters: ParametersDefinition? = null,
+) = lazy(lazyMode) { get<T>(qualifier, parameters) }
+
+/**
+ * Checks for existing fragment in [FragmentManager], if one exists that is used otherwise
+ * a new instance is created.
+ *
+ * @param contentFrame Resource Id of the view to inflate the fragment into
+ * @param context Any lifecycle driver context
+ * @param fragmentTransaction Optional transaction to run while committing fragment
+ *
+ * @return [String] tag of the fragment
+ *
+ * @see androidx.fragment.app.commit
+ *
+ * @throws NotImplementedError if [context] cannot resolve [FragmentManager]
+ */
+inline fun FragmentItem<*>.commit(
+    @IdRes contentFrame: Int,
+    context: Context,
+    fragmentTransaction: FragmentTransaction.() -> Unit = {},
+): String {
+    val fragmentTag = tag()
+    val fragmentManager = context.fragmentManager()
+    val backStack = fragmentManager.findFragmentByTag(fragmentTag)
+
+    fragmentManager.commit {
+        fragmentTransaction()
+        backStack?.let {
+            replace(contentFrame, it, fragmentTag)
+        } ?: replace(contentFrame, fragment, parameter, fragmentTag)
+    }
+    return fragmentTag
+}
+
+/**
+ * Checks for existing fragment in [FragmentManager], if one exists that is used otherwise
+ * a new instance is created.
+ *
+ * @return tag of the fragment
+ *
+ * @see androidx.fragment.app.commit
+ */
+inline fun <T : Fragment> FragmentItem<T>.commit(
+    contentFrame: View,
+    context: Context,
+    action: FragmentTransaction.() -> Unit = {},
+) = commit(contentFrame.id, context, action)
+
+/**
+ * Uses fragment factory to instantiate a fragment class definition
+ *
+ * @param classDefinition [Class] with an out variance of type [Fragment]
+ */
+inline fun <reified T : Fragment> FragmentActivity.createFragment(classDefinition: Class<out T>): T {
+    val qualifier = classDefinition.name
+    val factory = supportFragmentManager.fragmentFactory
+    require(factory is KoinFragmentFactory) {
+        """Fragment factory for $this is $factory instead of `KoinFragmentFactory`.
+            |Did you forget to call setupKoinFragmentFactory before onCreate?
+        """.trimMargin()
+    }
+    return factory.instantiate(classLoader, qualifier) as T
+}
+
+/**
+ * Retrieves or creates a new fragment using the given [FragmentItem]
+ *
+ * @param activity Calling activity
+ *
+ * @see runIfActivityContext
+ */
+inline fun <reified T : Fragment> FragmentItem<T>.fragmentByTagOrNew(activity: FragmentActivity): T {
+    val fragmentTag = tag()
+    val fragmentManager = activity.supportFragmentManager
+    val fragment =
+        fragmentManager.findFragmentByTag(fragmentTag) as? T
+            ?: activity.createFragment(fragment)
+    fragment.arguments = parameter
+    return fragment
+}
+
+/**
+ * Retrieves or creates a new fragment using the given [tag]
+ *
+ * @param classDefinition A [Class] with an out variance of type [Fragment]
+ * @param tag Tag to identity the fragment
+ * @param lazyMode [LazyThreadSafetyMode] to use
+ */
+inline fun <reified T : Fragment> FragmentActivity.fragmentByTagOrNew(
+    fragmentItem: FragmentItem<T>,
+    lazyMode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+) = lazy(lazyMode) {
+    fragmentItem.fragmentByTagOrNew(this)
+}
+
+/**
+ * Resolve view models from within views
+ */
+inline fun <reified T : ViewModel> ViewGroup.viewModel(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+): Lazy<T> = lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+    when (val component = context) {
+        is ComponentActivity -> {
+            component.getViewModel(
+                qualifier = qualifier,
+                extrasProducer = null,
+                parameters = parameters,
+            )
+        }
+        else -> throw NotImplementedError("Not sure how to handle view model retrieval for $this")
+    }
+}
+
+/**
+ * Resolve view models from within action providers, by default this looks view models
+ * using the parent activity as the owner. You should assure that any fragment also use
+ * `sharedViewModel` to avoid getting a mismatch between viewModels
+ *
+ * @param qualifier Custom qualifier to lookup
+ * @param owner ViewModel owner, defaults to parent activity
+ * @param parameters
+ */
+inline fun <reified T : ViewModel> AbstractActionProvider.sharedViewModel(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+): Lazy<T> = lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+    when (val component = context) {
+        is ComponentActivity -> {
+            component.getViewModel(
+                qualifier = qualifier,
+                extrasProducer = null,
+                parameters = parameters,
+            )
+        }
+        else -> throw NotImplementedError("Not sure how to handle view model retrieval for $this")
+    }
+}

--- a/app/src/main/java/com/mxt/anitrend/ui/model/FragmentItem.kt
+++ b/app/src/main/java/com/mxt/anitrend/ui/model/FragmentItem.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.mxt.anitrend.ui.model
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+
+/**
+ * Fragment loader holder helper
+ */
+data class FragmentItem<T : Fragment>(
+    val fragment: Class<out T>,
+    val parameter: Bundle? = null,
+    val tag: String = fragment.simpleName,
+) {
+    fun tag(): String = tag
+}

--- a/app/src/main/java/com/mxt/anitrend/view/activity/CommonActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/CommonActivity.kt
@@ -1,0 +1,68 @@
+package com.mxt.anitrend.view.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import com.mxt.anitrend.R
+import com.mxt.anitrend.extension.applyConfiguredTheme
+import com.mxt.anitrend.util.CompatUtil
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.Settings
+import org.koin.android.ext.android.inject
+import org.koin.android.scope.AndroidScopeComponent
+import org.koin.androidx.fragment.android.setupKoinFragmentFactory
+import org.koin.androidx.scope.activityScope
+import org.koin.core.scope.Scope
+import java.util.Locale
+
+abstract class CommonActivity :
+    AppCompatActivity(),
+    AndroidScopeComponent {
+
+    override val scope: Scope by activityScope()
+    protected val settings by inject<Settings>()
+
+    protected var currentLocale: String? = null
+    protected var currentTheme: String? = null
+
+    @Suppress("DEPRECATION")
+    private fun onResumeThemeCheck() {
+        if (currentTheme != settings.theme || currentLocale != settings.userLanguage) {
+            applyConfiguredTheme()
+            val currentIntent = intent
+            finish()
+            overridePendingTransition(0, 0)
+            startActivity(currentIntent)
+            overridePendingTransition(0, 0)
+        }
+    }
+
+    protected fun enableEdgeToEdge() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        if (CompatUtil.isLightTheme(settings)) {
+            WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars =
+                true
+            WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightNavigationBars =
+                true
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        currentLocale = settings.userLanguage ?: Locale.getDefault().language
+        currentTheme = settings.theme
+        val themeRes = when (currentTheme) {
+            KeyUtil.THEME_DARK -> R.style.AppThemeDark
+            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
+            else -> R.style.AppThemeLight
+        }
+        setTheme(themeRes)
+        enableEdgeToEdge()
+        setupKoinFragmentFactory()
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        onResumeThemeCheck()
+    }
+}

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/AboutActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/AboutActivity.kt
@@ -2,29 +2,18 @@ package com.mxt.anitrend.view.activity.base
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.mxt.anitrend.R
-import com.mxt.anitrend.extension.KoinExt
-import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.fragment.detail.AboutFragment
 
-class AboutActivity : AppCompatActivity() {
+class AboutActivity : CommonActivity() {
 
     private val toolbar by lazy(LazyThreadSafetyMode.NONE) {
         findViewById<Toolbar?>(R.id.toolbar)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_frame_generic)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/ChangelogActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/ChangelogActivity.kt
@@ -2,12 +2,10 @@ package com.mxt.anitrend.view.activity.base
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.mxt.anitrend.R
-import com.mxt.anitrend.extension.KoinExt
-import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.fragment.detail.ChangelogFragment
 
 /**
@@ -15,21 +13,13 @@ import com.mxt.anitrend.view.fragment.detail.ChangelogFragment
  * Used as an alternative to the changelog dialog when
  * [Settings.experimentalInitialScreens] is enabled.
  */
-class ChangelogActivity : AppCompatActivity() {
+class ChangelogActivity : CommonActivity() {
 
     private val toolbar by lazy(LazyThreadSafetyMode.NONE) {
         findViewById<Toolbar?>(R.id.toolbar)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (same pattern as AboutActivity)
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_frame_generic)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
@@ -8,7 +8,6 @@ import android.view.Window
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import com.bumptech.glide.Glide
@@ -18,14 +17,13 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityGiphyPreviewBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 
 class GiphyPreviewActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     RequestListener<Drawable> {
 
     data class Args(val modelUrl: String)
@@ -51,14 +49,6 @@ class GiphyPreviewActivity :
             WindowManager.LayoutParams.FLAG_FULLSCREEN,
             WindowManager.LayoutParams.FLAG_FULLSCREEN,
         )
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         binding = ActivityGiphyPreviewBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivity.kt
@@ -15,21 +15,19 @@ import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.bumptech.glide.Glide
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityImagePreviewBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import timber.log.Timber
 
-class ImagePreviewActivity : AppCompatActivity() {
+class ImagePreviewActivity : CommonActivity() {
 
     data class Args(val modelUrl: String)
 
@@ -58,14 +56,6 @@ class ImagePreviewActivity : AppCompatActivity() {
             WindowManager.LayoutParams.FLAG_FULLSCREEN,
             WindowManager.LayoutParams.FLAG_FULLSCREEN,
         )
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         binding = ActivityImagePreviewBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/LoggingActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/LoggingActivity.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
@@ -20,18 +19,16 @@ import com.mxt.anitrend.BuildConfig
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.recycler.detail.LogEntryAdapter
 import com.mxt.anitrend.databinding.ActivityLoggingBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.model.entity.log.LogFilter
 import com.mxt.anitrend.model.entity.log.LogUiState
-import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.viewmodel.LoggingViewModel
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
-class LoggingActivity : AppCompatActivity() {
+class LoggingActivity : CommonActivity() {
 
     private lateinit var binding: ActivityLoggingBinding
 
@@ -45,16 +42,6 @@ class LoggingActivity : AppCompatActivity() {
     internal val loggingViewModel: LoggingViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Replicates ActivityBase.configureActivity() theme behaviour via
-        // ConfigurationUtil.onCreateAttach. Must run before super.onCreate() so
-        // the correct theme resource is locked in before setContentView().
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         binding = ActivityLoggingBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/SettingsActivity.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
@@ -23,27 +22,22 @@ import com.mxt.anitrend.databinding.ItemSettingsRowSwitchBinding
 import com.mxt.anitrend.databinding.ItemSettingsRowValueBinding
 import com.mxt.anitrend.databinding.ItemSettingsSectionCardBinding
 import com.mxt.anitrend.databinding.SettingsActivityBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.extension.applyConfiguredTheme
 import com.mxt.anitrend.presenter.base.BasePresenter
+import com.mxt.anitrend.ui.commit
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 
-class SettingsActivity : AppCompatActivity() {
+class SettingsActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = SettingsActivityBinding.inflate(layoutInflater)
@@ -52,16 +46,15 @@ class SettingsActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         if (savedInstanceState == null) {
-            val fragment: Fragment =
-                if (settings.experimentalSettingsScreen) {
-                    MaterialSettingsFragment()
-                } else {
-                    SettingsFragment()
-                }
-            supportFragmentManager
-                .beginTransaction()
-                .replace(R.id.settings, fragment)
-                .commit()
+            if (settings.experimentalSettingsScreen) {
+                FragmentItem(
+                    fragment = MaterialSettingsFragment::class.java,
+                ).commit(R.id.settings, this)
+            } else {
+                FragmentItem(
+                    fragment = SettingsFragment::class.java,
+                ).commit(R.id.settings, this)
+            }
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/SharedContentActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/SharedContentActivity.kt
@@ -2,7 +2,6 @@ package com.mxt.anitrend.view.activity.base
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Lifecycle
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -12,19 +11,20 @@ import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.interfaces.event.BottomSheetListener
 import com.mxt.anitrend.base.interfaces.event.ItemClickListener
 import com.mxt.anitrend.databinding.ActivityShareContentBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.extension.getCompatTintedDrawable
 import com.mxt.anitrend.extension.hideKeyboard
+import com.mxt.anitrend.ui.fragmentByTagOrNew
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.markdown.MarkDownUtil
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.sheet.BottomSheetGiphy
 
 class SharedContentActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     BottomSheetListener,
     ItemClickListener<Any> {
 
@@ -65,15 +65,6 @@ class SharedContentActivity :
         )
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Translucent theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        setTheme(
-            if (CompatUtil.isLightTheme(settings)) {
-                R.style.AppThemeLight_Translucent
-            } else {
-                R.style.AppThemeDark_Translucent
-            },
-        )
         super.onCreate(savedInstanceState)
 
         // Process share-intent deep links (previously ActivityBase.onCreate).
@@ -177,11 +168,9 @@ class SharedContentActivity :
             R.id.insert_emoticon -> Unit
             R.id.insert_gif -> {
                 mBottomSheet =
-                    BottomSheetGiphy
-                        .Builder()
-                        .setTitle(R.string.title_bottom_sheet_giphy)
-                        .build()
-                        .also { (it as? BottomSheetGiphy)?.onGiphySelected = { giphy -> binding.composerWidget.insertGiphy(giphy) } }
+                    FragmentItem(fragment = BottomSheetGiphy::class.java)
+                        .fragmentByTagOrNew(this@SharedContentActivity)
+                        .also { it.onGiphySelected = { giphy -> binding.composerWidget.insertGiphy(giphy) } }
                 mBottomSheet?.let { sheet ->
                     sheet.show(supportFragmentManager, sheet.tag)
                 }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivity.kt
@@ -5,20 +5,18 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatActivity
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityVideoPlayerBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import timber.log.Timber
 
-class VideoPlayerActivity : AppCompatActivity() {
+class VideoPlayerActivity : CommonActivity() {
 
     /**
      * Navigation args for [VideoPlayerActivity]. Use [newIntent] to build and
@@ -43,14 +41,6 @@ class VideoPlayerActivity : AppCompatActivity() {
     private lateinit var binding: ActivityVideoPlayerBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         binding = ActivityVideoPlayerBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
@@ -1,7 +1,6 @@
 package com.mxt.anitrend.view.activity.base
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -26,10 +25,9 @@ class WelcomeActivity : AhoyOnboarderActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val isModernIcons = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-        val paintIcon = if (isModernIcons) R.drawable.ic_format_paint_white_24dp else R.drawable.ic_format_paint_white_48dp
-        val chartIcon = if (isModernIcons) R.drawable.ic_bubble_chart_white_24dp else R.drawable.ic_bubble_chart_white_48dp
-        val searchIcon = if (isModernIcons) R.drawable.ic_search_white_24dp else R.drawable.ic_search_white_48dp
+        val paintIcon = R.drawable.ic_format_paint_white_24dp
+        val chartIcon = R.drawable.ic_bubble_chart_white_24dp
+        val searchIcon = R.drawable.ic_search_white_24dp
 
         ahoyPages =
             listOf(
@@ -67,14 +65,14 @@ class WelcomeActivity : AhoyOnboarderActivity() {
     }
 
     override fun onFinishButtonPressed() {
-        val target = findViewById<View>(com.codemybrainsout.onboarder.R.id.btn_skip)
+        val target = findViewById<View>(R.id.btn_skip)
         CompatUtil.startRevealAnim(this, target, Intent(this, MainActivity::class.java), true)
     }
 
     @Suppress("DEPRECATION")
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && hasFocus) {
+        if (hasFocus) {
             window.decorView.systemUiVisibility =
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -20,6 +19,7 @@ import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.viewmodel.CharacterViewModel
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -29,7 +29,7 @@ import java.util.Locale
  * Created by max on 2017/12/14.
  * character activity
  */
-class CharacterActivity : AppCompatActivity() {
+class CharacterActivity : CommonActivity() {
 
     private lateinit var binding: ActivityPagerGenericBinding
 
@@ -39,14 +39,6 @@ class CharacterActivity : AppCompatActivity() {
     private val characterViewModel: CharacterViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (was previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/character/{id}) so arg_id is injected

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/CommentActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/CommentActivity.kt
@@ -2,26 +2,16 @@ package com.mxt.anitrend.view.activity.detail
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityFrameGenericBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.fragment.detail.CommentFragment
 
-class CommentActivity : AppCompatActivity() {
+class CommentActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/activity/{id}) so arg extras are

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/FavouriteActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/FavouriteActivity.kt
@@ -2,26 +2,15 @@ package com.mxt.anitrend.view.activity.detail
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.tabs.TabLayoutMediator
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.detail.FavouritePageAdapter
 import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
-import com.mxt.anitrend.extension.KoinExt
-import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 
-class FavouriteActivity : AppCompatActivity() {
+class FavouriteActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityPagerGenericBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaActivity.kt
@@ -7,7 +7,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -25,13 +24,12 @@ import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.TapTargetUtil
 import com.mxt.anitrend.util.TutorialUtil
 import com.mxt.anitrend.util.media.MediaActionUtil
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.viewmodel.MediaViewModel
 import kotlinx.coroutines.launch
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.util.Locale
 
@@ -40,12 +38,10 @@ import java.util.Locale
  * Media activity
  */
 class MediaActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     View.OnClickListener {
 
     private lateinit var binding: ActivitySeriesBinding
-
-    private val settings: Settings by inject()
 
     @KeyUtil.MediaType
     private var mediaType: String? = null
@@ -61,13 +57,6 @@ class MediaActivity :
     private val mediaViewModel: MediaViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (was previously handled by ActivityBase.configureActivity).
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/anime/{id}) so arg_id is injected

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaBrowseActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaBrowseActivity.kt
@@ -2,26 +2,16 @@ package com.mxt.anitrend.view.activity.detail
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityFrameGenericBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.markdown.MarkDownUtil
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.fragment.list.MediaBrowseFragment
 
-class MediaBrowseActivity : AppCompatActivity() {
+class MediaBrowseActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityFrameGenericBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaListActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaListActivity.kt
@@ -3,27 +3,17 @@ package com.mxt.anitrend.view.activity.detail
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.tabs.TabLayoutMediator
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.index.MediaListPageAdapter
 import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 
-class MediaListActivity : AppCompatActivity() {
+class MediaListActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityPagerGenericBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/MessageActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/MessageActivity.kt
@@ -2,29 +2,20 @@ package com.mxt.anitrend.view.activity.detail
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.tabs.TabLayoutMediator
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.detail.MessagePageAdapter
 import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
 import com.mxt.anitrend.repository.UserRepository
 import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import org.koin.android.ext.android.inject
 
-class MessageActivity : AppCompatActivity() {
+class MessageActivity : CommonActivity() {
 
-    private val settings: Settings by inject()
     private val userRepository: UserRepository by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityPagerGenericBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/NotificationActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/NotificationActivity.kt
@@ -3,26 +3,15 @@ package com.mxt.anitrend.view.activity.detail
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityFrameGenericBinding
-import com.mxt.anitrend.extension.KoinExt
-import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.activity.index.MainActivity
 import com.mxt.anitrend.view.fragment.detail.NotificationFragment
 
-class NotificationActivity : AppCompatActivity() {
+class NotificationActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityFrameGenericBinding.inflate(layoutInflater)
@@ -39,6 +28,7 @@ class NotificationActivity : AppCompatActivity() {
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
+        super.onBackPressed()
         navigateBack()
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.kt
@@ -6,7 +6,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,7 +13,6 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.detail.ProfilePageAdapter
 import com.mxt.anitrend.base.custom.view.image.WideImageView
-import com.mxt.anitrend.base.interfaces.dao.BoxQuery
 import com.mxt.anitrend.databinding.ActivityProfileBinding
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.base.UserBase
@@ -22,12 +20,11 @@ import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.TutorialUtil
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.sheet.BottomSheetComposer
 import com.mxt.anitrend.viewmodel.ProfileViewModel
 import kotlinx.coroutines.launch
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.util.Locale
 
@@ -36,7 +33,7 @@ import java.util.Locale
  * Profile activity
  */
 class ProfileActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     View.OnClickListener {
 
     private lateinit var binding: ActivityProfileBinding
@@ -48,17 +45,7 @@ class ProfileActivity :
 
     private val profileViewModel: ProfileViewModel by viewModel()
 
-    private val settings: Settings by inject()
-    private val boxQuery: BoxQuery by inject()
-
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (was previously handled by ActivityBase.configureActivity).
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/user/{name}) so arg_userName/arg_id
@@ -277,11 +264,6 @@ class ProfileActivity :
 
     private fun isCurrentUser(userId: Long, userName: String? = null): Boolean {
         if (!settings.isAuthenticated) return false
-        val currentUser = boxQuery.currentUser ?: return false
-        return if (userName != null) {
-            currentUser.name == userName
-        } else {
-            userId != 0L && currentUser.id == userId
-        }
+        return profileViewModel.isCurrentUser(userId, userName)
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -24,6 +23,7 @@ import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.selectedIndex
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.viewmodel.StaffViewModel
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -33,7 +33,7 @@ import java.util.Locale
  * Created by max on 2017/12/14.
  * staff activity
  */
-class StaffActivity : AppCompatActivity() {
+class StaffActivity : CommonActivity() {
 
     private lateinit var binding: ActivityPagerGenericBinding
 
@@ -48,14 +48,6 @@ class StaffActivity : AppCompatActivity() {
     private val staffViewModel: StaffViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (was previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/staff/{id}) so arg_id is injected

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/StudioActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/StudioActivity.kt
@@ -6,28 +6,26 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.view.widget.FavouriteToolbarWidget
 import com.mxt.anitrend.databinding.ActivityFrameGenericBinding
-import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.model.entity.base.StudioBase
+import com.mxt.anitrend.ui.commit
+import com.mxt.anitrend.ui.model.FragmentItem
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.fragment.detail.StudioMediaFragment
 import com.mxt.anitrend.viewmodel.StudioViewModel
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.util.Locale
 
-class StudioActivity : AppCompatActivity() {
+class StudioActivity : CommonActivity() {
 
     data class Args(val id: Long)
 
@@ -51,14 +49,6 @@ class StudioActivity : AppCompatActivity() {
     private val studioViewModel: StudioViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (was previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         // Process deep links (e.g. anilist.co/studio/{id}) so arg_id is injected
@@ -113,15 +103,12 @@ class StudioActivity : AppCompatActivity() {
     }
 
     private fun addStudioMediaFragment(args: Bundle) {
-        val fragment = StudioMediaFragment.newInstance(args)
-        val fragmentManager: FragmentManager = supportFragmentManager
-        val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
-        fragmentTransaction.replace(R.id.content_frame, fragment, fragment.TAG)
-        fragmentTransaction.commit()
+        FragmentItem(fragment = StudioMediaFragment::class.java, parameter = args)
+            .commit(contentFrame = R.id.content_frame, context = this@StudioActivity)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        val isAuth = KoinExt.get(Settings::class.java).isAuthenticated
+        val isAuth = studioViewModel.isAuthenticated()
         menuInflater.inflate(R.menu.custom_menu, menu)
         menu.findItem(R.id.action_favourite).isVisible = isAuth
         if (isAuth) {

--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/LoginActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/LoginActivity.kt
@@ -7,24 +7,21 @@ import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.async.WebTokenRequest
-import com.mxt.anitrend.base.interfaces.dao.BoxQuery
 import com.mxt.anitrend.binding.basicText
 import com.mxt.anitrend.databinding.ActivityLoginBinding
 import com.mxt.anitrend.model.api.retro.ServiceFactory
 import com.mxt.anitrend.model.entity.anilist.User
-import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.ShortcutUtil
 import com.mxt.anitrend.util.WidgetState
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.viewmodel.LoginAuthState
 import com.mxt.anitrend.viewmodel.LoginAuthViewModel
 import com.mxt.anitrend.viewmodel.LoginUserViewModel
@@ -38,27 +35,16 @@ import timber.log.Timber
  * Authentication activity
  */
 class LoginActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     View.OnClickListener {
 
     private lateinit var binding: ActivityLoginBinding
     private val authViewModel: LoginAuthViewModel by viewModel()
     private val userViewModel: LoginUserViewModel by viewModel()
     private var model: User? = null
-
-    private val settings: Settings by inject()
     private val scheduler: JobSchedulerUtil by inject()
-    private val boxQuery: BoxQuery by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve translucent theme (was previously handled by ActivityBase.configureActivity).
-        setTheme(
-            if (CompatUtil.isLightTheme(settings)) {
-                R.style.AppThemeLight_Translucent
-            } else {
-                R.style.AppThemeDark_Translucent
-            },
-        )
         super.onCreate(savedInstanceState)
 
         binding = ActivityLoginBinding.inflate(layoutInflater)
@@ -85,7 +71,6 @@ class LoginActivity :
                         is LoginUserViewModel.UiState.Loading -> Unit
                         is LoginUserViewModel.UiState.Success -> {
                             model = state.user
-                            boxQuery.currentUser = model
                             scheduleJobAndShortcuts()
                             finish()
                         }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
@@ -11,12 +11,9 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
-import androidx.annotation.StyleRes
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.core.view.GravityCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -43,12 +40,10 @@ import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.custom.view.image.AvatarIndicatorView
 import com.mxt.anitrend.base.custom.view.image.HeaderImageView
 import com.mxt.anitrend.base.custom.view.search.MaterialSearchView
-import com.mxt.anitrend.base.interfaces.dao.BoxQuery
 import com.mxt.anitrend.base.interfaces.event.BottomSheetChoice
 import com.mxt.anitrend.base.interfaces.event.ISearchDelegate
 import com.mxt.anitrend.databinding.ActivityMainBinding
 import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
-import com.mxt.anitrend.extension.applyConfiguredTheme
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.extension.requestNotificationsPermission
@@ -57,9 +52,9 @@ import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.date.DateUtil
 import com.mxt.anitrend.util.media.MediaActionUtil
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.activity.base.AboutActivity
 import com.mxt.anitrend.view.activity.base.ChangelogActivity
 import com.mxt.anitrend.view.activity.base.LoggingActivity
@@ -69,10 +64,8 @@ import com.mxt.anitrend.view.sheet.BottomSheetMessage
 import com.mxt.anitrend.viewmodel.MainViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
-import java.util.Locale
 
 /**
  * Created by max on 2017/10/04.
@@ -80,16 +73,13 @@ import java.util.Locale
  */
 
 class MainActivity :
-    AppCompatActivity(),
+    CommonActivity(),
     View.OnClickListener,
     NavigationView.OnNavigationItemSelectedListener {
     private lateinit var binding: ActivityMainBinding
 
     // --- Fields carried over from ActivityBase shell ---
     private var mediaActionUtil: MediaActionUtil? = null
-
-    private var currentTheme: String? = null
-    private var currentLocale: String? = null
 
     /** @see ActivityBase.showBottomSheet */
     internal var mBottomSheet: BottomSheetBase<*>? = null
@@ -104,9 +94,6 @@ class MainActivity :
     }
     private val mNavigationTabStrip by lazy(LazyThreadSafetyMode.NONE) {
         binding.appBarMain.customTab.smartTab
-    }
-    private val coordinatorLayout by lazy(LazyThreadSafetyMode.NONE) {
-        binding.appBarMain.coordinator
     }
     private val mDrawerLayout by lazy(LazyThreadSafetyMode.NONE) {
         binding.drawerLayout
@@ -145,10 +132,6 @@ class MainActivity :
 
     private val mainViewModel: MainViewModel by viewModel()
 
-    private val settings: Settings by inject()
-    private val boxQuery: BoxQuery by inject()
-    private val currentUser get() = boxQuery.currentUser
-
     private lateinit var menuItems: Menu
 
     private lateinit var mHomeFeed: MenuItem
@@ -171,8 +154,6 @@ class MainActivity :
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        configureActivity()
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -227,7 +208,6 @@ class MainActivity :
                     when (state) {
                         is MainViewModel.UiState.Loading -> Unit
                         is MainViewModel.UiState.Success -> {
-                            boxQuery.currentUser = state.user
                             updateUI()
                         }
                         is MainViewModel.UiState.Error -> {
@@ -412,7 +392,6 @@ class MainActivity :
      */
     override fun onResume() {
         super.onResume()
-        onResumeThemeCheck()
         mediaActionUtil?.onResume(null)
         mDrawerLayout.addDrawerListener(mDrawerToggle)
         mDrawerToggle.syncState()
@@ -474,8 +453,8 @@ class MainActivity :
             R.id.nav_myanime -> {
                 val animeParams = Bundle()
                 animeParams.putString(KeyUtil.arg_mediaType, KeyUtil.ANIME)
-                animeParams.putString(KeyUtil.arg_userName, currentUser?.name)
-                animeParams.putLong(KeyUtil.arg_id, currentUser?.id ?: 0)
+                animeParams.putString(KeyUtil.arg_userName, mainViewModel.currentUser()?.name)
+                animeParams.putLong(KeyUtil.arg_id, mainViewModel.currentUser()?.id ?: 0)
 
                 val animeListPageAdapter =
                     MediaListPageAdapter(this, applicationContext)
@@ -489,8 +468,8 @@ class MainActivity :
             R.id.nav_mymanga -> {
                 val mangaParams = Bundle()
                 mangaParams.putString(KeyUtil.arg_mediaType, KeyUtil.MANGA)
-                mangaParams.putString(KeyUtil.arg_userName, currentUser?.name)
-                mangaParams.putLong(KeyUtil.arg_id, currentUser?.id ?: 0)
+                mangaParams.putString(KeyUtil.arg_userName, mainViewModel.currentUser()?.name)
+                mangaParams.putLong(KeyUtil.arg_id, mainViewModel.currentUser()?.id ?: 0)
 
                 val mangaListPageAdapter =
                     MediaListPageAdapter(this, applicationContext)
@@ -653,7 +632,7 @@ class MainActivity :
     }
 
     private fun setupUserItems() {
-        currentUser?.apply {
+        mainViewModel.currentUser()?.apply {
             mUserName.text = name.orEmpty()
             mUserAvatar.onInit()
             mHeaderView.setImage(bannerImage.orEmpty())
@@ -681,11 +660,11 @@ class MainActivity :
     override fun onClick(view: View) {
         if (view.id == R.id.banner_clickable) {
             if (settings.isAuthenticated) {
-                val user = currentUser
+                val user = mainViewModel.currentUser()
                 if (user != null) {
                     startNewActivity<ProfileActivity>(
                         Bundle().apply {
-                            putString(KeyUtil.arg_userName, currentUser?.name)
+                            putString(KeyUtil.arg_userName, user.name)
                         },
                     )
                 } else {
@@ -710,39 +689,6 @@ class MainActivity :
         }
         mediaActionUtil?.onDestroy()
         super.onDestroy()
-    }
-
-    private fun configureActivity() {
-        currentTheme = settings.theme
-        currentLocale = settings.userLanguage ?: Locale.getDefault().language
-        @StyleRes val theme = when (currentTheme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(theme)
-    }
-
-    private fun enableEdgeToEdge() {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        if (CompatUtil.isLightTheme(settings)) {
-            WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars =
-                true
-            WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightNavigationBars =
-                true
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun onResumeThemeCheck() {
-        if (currentTheme != settings.theme || currentLocale != settings.userLanguage) {
-            applyConfiguredTheme()
-            val currentIntent = intent
-            finish()
-            overridePendingTransition(0, 0)
-            startActivity(currentIntent)
-            overridePendingTransition(0, 0)
-        }
     }
 
     /** @see ActivityBase.showBottomSheet */

--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/SearchActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/SearchActivity.kt
@@ -2,26 +2,15 @@ package com.mxt.anitrend.view.activity.index
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.tabs.TabLayoutMediator
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.index.SearchPageAdapter
 import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
-import com.mxt.anitrend.extension.KoinExt
-import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 
-class SearchActivity : AppCompatActivity() {
+class SearchActivity : CommonActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Preserve configured theme (previously handled by ActivityBase.configureActivity).
-        val settings = KoinExt.get(Settings::class.java)
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         val binding = ActivityPagerGenericBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/SplashActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/SplashActivity.kt
@@ -2,7 +2,6 @@ package com.mxt.anitrend.view.activity.index
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,10 +13,9 @@ import com.mxt.anitrend.repository.UserRepository
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.JobSchedulerUtil
-import com.mxt.anitrend.util.KeyUtil
-import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.migration.MigrationUtil
 import com.mxt.anitrend.util.migration.Migrations
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.activity.base.WelcomeActivity
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -28,21 +26,11 @@ import org.koin.android.ext.android.inject
  * Base splash screen
  */
 
-class SplashActivity : AppCompatActivity() {
+class SplashActivity : CommonActivity() {
     private lateinit var binding: ActivitySplashBinding
-    private lateinit var settings: Settings
     private val userRepository: UserRepository by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Apply theme before super.onCreate() -- replicates ActivityBase.configureActivity()
-        // theme logic using the proven pattern from LoggingActivity.
-        settings = inject<Settings>().value
-        val themeRes = when (settings.theme) {
-            KeyUtil.THEME_DARK -> R.style.AppThemeDark
-            KeyUtil.THEME_BLACK -> R.style.AppThemeBlack
-            else -> R.style.AppThemeLight
-        }
-        setTheme(themeRes)
         super.onCreate(savedInstanceState)
 
         binding = ActivitySplashBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
@@ -235,10 +235,12 @@ class CommentFragment : FragmentBaseComment() {
                         R.id.insert_emoticon -> Unit
                         R.id.insert_gif -> {
                             mBottomSheet =
-                                BottomSheetGiphy.Builder()
-                                    .setTitle(R.string.title_bottom_sheet_giphy)
-                                    .build()
-                                    .also { (it as? BottomSheetGiphy)?.onGiphySelected = { giphy -> composerWidget.insertGiphy(giphy) } }
+                                BottomSheetGiphy().apply {
+                                    arguments =
+                                        Bundle().apply {
+                                            putInt(KeyUtil.arg_title, R.string.title_bottom_sheet_giphy)
+                                        }
+                                }.also { it.onGiphySelected = { giphy -> composerWidget.insertGiphy(giphy) } }
                             showBottomSheet()
                         }
                         R.id.widget_flipper -> Unit

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/youtube/YouTubeEmbedFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/youtube/YouTubeEmbedFragment.kt
@@ -2,7 +2,6 @@ package com.mxt.anitrend.view.fragment.youtube
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +19,7 @@ import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.markdown.RegexUtil
 import timber.log.Timber
+import androidx.core.net.toUri
 
 class YouTubeEmbedFragment : Fragment() {
     private var mediaTrailer: MediaTrailer? = null
@@ -82,7 +82,7 @@ class YouTubeEmbedFragment : Fragment() {
                 val youtubeLink = RegexUtil.buildYoutube(trailer.id.orEmpty())
                 val intent =
                     Intent(Intent.ACTION_VIEW).apply {
-                        data = Uri.parse(youtubeLink)
+                        data = youtubeLink.toUri()
                     }
                 startActivity(intent)
             } catch (e: ActivityNotFoundException) {

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetComposer.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetComposer.kt
@@ -141,11 +141,12 @@ class BottomSheetComposer :
             R.id.insert_emoticon -> Unit
             R.id.insert_gif -> {
                 mBottomSheet =
-                    BottomSheetGiphy
-                        .Builder()
-                        .setTitle(R.string.title_bottom_sheet_giphy)
-                        .build()
-                        .also { (it as? BottomSheetGiphy)?.onGiphySelected = { giphy -> composerWidget?.insertGiphy(giphy) } }
+                    BottomSheetGiphy().apply {
+                        arguments =
+                            Bundle().apply {
+                                putInt(KeyUtil.arg_title, R.string.title_bottom_sheet_giphy)
+                            }
+                    }.also { it.onGiphySelected = { giphy -> composerWidget?.insertGiphy(giphy) } }
                 activity?.let { host ->
                     mBottomSheet?.show(host.supportFragmentManager, mBottomSheet?.tag)
                 }

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetGiphy.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetGiphy.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.recycler.detail.GiphyAdapter
-import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.custom.sheet.BottomSheetGiphyList
 import com.mxt.anitrend.base.interfaces.event.ISearchDelegate
 import com.mxt.anitrend.databinding.BottomSheetListBinding
@@ -32,13 +31,6 @@ class BottomSheetGiphy : BottomSheetGiphyList() {
     var onGiphySelected: ((Giphy) -> Unit)? = null
 
     private val giphyViewModel: GiphyViewModel by viewModel()
-
-    companion object {
-        @JvmStatic
-        fun newInstance(bundle: Bundle): BottomSheetGiphy = BottomSheetGiphy().apply {
-            arguments = bundle
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -163,9 +155,5 @@ class BottomSheetGiphy : BottomSheetGiphyList() {
             val intent = GiphyPreviewActivity.newIntent(host, giphySample?.url ?: "")
             host.startActivity(intent)
         }
-    }
-
-    class Builder : BottomSheetBuilder() {
-        override fun build(): BottomSheetBase<*> = newInstance(bundle)
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
@@ -26,7 +26,6 @@ import com.google.android.material.textview.MaterialTextView
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import com.mxt.anitrend.R
-import com.mxt.anitrend.base.interfaces.dao.BoxQuery
 import com.mxt.anitrend.base.custom.view.editor.MarkdownInputEditor
 import com.mxt.anitrend.base.custom.view.widget.FuzzyDateWidget
 import com.mxt.anitrend.base.custom.view.widget.ProgressWidget
@@ -42,7 +41,6 @@ import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.media.MediaUtil
 import com.mxt.anitrend.viewmodel.MediaListMutationViewModel
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import kotlinx.coroutines.launch
 
@@ -64,7 +62,6 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
     private val mediaListStatuses =
         arrayOf(KeyUtil.CURRENT, KeyUtil.PLANNING, KeyUtil.COMPLETED, KeyUtil.DROPPED, KeyUtil.PAUSED, KeyUtil.REPEATING)
 
-    private val boxQuery by inject<BoxQuery>()
     private val mediaListMutationViewModel: MediaListMutationViewModel by activityViewModel()
 
     private lateinit var mediaBase: MediaBase
@@ -296,9 +293,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
     private fun populateCustomListsAndAdvancedScores() {
         val committedModel = mediaListModel
         val draft = mediaListDraft
-        val mediaListOptions = runCatching {
-            boxQuery.currentUser?.mediaListOptions
-        }.getOrNull() ?: return
+        val mediaListOptions = mediaListMutationViewModel.currentUserMediaListOptions ?: return
 
         val typeOptions = (if (isAnime) mediaListOptions.animeList else mediaListOptions.mangaList) ?: return
 
@@ -501,9 +496,7 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
      * Resolves the user's score format from the current user's media list options.
      * Falls back to [KeyUtil.POINT_100] if the user data cannot be resolved.
      */
-    private fun resolveScoreFormat(): String = runCatching {
-        boxQuery.currentUser?.mediaListOptions?.scoreFormat
-    }.getOrNull() ?: KeyUtil.POINT_100
+    private fun resolveScoreFormat(): String = mediaListMutationViewModel.currentUserMediaListOptions?.scoreFormat ?: KeyUtil.POINT_100
 
     private fun observeMutationState() {
         mediaListMutationViewModel.reset(mediaBase.id)

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/MainViewModel.kt
@@ -47,4 +47,6 @@ class MainViewModel(
             }
         }
     }
+
+    fun currentUser() = userRepository.cachedCurrentUser
 }

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/MediaListMutationViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/MediaListMutationViewModel.kt
@@ -11,6 +11,8 @@ import com.mxt.anitrend.domain.medialist.interactor.IncrementMediaProgressIntera
 import com.mxt.anitrend.domain.medialist.interactor.SaveMediaListEntryInteractor
 import com.mxt.anitrend.domain.model.IncrementMediaProgressCommand
 import com.mxt.anitrend.domain.model.SaveMediaListEntryCommand
+import com.mxt.anitrend.model.entity.anilist.meta.MediaListOptions
+import com.mxt.anitrend.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -22,7 +24,12 @@ class MediaListMutationViewModel(
     private val deleteMediaListEntryInteractor: DeleteMediaListEntryInteractor,
     private val incrementMediaProgressInteractor: IncrementMediaProgressInteractor,
     private val mutationRegistry: MutationRegistry,
+    private val userRepository: UserRepository,
 ) : ViewModel() {
+
+    /** Read-only access to the current user's media list options, if a user is cached. */
+    val currentUserMediaListOptions: MediaListOptions?
+        get() = userRepository.cachedCurrentUser?.mediaListOptions
 
     enum class CompletedAction {
         SAVED,

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/ProfileViewModel.kt
@@ -70,4 +70,9 @@ class ProfileViewModel(
                 connectionContainer.connection
             }
     }
+
+    fun isCurrentUser(userId: Long, userName: String?) = userRepository.isCurrentUser(
+        userId = userId,
+        userName = userName,
+    )
 }

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/StudioViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/StudioViewModel.kt
@@ -61,4 +61,6 @@ class StudioViewModel(
     ): Result<Unit> = withContext(ioDispatcher) {
         baseRepository.toggleFavourite(animeId, mangaId, characterId, staffId, studioId)
     }
+
+    fun isAuthenticated() = studioRepository.isAuthenticated()
 }

--- a/app/src/main/res/values/custom_ids.xml
+++ b/app/src/main/res/values/custom_ids.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2021  AniTrend
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+    <item name="tag_system_window_inset_top" type="id"/>
+</resources>

--- a/app/src/test/java/com/mxt/anitrend/koin/KoinModuleVerificationTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/koin/KoinModuleVerificationTest.kt
@@ -42,18 +42,19 @@ class KoinModuleVerificationTest {
         12 to 7, // staffFeatureModule
         13 to 4, // studioFeatureModule
         14 to 5, // utilityFeatureModule (GiphyVM + LoginAuthVM + LoggingVM + logFile + metadata)
+        15 to 43, // fragmentModule (settings x2 + giphy sheet + 40 koin-owned fragment factories)
     )
 
     @OptIn(KoinInternalApi::class)
     @Test
-    fun `appModules has exactly 15 entries`() {
+    fun `appModules has exactly 16 entries`() {
         assertEquals(
-            "appModules should contain exactly 15 modules:\n" +
+            "appModules should contain exactly 16 modules:\n" +
                 "  coroutineModule, core, widget, worker, presenter, network, retrofit,\n" +
                 "  service, repository,\n" +
                 "  mediaFeature, userFeature, characterFeature, staffFeature,\n" +
-                "  studioFeature, utilityFeature",
-            15,
+                "  studioFeature, utilityFeature, fragment",
+            16,
             appModules.includedModules.size,
         )
     }
@@ -62,7 +63,7 @@ class KoinModuleVerificationTest {
     @Test
     fun `each module is non-null and at expected position`() {
         val modules = appModules.includedModules
-        for (i in 0 until 15) {
+        for (i in 0 until 16) {
             assertNotNull("Module at index $i must not be null", modules[i])
         }
     }
@@ -84,11 +85,11 @@ class KoinModuleVerificationTest {
 
     @OptIn(KoinInternalApi::class)
     @Test
-    fun `appModules combined has 129 distinct definitions`() {
+    fun `appModules combined has 172 distinct definitions`() {
         val total = appModules.includedModules.sumOf { it.mappings.values.distinct().size }
         assertEquals(
-            "Combined distinct definition count drifted. Expected 129, got $total.",
-            129,
+            "Combined distinct definition count drifted. Expected 172, got $total.",
+            172,
             total,
         )
     }

--- a/app/src/test/java/com/mxt/anitrend/repository/StudioRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/StudioRepositoryTest.kt
@@ -16,6 +16,7 @@ import com.mxt.anitrend.model.api.retro.anilist.StudioService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import com.mxt.anitrend.util.Settings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -31,8 +32,10 @@ class StudioRepositoryTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val service = mock(StudioService::class.java)
+    private val settings = mock(Settings::class.java)
     private val repository = StudioRepository(
         studioService = service,
+        settings = settings,
         ioDispatcher = testDispatcher,
     )
 


### PR DESCRIPTION
## Description

- Centralize activity setup in CommonActivity and install the Koin FragmentFactory.
- Register 40 concrete fragments and migrate all 16 PageAdapters to FragmentItem creation.
- Remove lifecycle UI BoxQuery access and preserve fragment arguments, tags, and recreation behavior.
- Update Koin structural verification for 16 modules and 172 definitions.

## Verification

- `./gradlew :app:compileAppDebugKotlin :app:testAppDebugUnitTest --tests com.mxt.anitrend.koin.KoinModuleVerificationTest --no-daemon`
- `git diff --check`

Four unrelated unstaged concurrent edits were intentionally excluded from this commit.