### PR TITLE
feat(ui): modernize studio character and staff screens

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -13,7 +15,7 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.detail.CharacterPageAdapter
 import com.mxt.anitrend.base.custom.view.widget.FavouriteToolbarWidget
 import com.mxt.anitrend.base.custom.view.widget.FavouriteWidgetRenderState
-import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
+import com.mxt.anitrend.databinding.ActivityCharacterBinding
 import com.mxt.anitrend.domain.model.CharacterRecord
 import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.util.IntentBundleUtil
@@ -33,7 +35,7 @@ import java.util.Locale
  */
 class CharacterActivity : CommonActivity() {
 
-    private lateinit var binding: ActivityPagerGenericBinding
+    private lateinit var binding: ActivityCharacterBinding
 
     private var model: CharacterRecord? = null
     private var characterId: Long = 0
@@ -48,10 +50,13 @@ class CharacterActivity : CommonActivity() {
         // ActivityBase.onCreate -> IntentBundleUtil.checkIntentData.
         IntentBundleUtil(intent).checkIntentData(this)
 
-        binding = ActivityPagerGenericBinding.inflate(layoutInflater)
+        binding = ActivityCharacterBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        setSupportActionBar(binding.customToolbar.toolbar)
+        setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.characterErrorRetry.setOnClickListener {
+            characterViewModel.load(characterId)
+        }
 
         if (intent.hasExtra(KeyUtil.arg_id)) {
             characterId = intent.getLongExtra(KeyUtil.arg_id, -1)
@@ -66,17 +71,14 @@ class CharacterActivity : CommonActivity() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 characterViewModel.state.collect { state ->
                     when (state) {
-                        is CharacterViewModel.UiState.Loading -> { /* content loads below */ }
+                        is CharacterViewModel.UiState.Loading -> showLoadingState()
                         is CharacterViewModel.UiState.Success -> {
                             model = state.character
+                            showContentState()
+                            updateUI()
                         }
                         is CharacterViewModel.UiState.Error -> {
-                            NotifyUtil.makeText(
-                                this@CharacterActivity,
-                                state.message,
-                                R.drawable.ic_warning_white_18dp,
-                                Toast.LENGTH_LONG,
-                            ).show()
+                            showErrorState(state.message)
                         }
                     }
                 }
@@ -191,6 +193,33 @@ class CharacterActivity : CommonActivity() {
     override fun onResume() {
         super.onResume()
         characterViewModel.load(characterId)
+    }
+
+    private fun updateUI() {
+        model?.let { current ->
+            binding.characterDisplayName.text = current.name
+            binding.characterIdentityTier.visibility = VISIBLE
+        }
+    }
+
+    private fun showLoadingState() {
+        binding.characterStateOverlay.visibility = VISIBLE
+        binding.characterLoadingState.visibility = VISIBLE
+        binding.characterErrorState.visibility = GONE
+        binding.characterStateOverlay.contentDescription =
+            getString(R.string.character_loading_content_description)
+    }
+
+    private fun showContentState() {
+        binding.characterStateOverlay.visibility = GONE
+    }
+
+    private fun showErrorState(message: String) {
+        binding.characterStateOverlay.visibility = VISIBLE
+        binding.characterLoadingState.visibility = GONE
+        binding.characterErrorState.visibility = VISIBLE
+        binding.characterErrorText.text = message
+        binding.characterStateOverlay.contentDescription = message
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -13,7 +15,7 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.pager.detail.StaffPageAdapter
 import com.mxt.anitrend.base.custom.view.widget.FavouriteToolbarWidget
 import com.mxt.anitrend.base.custom.view.widget.FavouriteWidgetRenderState
-import com.mxt.anitrend.databinding.ActivityPagerGenericBinding
+import com.mxt.anitrend.databinding.ActivityStaffBinding
 import com.mxt.anitrend.domain.model.StaffRecord
 import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.extension.serializableExtra
@@ -37,7 +39,7 @@ import java.util.Locale
  */
 class StaffActivity : CommonActivity() {
 
-    private lateinit var binding: ActivityPagerGenericBinding
+    private lateinit var binding: ActivityStaffBinding
 
     private var model: StaffRecord? = null
     private var staffId: Long = 0
@@ -57,10 +59,13 @@ class StaffActivity : CommonActivity() {
         // ActivityBase.onCreate -> IntentBundleUtil.checkIntentData.
         IntentBundleUtil(intent).checkIntentData(this)
 
-        binding = ActivityPagerGenericBinding.inflate(layoutInflater)
+        binding = ActivityStaffBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        setSupportActionBar(binding.customToolbar.toolbar)
+        setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.staffErrorRetry.setOnClickListener {
+            staffViewModel.load(staffId)
+        }
 
         if (intent.hasExtra(KeyUtil.arg_id)) {
             staffId = intent.getLongExtra(KeyUtil.arg_id, -1)
@@ -76,18 +81,14 @@ class StaffActivity : CommonActivity() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 staffViewModel.state.collect { state ->
                     when (state) {
-                        is StaffViewModel.UiState.Loading -> { /* content loads below */ }
+                        is StaffViewModel.UiState.Loading -> showLoadingState()
                         is StaffViewModel.UiState.Success -> {
                             model = state.staff
+                            showContentState()
                             updateUI()
                         }
                         is StaffViewModel.UiState.Error -> {
-                            NotifyUtil.makeText(
-                                this@StaffActivity,
-                                state.message,
-                                R.drawable.ic_warning_white_18dp,
-                                Toast.LENGTH_LONG,
-                            ).show()
+                            showErrorState(state.message)
                         }
                     }
                 }
@@ -234,8 +235,29 @@ class StaffActivity : CommonActivity() {
 
     private fun updateUI() {
         model?.let { current ->
-            supportActionBar?.title = current.name
+            binding.staffDisplayName.text = current.name
+            binding.staffIdentityTier.visibility = VISIBLE
         }
+    }
+
+    private fun showLoadingState() {
+        binding.staffStateOverlay.visibility = VISIBLE
+        binding.staffLoadingState.visibility = VISIBLE
+        binding.staffErrorState.visibility = GONE
+        binding.staffStateOverlay.contentDescription =
+            getString(R.string.staff_loading_content_description)
+    }
+
+    private fun showContentState() {
+        binding.staffStateOverlay.visibility = GONE
+    }
+
+    private fun showErrorState(message: String) {
+        binding.staffStateOverlay.visibility = VISIBLE
+        binding.staffLoadingState.visibility = GONE
+        binding.staffErrorState.visibility = VISIBLE
+        binding.staffErrorText.text = message
+        binding.staffStateOverlay.contentDescription = message
     }
 
     private fun reloadViewPager() {

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/StudioActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/StudioActivity.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -12,7 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.view.widget.FavouriteToolbarWidget
 import com.mxt.anitrend.base.custom.view.widget.FavouriteWidgetRenderState
-import com.mxt.anitrend.databinding.ActivityFrameGenericBinding
+import com.mxt.anitrend.databinding.ActivityStudioBinding
 import com.mxt.anitrend.domain.model.StudioRecord
 import com.mxt.anitrend.navigation.extension.putScreenParam
 import com.mxt.anitrend.navigation.extension.screenParam
@@ -64,7 +66,7 @@ class StudioActivity : CommonActivity() {
         }
     }
 
-    private lateinit var binding: ActivityFrameGenericBinding
+    private lateinit var binding: ActivityStudioBinding
 
     private var model: StudioRecord? = null
     private var studioId: Long = 0
@@ -79,10 +81,13 @@ class StudioActivity : CommonActivity() {
         // ActivityBase.onCreate → IntentBundleUtil.checkIntentData.
         IntentBundleUtil(intent).checkIntentData(this)
 
-        binding = ActivityFrameGenericBinding.inflate(layoutInflater)
+        binding = ActivityStudioBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        setSupportActionBar(binding.customToolbar.toolbar)
+        setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.studioErrorRetry.setOnClickListener {
+            studioViewModel.load(studioId)
+        }
 
         val args = fromIntent(intent)
         if (args == null) {
@@ -107,18 +112,14 @@ class StudioActivity : CommonActivity() {
                 launch {
                     studioViewModel.state.collect { state ->
                         when (state) {
-                            is StudioViewModel.UiState.Loading -> { /* content loads below */ }
+                            is StudioViewModel.UiState.Loading -> showLoadingState()
                             is StudioViewModel.UiState.Success -> {
                                 model = state.studio
+                                showContentState()
                                 updateUI()
                             }
                             is StudioViewModel.UiState.Error -> {
-                                NotifyUtil.makeText(
-                                    this@StudioActivity,
-                                    state.message,
-                                    R.drawable.ic_warning_white_18dp,
-                                    Toast.LENGTH_LONG,
-                                ).show()
+                                showErrorState(state.message)
                             }
                         }
                     }
@@ -231,6 +232,26 @@ class StudioActivity : CommonActivity() {
         model?.let { current ->
             supportActionBar?.title = current.name
         }
+    }
+
+    private fun showLoadingState() {
+        binding.studioStateOverlay.visibility = VISIBLE
+        binding.studioLoadingState.visibility = VISIBLE
+        binding.studioErrorState.visibility = GONE
+        binding.studioStateOverlay.contentDescription =
+            getString(R.string.studio_loading_content_description)
+    }
+
+    private fun showContentState() {
+        binding.studioStateOverlay.visibility = GONE
+    }
+
+    private fun showErrorState(message: String) {
+        binding.studioStateOverlay.visibility = VISIBLE
+        binding.studioLoadingState.visibility = GONE
+        binding.studioErrorState.visibility = VISIBLE
+        binding.studioErrorText.text = message
+        binding.studioStateOverlay.contentDescription = message
     }
 
     override fun onDestroy() {

--- a/app/src/main/res/layout/activity_character.xml
+++ b/app/src/main/res/layout/activity_character.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Character detail screen. A screen-specific layout with an M3 toolbar,
+     a text identity tier (character name on a surface container, no image
+     since CharacterRecord has none), pinned tabs, and a ViewPager2. The
+     content_main include preserves the page_container ID so the existing
+     CharacterPageAdapter and TabLayoutMediator work unchanged. -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fitsSystemWindows="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceContainerLowest">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurfaceContainerHighest"
+            app:titleTextAppearance="?attr/textAppearanceTitleLarge" />
+
+        <!-- Text identity tier: character name on a surface container.
+             Shown when the activity ViewModel succeeds, hidden until then. -->
+        <LinearLayout
+            android:id="@+id/character_identity_tier"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurfaceContainerHigh"
+            android:orientation="vertical"
+            android:paddingHorizontal="@dimen/spacing_xs"
+            android:paddingVertical="@dimen/mg_margin"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/character_display_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textAppearance="?attr/textAppearanceHeadlineSmall"
+                android:textColor="?attr/colorOnSurface"
+                tools:text="Gintoki Sakata" />
+        </LinearLayout>
+
+        <!-- Pinned tab row -->
+        <include
+            android:id="@+id/custom_tab"
+            layout="@layout/custom_tab" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- ViewPager content. Include preserves content_main / page_container IDs. -->
+    <include
+        android:id="@+id/content_main"
+        layout="@layout/content_main" />
+
+    <!-- State overlay (loading / error) covers the content area -->
+    <FrameLayout
+        android:id="@+id/character_state_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurfaceContainerLowest"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:visibility="gone">
+
+        <!-- Loading state -->
+        <LinearLayout
+            android:id="@+id/character_loading_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/character_loading_indicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                app:indicatorSize="40dp"
+                app:trackThickness="4dp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/character_loading_caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:text="@string/character_loading"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+
+        <!-- Error state -->
+        <LinearLayout
+            android:id="@+id/character_error_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs"
+            android:visibility="gone">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_emoji_sweat"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/character_error_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:gravity="center"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="Couldn\'t load character" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/character_error_retry"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/xl_margin"
+                android:minHeight="48dp"
+                android:text="@string/character_retry" />
+        </LinearLayout>
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_staff.xml
+++ b/app/src/main/res/layout/activity_staff.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Staff detail screen. A screen-specific layout with an M3 toolbar,
+     a text identity tier (staff name on a surface container, no image
+     since StaffRecord has none), pinned tabs, and a ViewPager2. The
+     content_main include preserves the page_container ID so the existing
+     StaffPageAdapter, TabLayoutMediator, and reloadViewPager work
+     unchanged. The staff On My List filter and share actions stay in
+     the overflow menu. -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fitsSystemWindows="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceContainerLowest">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurfaceContainerHighest"
+            app:titleTextAppearance="?attr/textAppearanceTitleLarge" />
+
+        <!-- Text identity tier: staff name on a surface container.
+             Shown when the activity ViewModel succeeds, hidden until then. -->
+        <LinearLayout
+            android:id="@+id/staff_identity_tier"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurfaceContainerHigh"
+            android:orientation="vertical"
+            android:paddingHorizontal="@dimen/spacing_xs"
+            android:paddingVertical="@dimen/mg_margin"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/staff_display_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textAppearance="?attr/textAppearanceHeadlineSmall"
+                android:textColor="?attr/colorOnSurface"
+                tools:text="Tomokazu Sugita" />
+        </LinearLayout>
+
+        <!-- Pinned tab row -->
+        <include
+            android:id="@+id/custom_tab"
+            layout="@layout/custom_tab" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- ViewPager content. Include preserves content_main / page_container IDs. -->
+    <include
+        android:id="@+id/content_main"
+        layout="@layout/content_main" />
+
+    <!-- State overlay (loading / error) covers the content area -->
+    <FrameLayout
+        android:id="@+id/staff_state_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurfaceContainerLowest"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:visibility="gone">
+
+        <!-- Loading state -->
+        <LinearLayout
+            android:id="@+id/staff_loading_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/staff_loading_indicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                app:indicatorSize="40dp"
+                app:trackThickness="4dp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/staff_loading_caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:text="@string/staff_loading"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+
+        <!-- Error state -->
+        <LinearLayout
+            android:id="@+id/staff_error_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs"
+            android:visibility="gone">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_emoji_sweat"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/staff_error_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:gravity="center"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="Couldn\'t load staff" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/staff_error_retry"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/xl_margin"
+                android:minHeight="48dp"
+                android:text="@string/staff_retry" />
+        </LinearLayout>
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_studio.xml
+++ b/app/src/main/res/layout/activity_studio.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Studio detail screen. A screen-specific layout with an M3 toolbar,
+     a frame container for StudioMediaFragment, and an inline state
+     overlay for loading and error states. Replaces the shared
+     activity_frame_generic.xml so the shared layout is not touched. -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fitsSystemWindows="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceContainerLowest">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurfaceContainerHighest"
+            app:titleTextAppearance="?attr/textAppearanceTitleLarge" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- Frame container for StudioMediaFragment. ID preserved from
+         content_generic.xml so FragmentItem.commit works unchanged. -->
+    <FrameLayout
+        android:id="@+id/content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <!-- State overlay (loading / error) covers the content area -->
+    <FrameLayout
+        android:id="@+id/studio_state_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurfaceContainerLowest"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:visibility="gone">
+
+        <!-- Loading state -->
+        <LinearLayout
+            android:id="@+id/studio_loading_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/studio_loading_indicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                app:indicatorSize="40dp"
+                app:trackThickness="4dp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/studio_loading_caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:text="@string/studio_loading"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+
+        <!-- Error state -->
+        <LinearLayout
+            android:id="@+id/studio_error_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_xs"
+            android:visibility="gone">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_emoji_sweat"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/studio_error_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/lg_margin"
+                android:gravity="center"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:text="Couldn\'t load studio" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/studio_error_retry"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/xl_margin"
+                android:minHeight="48dp"
+                android:text="@string/studio_retry" />
+        </LinearLayout>
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_character_overview.xml
+++ b/app/src/main/res/layout/fragment_character_overview.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Character overview tab. Two filled M3 section cards over a scrolling
+     surface: an identity card (image + name + native name) and a details
+     card (alternative names + summary). Uses M3 typography tokens,
+     MaterialDivider for breaks, and the existing ProgressLayout for
+     loading/error/empty states. Preserves all binding IDs used by
+     CharacterOverviewFragment. -->
 <com.mxt.anitrend.widget.ProgressLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -6,148 +12,140 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurfaceContainerLowest">
 
-            <LinearLayout
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="@dimen/spacing_xs"
+            android:paddingTop="@dimen/spacing_xs"
+            android:paddingBottom="@dimen/spacing_sm">
+
+            <!-- ============ Identity section ============ -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/sheet_section_margin">
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <com.mxt.anitrend.base.custom.view.image.AspectImageView
+                        android:id="@+id/character_img"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground"
+                        android:layout_width="@dimen/series_image_xs"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/image_preview_error_character_image"
+                        tools:src="@sample/gintama" />
+
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_marginStart="@dimen/xl_margin"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/character_name_text"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:maxLines="2"
+                            android:ellipsize="end"
+                            android:textIsSelectable="true"
+                            android:textAppearance="?attr/textAppearanceTitleMedium"
+                            android:textColor="?attr/colorOnSurface"
+                            tools:text="Gintoki Sakata" />
+
+                        <com.google.android.material.divider.MaterialDivider
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginVertical="@dimen/lg_margin" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/title_native_name"
+                            android:textAppearance="?attr/textAppearanceLabelMedium"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/character_native_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/sheet_inline_spacing"
+                            android:maxLines="2"
+                            android:ellipsize="end"
+                            android:textIsSelectable="true"
+                            android:textAppearance="?attr/textAppearanceBodyMedium"
+                            android:textColor="?attr/colorOnSurface"
+                            tools:text="坂田銀時" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ============ Details section ============ -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
                     android:orientation="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?selectableItemBackground"
-                    android:layout_margin="@dimen/lg_margin"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:cardPreventCornerOverlap="false"
-                    app:cardBackgroundColor="?cardColor"
-                    app:cardElevation="@dimen/sm_margin"
-                    app:cardCornerRadius="@dimen/lg_margin">
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/title_alternative_names"
+                        android:textAppearance="@style/Widget.AniTrend.ManageSheet.SectionLabel" />
 
-                        <LinearLayout
-                            android:orientation="horizontal"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                    <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
+                        android:id="@+id/character_alternative_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/sheet_field_margin"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        tools:text="Yorozuya, Mr. Odd Jobs, Shiroyasha, Gin, Gin-chan, Kintoki, Paako, Ginpachi-sensei" />
 
-                            <com.mxt.anitrend.base.custom.view.image.AspectImageView
-                                android:id="@+id/character_img"
-                                android:clickable="true"
-                                android:focusable="true"
-                                android:foreground="?selectableItemBackground"
-                                android:layout_width="@dimen/series_image_xs"
-                                android:layout_height="wrap_content"
-                                tools:src="@sample/gintama"/>
+                    <com.google.android.material.divider.MaterialDivider
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginVertical="@dimen/lg_margin" />
 
-                            <LinearLayout
-                                android:orientation="vertical"
-                                android:layout_margin="@dimen/lg_margin"
-                                android:layout_width="match_parent"
-                                android:layout_height="match_parent">
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/title_summary"
+                        android:textAppearance="@style/Widget.AniTrend.ManageSheet.SectionLabel" />
 
-                                <TextView
-                                    android:id="@+id/character_name_text"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:maxLines="2"
-                                    android:ellipsize="end"
-                                    android:textStyle="bold"
-                                    android:textIsSelectable="true"
-                                    tools:text="Gintoki Sakata"/>
+                    <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
+                        android:id="@+id/character_summary_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/sheet_field_margin"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        tools:text="The Amanto, aliens from outer space, have invaded Earth and taken over feudal Japan." />
 
-                                <androidx.legacy.widget.Space
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="@dimen/lg_margin" />
+                </LinearLayout>
 
-                                <FrameLayout
-                                    android:layerType="software"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="@dimen/md_margin"
-                                    android:background="@drawable/dashed_background" />
+            </com.google.android.material.card.MaterialCardView>
 
-                                <androidx.legacy.widget.Space
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="@dimen/lg_margin" />
+        </LinearLayout>
 
-                                <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/title_native_name"/>
+    </androidx.core.widget.NestedScrollView>
 
-                                <com.google.android.material.textview.MaterialTextView
-                                    android:id="@+id/character_native_text"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:fontFamily="sans-serif-light"
-                                    android:maxLines="2"
-                                    android:ellipsize="end"
-                                    android:textIsSelectable="true"
-                                    tools:text="坂田銀時" />
-
-                            </LinearLayout>
-
-                        </LinearLayout>
-
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.mxt.anitrend.base.custom.view.container.CardViewBase
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="@dimen/lg_margin">
-
-                        <LinearLayout
-                            android:orientation="vertical"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent">
-
-                            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:text="@string/title_alternative_names"
-                                />
-
-                            <androidx.legacy.widget.Space
-                                android:layout_width="wrap_content"
-                                android:layout_height="@dimen/md_margin" />
-
-                            <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
-                                android:id="@+id/character_alternative_text"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="sans-serif-light"
-                                tools:text="Yorozuya, Mr. Odd Jobs, Shiroyasha, Gin, Gin-chan, Kintoki, Paako, Ginpachi-sensei" />
-
-                            <androidx.legacy.widget.Space
-                                android:layout_width="wrap_content"
-                                android:layout_height="@dimen/xl_margin" />
-
-                            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:text="@string/title_summary"
-                                />
-
-                            <androidx.legacy.widget.Space
-                                android:layout_width="wrap_content"
-                                android:layout_height="@dimen/md_margin" />
-
-                            <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
-                                android:id="@+id/character_summary_text"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="sans-serif-light"
-                                tools:text="The Amanto, aliens from outer space, have invaded Earth and taken over feudal Japan."/>
-
-                        </LinearLayout>
-
-                    </com.mxt.anitrend.base.custom.view.container.CardViewBase>
-
-            </LinearLayout>
-
-        </androidx.core.widget.NestedScrollView>
-
-    </com.mxt.anitrend.widget.ProgressLayout>
+</com.mxt.anitrend.widget.ProgressLayout>

--- a/app/src/main/res/layout/fragment_staff_overview.xml
+++ b/app/src/main/res/layout/fragment_staff_overview.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Staff overview tab. Two filled M3 section cards over a scrolling
+     surface: an identity card (image + name + language) and a details
+     card (summary). Uses M3 typography tokens, MaterialDivider for
+     breaks, and the existing ProgressLayout for loading/error/empty
+     states. Preserves all binding IDs used by StaffOverviewFragment. -->
 <com.mxt.anitrend.widget.ProgressLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -6,127 +11,120 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-        <androidx.core.widget.NestedScrollView
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurfaceContainerLowest">
+
+        <LinearLayout
+            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="@dimen/spacing_xs"
+            android:paddingTop="@dimen/spacing_xs"
+            android:paddingBottom="@dimen/spacing_sm">
 
-            <LinearLayout
-                android:orientation="vertical"
+            <!-- ============ Identity section ============ -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/sheet_section_margin">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?selectableItemBackground"
-                    android:layout_margin="@dimen/lg_margin"
+                <LinearLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:cardPreventCornerOverlap="false"
-                    app:cardBackgroundColor="?cardColor"
-                    app:cardElevation="@dimen/sm_margin"
-                    app:cardCornerRadius="@dimen/lg_margin">
+                    android:layout_height="wrap_content">
 
-                    <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                        <com.mxt.anitrend.base.custom.view.image.AspectImageView
-                            android:id="@+id/staff_img"
-                            android:clickable="true"
-                            android:focusable="true"
-                            android:foreground="?selectableItemBackground"
-                            android:layout_width="@dimen/series_image_xs"
-                            android:layout_height="wrap_content"
-                            tools:src="@sample/gintama"/>
-
-                        <LinearLayout
-                            android:layout_margin="@dimen/lg_margin"
-                            android:orientation="vertical"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent">
-
-                            <TextView
-                                android:id="@+id/staff_name_text"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:maxLines="2"
-                                android:ellipsize="end"
-                                android:textStyle="bold"
-                                android:textIsSelectable="true"
-                                tools:text="Tomokazu Sugita"/>
-
-                            <androidx.legacy.widget.Space
-                                android:layout_width="wrap_content"
-                                android:layout_height="@dimen/lg_margin" />
-
-                            <FrameLayout
-                                android:layerType="software"
-                                android:layout_width="match_parent"
-                                android:layout_height="@dimen/md_margin"
-                                android:background="@drawable/dashed_background" />
-
-                            <androidx.legacy.widget.Space
-                                android:layout_width="wrap_content"
-                                android:layout_height="@dimen/lg_margin" />
-
-                            <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/title_language"/>
-
-                            <com.google.android.material.textview.MaterialTextView
-                                android:id="@+id/staff_language_text"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:fontFamily="sans-serif-light"
-                                android:maxLines="2"
-                                android:ellipsize="end"
-                                android:textIsSelectable="true"
-                                tools:text="Japanese" />
-
-                        </LinearLayout>
-
-                    </LinearLayout>
-
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.mxt.anitrend.base.custom.view.container.CardViewBase
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="@dimen/lg_margin">
+                    <com.mxt.anitrend.base.custom.view.image.AspectImageView
+                        android:id="@+id/staff_img"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground"
+                        android:layout_width="@dimen/series_image_xs"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/image_preview_error_staff_image"
+                        tools:src="@sample/gintama" />
 
                     <LinearLayout
                         android:orientation="vertical"
+                        android:layout_marginStart="@dimen/xl_margin"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent">
+                        android:layout_height="wrap_content">
 
-                        <com.mxt.anitrend.base.custom.view.text.SingleLineTextView
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/staff_name_text"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="@string/title_summary"
-                            />
+                            android:maxLines="2"
+                            android:ellipsize="end"
+                            android:textIsSelectable="true"
+                            android:textAppearance="?attr/textAppearanceTitleMedium"
+                            android:textColor="?attr/colorOnSurface"
+                            tools:text="Tomokazu Sugita" />
 
-                        <androidx.legacy.widget.Space
+                        <com.google.android.material.divider.MaterialDivider
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginVertical="@dimen/lg_margin" />
+
+                        <com.google.android.material.textview.MaterialTextView
                             android:layout_width="wrap_content"
-                            android:layout_height="@dimen/md_margin" />
-
-                        <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
-                            android:id="@+id/staff_summary_text"
-                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:fontFamily="sans-serif-light"
-                            tools:text="The Amanto, aliens from outer space, have invaded Earth and taken over feudal Japan."/>
+                            android:text="@string/title_language"
+                            android:textAppearance="?attr/textAppearanceLabelMedium"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/staff_language_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/sheet_inline_spacing"
+                            android:maxLines="2"
+                            android:ellipsize="end"
+                            android:textIsSelectable="true"
+                            android:textAppearance="?attr/textAppearanceBodyMedium"
+                            android:textColor="?attr/colorOnSurface"
+                            tools:text="Japanese" />
 
                     </LinearLayout>
 
-                </com.mxt.anitrend.base.custom.view.container.CardViewBase>
+                </LinearLayout>
 
-            </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-        </androidx.core.widget.NestedScrollView>
+            <!-- ============ Details section ============ -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-    </com.mxt.anitrend.widget.ProgressLayout>
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/title_summary"
+                        android:textAppearance="@style/Widget.AniTrend.ManageSheet.SectionLabel" />
+
+                    <com.mxt.anitrend.base.custom.view.text.RichMarkdownTextView
+                        android:id="@+id/staff_summary_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/sheet_field_margin"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        tools:text="The Amanto, aliens from outer space, have invaded Earth and taken over feudal Japan." />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</com.mxt.anitrend.widget.ProgressLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,6 +772,36 @@
     <!-- TalkBack description for the profile loading indicator -->
     <string name="profile_loading_content_description">Loading profile</string>
 
+    <!-- Studio detail strings -->
+    <!-- Loading caption shown while the studio is being fetched -->
+    <string name="studio_loading">Loading studio…</string>
+    <!-- Retry button shown on the studio error state -->
+    <string name="studio_retry">Retry</string>
+    <!-- Generic error shown when the studio request fails -->
+    <string name="studio_error_generic">Couldn\'t load this studio</string>
+    <!-- TalkBack description for the studio loading indicator -->
+    <string name="studio_loading_content_description">Loading studio</string>
+
+    <!-- Character detail strings -->
+    <!-- Loading caption shown while the character is being fetched -->
+    <string name="character_loading">Loading character…</string>
+    <!-- Retry button shown on the character error state -->
+    <string name="character_retry">Retry</string>
+    <!-- Generic error shown when the character request fails -->
+    <string name="character_error_generic">Couldn\'t load this character</string>
+    <!-- TalkBack description for the character loading indicator -->
+    <string name="character_loading_content_description">Loading character</string>
+
+    <!-- Staff detail strings -->
+    <!-- Loading caption shown while the staff member is being fetched -->
+    <string name="staff_loading">Loading staff…</string>
+    <!-- Retry button shown on the staff error state -->
+    <string name="staff_retry">Retry</string>
+    <!-- Generic error shown when the staff request fails -->
+    <string name="staff_error_generic">Couldn\'t load this staff member</string>
+    <!-- TalkBack description for the staff loading indicator -->
+    <string name="staff_loading_content_description">Loading staff</string>
+
     <!-- Image Preview error strings -->
     <string name="image_preview_error_character_image">The character image doesn\'t exist!</string>
     <string name="image_preview_error_profile_banner">The user has not set a banner image!</string>


### PR DESCRIPTION
## Description

Apply the Material 3 treatment to Studio, Character, and Staff screens, with actor routes covered by StaffActivity. Builds on Ref: #1093.

- Add screen-specific Studio, Character, and Staff layouts without changing shared shells.
- Add inline loading and error states to the three activity surfaces.
- Redesign Character and Staff overview cards with M3 section cards, typography, dividers, and spacing.
- Preserve pager, favourites, share, filters, deep links, adapters, ViewModels, and repositories.

## Verification

- ./gradlew :app:spotlessCheck :app:compileAppDebugKotlin :app:compileGithubDebugKotlin :app:assembleAppDebug test --stacktrace --no-daemon
- Studio, Character, Staff, overview, repository, mapper, Koin, and full unit tests passed.
- Shared layout scope checked: activity_frame_generic.xml and activity_pager_generic.xml were not modified.

## Runtime note

Cold direct activity launch on the debug emulator exposed an existing Application Koin bootstrap failure in App.onCreate before the target activity is created. This is separate from the new layout changes and is documented for follow-up.
