### PR TITLE
fix(ui): render replies on first activity open

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/base/custom/fragment/FragmentBaseComment.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/fragment/FragmentBaseComment.kt
@@ -86,7 +86,6 @@ abstract class FragmentBaseComment :
         originRecycler = requireNotNull(binding).commentOrigin
         stateLayout = requireNotNull(binding).stateLayout
         composerWidget = requireNotNull(binding).composerWidget
-        recyclerView.setHasFixedSize(true)
         recyclerView.isNestedScrollingEnabled = false
         mLayoutManager =
             StaggeredGridLayoutManager(

--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -701,6 +701,7 @@ private val userFeatureModule = module {
             deleteReplyInteractor = get(),
             deleteFeedInteractor = get(),
             saveFeedInteractor = get(),
+            requestSequence = get(),
         )
     }
     viewModel {

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
@@ -285,8 +285,15 @@ class CommentFragment : FragmentBaseComment() {
         // The ViewModel precomputes the canonical feed projection; the header
         // renders exactly what the store-backed state emits.
         val headerItems = listOfNotNull(state.feedItem)
-        feedAdapter.submitList(headerItems)
-        commentListAdapter.submitList(state.replies)
+        // ListAdapter commits asynchronously. Chain the submissions so the
+        // empty/content decision runs only after both adapter item counts have
+        // settled; otherwise the first load briefly sees 0/0 and leaves the
+        // reply list behind the empty-state overlay until re-entry.
+        feedAdapter.submitList(headerItems) {
+            commentListAdapter.submitList(state.replies) {
+                updateUI()
+            }
+        }
 
         if (state.feed != null && composerMode == null) {
             setReplyComposer(state.feed)

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/CommentViewModel.kt
@@ -147,25 +147,23 @@ class CommentViewModel(
                 commitToStore = true,
                 readToken = token,
             ).onSuccess {
-                if (screenState.value.requestToken != token) {
-                    return@onSuccess
-                }
-                screenState.update { current ->
-                    current.copy(
-                        isLoading = false,
-                        errorMessage = null,
-                    )
+                if (screenState.value.requestToken == token) {
+                    screenState.update { current ->
+                        current.copy(
+                            isLoading = false,
+                            errorMessage = null,
+                        )
+                    }
                 }
             }.onFailure { throwable ->
-                if (screenState.value.requestToken != token) {
-                    return@onFailure
-                }
-                Timber.e(throwable, "CommentViewModel load failed")
-                screenState.update { current ->
-                    current.copy(
-                        isLoading = false,
-                        errorMessage = throwable.message ?: "Failed to load activity",
-                    )
+                if (screenState.value.requestToken == token) {
+                    Timber.e(throwable, "CommentViewModel load failed")
+                    screenState.update { current ->
+                        current.copy(
+                            isLoading = false,
+                            errorMessage = throwable.message ?: "Failed to load activity",
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/CommentViewModel.kt
@@ -7,6 +7,7 @@ import com.mxt.anitrend.data.store.mutation.MutationRegistry
 import com.mxt.anitrend.data.store.mutation.MutationResult
 import com.mxt.anitrend.data.store.mutation.OperationKey
 import com.mxt.anitrend.data.store.mutation.OperationStatus
+import com.mxt.anitrend.data.store.mutation.RequestSequence
 import com.mxt.anitrend.domain.feed.interactor.DeleteFeedInteractor
 import com.mxt.anitrend.domain.feed.interactor.DeleteReplyInteractor
 import com.mxt.anitrend.domain.feed.interactor.SaveFeedInteractor
@@ -51,6 +52,7 @@ class CommentViewModel(
     private val deleteReplyInteractor: DeleteReplyInteractor,
     private val deleteFeedInteractor: DeleteFeedInteractor,
     private val saveFeedInteractor: SaveFeedInteractor,
+    private val requestSequence: RequestSequence,
 ) : ViewModel() {
 
     data class CommentUiState(
@@ -65,6 +67,7 @@ class CommentViewModel(
     private data class ScreenState(
         val feedId: Long? = null,
         val currentUserId: Long? = null,
+        val requestToken: Long = 0L,
         val isLoading: Boolean = false,
         val hasAttemptedLoad: Boolean = false,
         val errorMessage: String? = null,
@@ -125,10 +128,12 @@ class CommentViewModel(
             return
         }
 
+        val token = requestSequence.next()
         screenState.update {
             it.copy(
                 feedId = feedId,
                 currentUserId = currentUserId,
+                requestToken = token,
                 isLoading = true,
                 hasAttemptedLoad = true,
                 errorMessage = null,
@@ -140,7 +145,11 @@ class CommentViewModel(
                 id = feedId,
                 asHtml = false,
                 commitToStore = true,
+                readToken = token,
             ).onSuccess {
+                if (screenState.value.requestToken != token) {
+                    return@onSuccess
+                }
                 screenState.update { current ->
                     current.copy(
                         isLoading = false,
@@ -148,6 +157,9 @@ class CommentViewModel(
                     )
                 }
             }.onFailure { throwable ->
+                if (screenState.value.requestToken != token) {
+                    return@onFailure
+                }
                 Timber.e(throwable, "CommentViewModel load failed")
                 screenState.update { current ->
                     current.copy(

--- a/app/src/main/res/layout/fragment_comment.xml
+++ b/app/src/main/res/layout/fragment_comment.xml
@@ -34,7 +34,7 @@
                 <com.mxt.anitrend.widget.ProgressLayout
                     android:id="@+id/stateLayout"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="wrap_content">
 
                     <com.mxt.anitrend.base.custom.recycler.StatefulRecyclerView
                         android:id="@+id/recyclerView"

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/CommentViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/CommentViewModelTest.kt
@@ -46,6 +46,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommentViewModelTest {
@@ -75,6 +76,7 @@ class CommentViewModelTest {
             deleteReplyInteractor = DeleteReplyInteractor(feedRepository, mutationExecutor, store, RequestSequence()),
             deleteFeedInteractor = DeleteFeedInteractor(feedRepository, mutationExecutor, store, RequestSequence()),
             saveFeedInteractor = SaveFeedInteractor(feedRepository, mutationExecutor, store, RequestSequence()),
+            requestSequence = RequestSequence(),
         )
     }
 
@@ -179,6 +181,16 @@ class CommentViewModelTest {
         assertEquals(2, replyModel.likeCount)
 
         // A different current user renders the same row as not liked.
+        doReturn(
+            Result.success(
+                FeedDetailResult(
+                    feed = feed.toFeedRecord(revision = 2L),
+                    replies = listOf(reply.toFeedReplyRecord(activityId = 1L, revision = 2L)),
+                ),
+            ),
+        )
+            .`when`(feedRepository)
+            .getFeedListReplyRecords(1L, false, true, 0L, 2L)
         viewModel.load(1L, currentUserId = 7L)
         advanceUntilIdle()
         assertFalse(viewModel.state.value.replies.first().isLikedByCurrentUser)
@@ -299,25 +311,105 @@ class CommentViewModelTest {
         collector.cancel()
     }
 
+    @Test
+    fun `detail response with fresh request token is not rejected as stale after revision 1 feed list commit`() = runTest {
+        val collector = backgroundScope.launch { viewModel.state.collect {} }
+        val feed = feed(1L, replyCount = 1)
+        val reply = reply(10L, activityId = 1L, text = "first")
+
+        // A feed list query previously committed this feed at revision 1 (the
+        // FeedListViewModel RequestSequence token). A detail response stamped
+        // with the default token 0 is rejected by the store staleness guard,
+        // which is the reply loading bug under test.
+        runBlocking {
+            store.apply(FeedStoreChange.FeedUpserted(feed = feed.toFeedRecord(revision = 1L)))
+        }
+
+        // The comment detail commit carries a fresh RequestSequence token (1L)
+        // and must not be rejected as stale over the existing revision 1 feed.
+        runBlocking {
+            store.apply(
+                FeedStoreChange.FeedDetailLoaded(
+                    feed = feed.toFeedRecord(revision = 1L),
+                    replies = listOf(reply.toFeedReplyRecord(activityId = feed.id, revision = 1L)),
+                ),
+            )
+        }
+        assertEquals(1L, store.state.value.feedsById.getValue(1L).revision)
+        assertEquals(listOf(10L), store.state.value.replyIdsByFeedId.getValue(1L))
+
+        // The ViewModel must request the detail with that same fresh token so
+        // a real repository commit carries revision >= 1 and clears the guard.
+        doReturn(
+            Result.success(
+                FeedDetailResult(
+                    feed = feed.toFeedRecord(revision = 1L),
+                    replies = listOf(reply.toFeedReplyRecord(activityId = feed.id, revision = 1L)),
+                ),
+            ),
+        )
+            .`when`(feedRepository)
+            .getFeedListReplyRecords(1L, false, true, 0L, 1L)
+
+        viewModel.load(1L)
+        advanceUntilIdle()
+
+        verify(feedRepository).getFeedListReplyRecords(1L, false, true, 0L, 1L)
+        assertFalse(viewModel.state.value.isLoading)
+        assertEquals(listOf(10L), viewModel.state.value.replies.map { it.id })
+        collector.cancel()
+    }
+
+    @Test
+    fun `refresh issues a fresh request token instead of being suppressed`() = runTest {
+        val collector = backgroundScope.launch { viewModel.state.collect {} }
+        val feed = feed(1L, replyCount = 1)
+        stubDetailLoad(feed, listOf(reply(10L, activityId = 1L, text = "first")))
+
+        viewModel.load(1L)
+        advanceUntilIdle()
+
+        doReturn(
+            Result.success(
+                FeedDetailResult(
+                    feed = feed.toFeedRecord(revision = 2L),
+                    replies = listOf(reply(11L, activityId = 1L, text = "second").toFeedReplyRecord(activityId = 1L, revision = 2L)),
+                ),
+            ),
+        )
+            .`when`(feedRepository)
+            .getFeedListReplyRecords(1L, false, true, 0L, 2L)
+
+        viewModel.load(1L)
+        advanceUntilIdle()
+
+        // Pull-to-refresh is not gated behind isLoading: a second load issues
+        // a new request token, and the newer token is used for the request.
+        verify(feedRepository).getFeedListReplyRecords(1L, false, true, 0L, 1L)
+        verify(feedRepository).getFeedListReplyRecords(1L, false, true, 0L, 2L)
+        assertFalse(viewModel.state.value.isLoading)
+        collector.cancel()
+    }
+
     private fun stubDetailLoad(feed: FeedList, replies: List<FeedReply>) {
         runBlocking {
             store.apply(
                 FeedStoreChange.FeedDetailLoaded(
-                    feed = feed.toFeedRecord(revision = 0L),
-                    replies = replies.map { it.toFeedReplyRecord(activityId = feed.id, revision = 0L) },
+                    feed = feed.toFeedRecord(revision = 1L),
+                    replies = replies.map { it.toFeedReplyRecord(activityId = feed.id, revision = 1L) },
                 ),
             )
 
             doReturn(
                 Result.success(
                     FeedDetailResult(
-                        feed = feed.toFeedRecord(revision = 0L),
-                        replies = replies.map { it.toFeedReplyRecord(activityId = feed.id, revision = 0L) },
+                        feed = feed.toFeedRecord(revision = 1L),
+                        replies = replies.map { it.toFeedReplyRecord(activityId = feed.id, revision = 1L) },
                     ),
                 ),
             )
                 .`when`(feedRepository)
-                .getFeedListReplyRecords(1L, false, true, 0L, 0L)
+                .getFeedListReplyRecords(1L, false, true, 0L, 1L)
         }
     }
 


### PR DESCRIPTION
## Description
Fixes first-open Reply screen rendering.

The feed-detail response was successful and included replies, but the nested replies RecyclerView stayed at height 0 because it used fixed-size measurement with wrap-content content. The ProgressLayout also used match-parent inside a wrap-content NestedScrollView. Adapter submissions are now chained until both lists commit before the content state is updated.

Also propagates monotonic request tokens through CommentViewModel to prevent stale detail responses, with regression coverage for initial load and refresh.

## Verification
- To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/9.6.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Calculating task graph as no cached configuration is available for tasks: :app:testAppDebugUnitTest --tests com.mxt.anitrend.viewmodel.CommentViewModelTest --tests com.mxt.anitrend.koin.KoinModuleVerificationTest :app:assembleAppDebug
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :app
WARNING: The option setting 'android.nonFinalResIds=false' is deprecated.
The current default is 'true'.
It will be removed in version 10.0 of the Android Gradle plugin.
Add android.sync.suppressAgpWarnings=UNSUPPORTED_PROJECT_OPTION_USE to the gradle.properties file to suppress this warning.
WARNING: The option setting 'android.enableJetifier=true' is deprecated.
The current default is 'false'.
It will be removed in version 10.0 of the Android Gradle plugin.
Add android.sync.suppressAgpWarnings=UNSUPPORTED_PROJECT_OPTION_USE to the gradle.properties file to suppress this warning.
/Users/maxwellmapako/Git/anitrend-app/app/.config/keystore.properties could not be found, release may fail
Configuring build type -> debug
Configuring build type -> release
VariantFilter { name: appDebug, flavor: app, module: app }
VariantFilter { name: githubDebug, flavor: github, module: app }
VariantFilter { name: appRelease, flavor: app, module: app }
VariantFilter { name: githubRelease, flavor: github, module: app }
Configuring build output build -> name: appDebug | output: app-debug.apk
Configuring build output build -> name: githubDebug | output: github-debug.apk
Configuring build output build -> name: appRelease | output: app-release-unsigned.apk
Configuring build output build -> name: githubRelease | output: github-release-unsigned.apk

> Task :app:objectboxPrepareBuild UP-TO-DATE
> Task :app:preBuild UP-TO-DATE
> Task :app:preAppDebugBuild UP-TO-DATE
> Task :app:dataBindingMergeDependencyArtifactsAppDebug UP-TO-DATE
> Task :app:generateAppDebugResValues UP-TO-DATE
> Task :app:generateAppDebugResources UP-TO-DATE
> Task :app:mergeAppDebugResources UP-TO-DATE
> Task :app:dataBindingGenBaseClassesAppDebug UP-TO-DATE
> Task :app:generateAppDebugBuildConfig UP-TO-DATE
> Task :app:packageAppDebugResources UP-TO-DATE
> Task :app:processAppDebugNavigationResources UP-TO-DATE
> Task :app:parseAppDebugLocalResources UP-TO-DATE
> Task :app:generateAppDebugRFile UP-TO-DATE
> Task :app:generateGraphQLSources UP-TO-DATE
> Task :app:kaptGenerateStubsAppDebugKotlin UP-TO-DATE
> Task :app:kaptAppDebugKotlin UP-TO-DATE
> Task :app:compileAppDebugKotlin UP-TO-DATE
> Task :app:javaPreCompileAppDebug UP-TO-DATE
> Task :app:compileAppDebugJavaWithJavac UP-TO-DATE
> Task :app:checkAppDebugAarMetadata UP-TO-DATE
> Task :app:mapAppDebugSourceSetPaths UP-TO-DATE
> Task :app:compileAppDebugNavigationResources UP-TO-DATE
> Task :app:createAppDebugCompatibleScreenManifests UP-TO-DATE
> Task :app:extractDeepLinksAppDebug UP-TO-DATE
> Task :app:processAppDebugMainManifest UP-TO-DATE
> Task :app:processAppDebugManifest UP-TO-DATE
> Task :app:processAppDebugManifestForPackage UP-TO-DATE
> Task :app:processAppDebugResources UP-TO-DATE
> Task :app:transformAppDebugClassesWithAsm UP-TO-DATE
> Task :app:bundleAppDebugClassesToRuntimeJar UP-TO-DATE
> Task :app:bundleAppDebugClassesToCompileJar UP-TO-DATE
> Task :app:preAppDebugUnitTestBuild UP-TO-DATE
> Task :app:kaptGenerateStubsAppDebugUnitTestKotlin UP-TO-DATE
> Task :app:kaptAppDebugUnitTestKotlin SKIPPED
> Task :app:compileAppDebugUnitTestKotlin UP-TO-DATE
> Task :app:javaPreCompileAppDebugUnitTest UP-TO-DATE
> Task :app:compileAppDebugUnitTestJavaWithJavac NO-SOURCE
> Task :app:processAppDebugJavaRes UP-TO-DATE
> Task :app:processAppDebugUnitTestJavaRes UP-TO-DATE
> Task :app:testAppDebugUnitTest UP-TO-DATE
> Task :app:mergeAppDebugNativeDebugMetadata NO-SOURCE
> Task :app:generateAppDebugAssets UP-TO-DATE
> Task :app:mergeAppDebugAssets UP-TO-DATE
> Task :app:compressAppDebugAssets UP-TO-DATE
> Task :app:generateAppDebugGlobalSynthetics UP-TO-DATE
> Task :app:mergeAppDebugJavaResource UP-TO-DATE
> Task :app:checkAppDebugDuplicateClasses UP-TO-DATE
> Task :app:desugarAppDebugFileDependencies UP-TO-DATE
> Task :app:mergeExtDexAppDebug UP-TO-DATE
> Task :app:mergeLibDexAppDebug UP-TO-DATE
> Task :app:dexBuilderAppDebug UP-TO-DATE
> Task :app:mergeProjectDexAppDebug UP-TO-DATE
> Task :app:mergeAppDebugJniLibFolders UP-TO-DATE
> Task :app:mergeAppDebugNativeLibs UP-TO-DATE
> Task :app:stripAppDebugDebugSymbols UP-TO-DATE
> Task :app:validateSigningAppDebug UP-TO-DATE
> Task :app:writeAppDebugAppMetadata UP-TO-DATE
> Task :app:writeAppDebugSigningConfigVersions UP-TO-DATE
> Task :app:packageAppDebug UP-TO-DATE
> Task :app:createAppDebugApkListingFileRedirect UP-TO-DATE
> Task :app:assembleAppDebug UP-TO-DATE

1 problem was found storing the configuration cache.
- Task `:app:objectboxPrepareBuild` of type `io.objectbox.gradle.PrepareTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.6.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types

See the complete report at file:///Users/maxwellmapako/Git/anitrend-app/build/reports/configuration-cache/72tm56f5kkmhm3prqfj39095i/4528e3o783o3nbl3pqeapu4dy/configuration-cache-report.html

[Incubating] Problems report is available at: file:///Users/maxwellmapako/Git/anitrend-app/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 48s
57 actionable tasks: 57 up-to-date
Configuration cache entry discarded with 1 problem.
- Authenticated emulator verification: first-open Reply card rendered and remained after pull-to-refresh.
- Logcat and Chucker confirmed HTTP 200 with the reply payload.
