### PR TITLE
fix(startup): initialize analytics after Koin

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -275,6 +275,8 @@
                 android:value="androidx.startup" />
             <meta-data  android:name="com.mxt.anitrend.initializer.scheduler.SchedulerInitializer"
                 android:value="androidx.startup" />
+            <meta-data  android:name="com.mxt.anitrend.initializer.analytics.AnalyticsInitializer"
+                android:value="androidx.startup" />
             <meta-data android:name="androidx.work.WorkManagerInitializer"
                 android:value="androidx.startup"
                 tools:node="remove" />

--- a/app/src/main/java/com/mxt/anitrend/App.kt
+++ b/app/src/main/java/com/mxt/anitrend/App.kt
@@ -1,10 +1,7 @@
 package com.mxt.anitrend
 
 import android.app.Application
-import com.mxt.anitrend.analytics.contract.ISupportAnalytics
 import com.mxt.anitrend.crash.runtime.UncaughtExceptionHandler
-import org.koin.android.ext.android.get
-import timber.log.Timber
 
 /**
  * Created by max on 2017/10/22.
@@ -12,14 +9,6 @@ import timber.log.Timber
  */
 
 class App : Application() {
-    /**
-     * Timber logging tree depending on the build type we plant the appropriate tree
-     */
-    private fun plantAnalyticsTree() {
-        val analyticsTree = get<ISupportAnalytics>() as? Timber.Tree ?: return
-        Timber.plant(analyticsTree)
-    }
-
     private fun createUncaughtExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler(
             UncaughtExceptionHandler(),
@@ -51,6 +40,5 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
         createUncaughtExceptionHandler()
-        plantAnalyticsTree()
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/initializer/analytics/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/mxt/anitrend/initializer/analytics/AnalyticsInitializer.kt
@@ -6,6 +6,7 @@ import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.initializer.contract.AbstractInitializer
 import timber.log.Timber
 
+/** Plants the analytics logging tree after the Koin graph has been initialized. */
 class AnalyticsInitializer : AbstractInitializer<Unit>() {
     /**
      * Plants the analytics logging tree resolved from Koin, if the resolved

--- a/app/src/main/java/com/mxt/anitrend/initializer/analytics/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/mxt/anitrend/initializer/analytics/AnalyticsInitializer.kt
@@ -1,0 +1,21 @@
+package com.mxt.anitrend.initializer.analytics
+
+import android.content.Context
+import com.mxt.anitrend.analytics.contract.ISupportAnalytics
+import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.initializer.contract.AbstractInitializer
+import timber.log.Timber
+
+class AnalyticsInitializer : AbstractInitializer<Unit>() {
+    /**
+     * Plants the analytics logging tree resolved from Koin, if the resolved
+     * [ISupportAnalytics] implementation is a [Timber.Tree].
+     *
+     * Runs after [com.mxt.anitrend.initializer.injector.InjectorInitializer]
+     * so Koin is guaranteed to be started before the lookup happens.
+     */
+    override fun create(context: Context) {
+        val analyticsTree = koinOf<ISupportAnalytics>() as? Timber.Tree ?: return
+        Timber.plant(analyticsTree)
+    }
+}


### PR DESCRIPTION
## Description

Fixes cold-start crashes caused by App.onCreate resolving analytics from Koin before Koin is initialized.

- Move analytics tree planting into an AndroidX Startup initializer.
- Declare InjectorInitializer as the dependency so Koin is started first.
- Keep App.onCreate limited to uncaught-exception handler setup.

## Verification

- ./gradlew :app:spotlessCheck :app:compileAppDebugKotlin :app:assembleAppDebug :app:testAppDebugUnitTest --stacktrace --no-daemon
- Clean uninstall and reinstall on the API 36 emulator.
- Cold SplashActivity launch stayed alive and advanced to WelcomeActivity.
- ADB-pulled log: /var/folders/05/hy5_8tps4c56xsvk6qbq7c7w0000gn/T/opencode/anitrend-fixed-launch-pulled.log
- No AndroidRuntime errors and no KoinApplication has not been started occurrences.
