### PR TITLE
fix(ui): restore profile follow CTA

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -671,7 +671,7 @@ private val mediaFeatureModule = module {
 
 private val userFeatureModule = module {
     viewModel { MainViewModel(userRepository = get()) }
-    viewModel { UserOverviewViewModel(userRepository = get()) }
+    viewModel { UserOverviewViewModel(userRepository = get(), toggleUserFollowInteractor = get(), userStore = get()) }
     viewModel {
         UserFeedViewModel(
             feedRepository = get(),

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
@@ -140,12 +140,6 @@ class UserOverviewFragment : Fragment() {
         showRingStats()
     }
 
-    /**
-     * Re-renders only the follow CTA from the ViewModel's committed follow state.
-     * Null means no committed record exists yet, so the server-loaded follow value
-     * on the loaded [model] stays the fallback. The loaded [User] is never mutated;
-     * a lightweight render-only model is pushed into the widget instead.
-     */
     private fun renderFollowCta(committedFollowState: Boolean?) {
         val user = model ?: return
         val isFollowing = committedFollowState ?: user.isFollowing

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
@@ -17,6 +17,7 @@ import com.mxt.anitrend.extension.getCompatColorAttr
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.anilist.User
 import com.mxt.anitrend.model.entity.base.StatsRing
+import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.repository.UserRepository
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -100,6 +101,14 @@ class UserOverviewFragment : Fragment() {
             }
         }
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                userOverviewViewModel.isFollowing.collect { committedFollowState ->
+                    renderFollowCta(committedFollowState)
+                }
+            }
+        }
+
         loadUser()
     }
 
@@ -115,11 +124,34 @@ class UserOverviewFragment : Fragment() {
         binding.widgetStatusText.richMarkDown(user.about)
         binding.widgetStatus.visibility = View.GONE
 
+        binding.userFollowStateWidget.setListener { userId ->
+            userOverviewViewModel.toggleFollow(userId)
+        }
+        binding.userFollowStateWidget.setCurrentUser(userOverviewViewModel.currentUserSnapshot)
         binding.userFollowStateWidget.setUserModel(user)
+        // Reconcile the CTA with the currently committed follow state so a pre-existing
+        // store record is never lost when the independent state and follow-state
+        // collectors race: the follow-state collector may have consumed and rendered
+        // its emission before [model] was available to render it.
+        renderFollowCta(userOverviewViewModel.isFollowing.value)
         binding.userAboutPanelWidget.setFragmentActivity(activity)
         binding.userAboutPanelWidget.setUserId(user.id, lifecycle)
         loadPanelStats(user.id)
         showRingStats()
+    }
+
+    /**
+     * Re-renders only the follow CTA from the ViewModel's committed follow state.
+     * Null means no committed record exists yet, so the server-loaded follow value
+     * on the loaded [model] stays the fallback. The loaded [User] is never mutated;
+     * a lightweight render-only model is pushed into the widget instead.
+     */
+    private fun renderFollowCta(committedFollowState: Boolean?) {
+        val user = model ?: return
+        val isFollowing = committedFollowState ?: user.isFollowing
+        binding.userFollowStateWidget.setUserModel(
+            UserBase(name = user.name, isFollowing = isFollowing).apply { id = user.id },
+        )
     }
 
     private fun loadPanelStats(userId: Long) {
@@ -201,6 +233,9 @@ class UserOverviewFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        binding.userFollowStateWidget.setListener(null)
+        binding.userFollowStateWidget.setCurrentUser(null)
+        binding.userFollowStateWidget.onViewRecycled()
         binding.userAboutPanelWidget.onViewRecycled()
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/UserOverviewViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/UserOverviewViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -30,12 +31,13 @@ class UserOverviewViewModel(
     private val _state = MutableStateFlow<UiState>(UiState.Loading)
     val state: StateFlow<UiState> = _state.asStateFlow()
 
+    private val _isFollowing = MutableStateFlow<Boolean?>(null)
+
     /**
      * Committed follow state of the displayed profile, derived from the canonical
      * [UserStore]. Null means no committed record exists yet, so the server-loaded
      * follow value from the overview response stays the fallback.
      */
-    private val _isFollowing = MutableStateFlow<Boolean?>(null)
     val isFollowing: StateFlow<Boolean?> = _isFollowing.asStateFlow()
 
     /** Snapshot of the authenticated user used for render-only widget wiring. */
@@ -74,23 +76,19 @@ class UserOverviewViewModel(
         }
     }
 
-    /**
-     * Observes the displayed profile's committed follow state in [UserStore]. A previous
-     * observation is cancelled and replaced. Null records are ignored so the server-loaded
-     * follow value remains the fallback, and records for other users are rejected defensively.
-     */
     private fun observeCommittedFollowState(userId: Long) {
         if (userId <= 0L) return
         displayedUserId = userId
         _isFollowing.value = null
         followObservationJob?.cancel()
         followObservationJob = viewModelScope.launch {
-            userStore.observeUser(userId).collect { record ->
-                if (record == null || record.id != userId || userId != displayedUserId) {
-                    return@collect
+            userStore.observeUser(userId)
+                .filterNotNull()
+                .collect { record ->
+                    if (record.id == userId && userId == displayedUserId) {
+                        _isFollowing.value = record.isFollowing
+                    }
                 }
-                _isFollowing.value = record.isFollowing
-            }
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/UserOverviewViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/UserOverviewViewModel.kt
@@ -2,8 +2,13 @@ package com.mxt.anitrend.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mxt.anitrend.data.store.user.UserStore
+import com.mxt.anitrend.domain.model.ToggleUserFollowCommand
+import com.mxt.anitrend.domain.user.interactor.ToggleUserFollowInteractor
 import com.mxt.anitrend.model.entity.anilist.User
+import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.repository.UserRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,6 +17,8 @@ import timber.log.Timber
 
 class UserOverviewViewModel(
     private val userRepository: UserRepository,
+    private val toggleUserFollowInteractor: ToggleUserFollowInteractor,
+    private val userStore: UserStore,
 ) : ViewModel() {
 
     sealed interface UiState {
@@ -23,7 +30,21 @@ class UserOverviewViewModel(
     private val _state = MutableStateFlow<UiState>(UiState.Loading)
     val state: StateFlow<UiState> = _state.asStateFlow()
 
+    /**
+     * Committed follow state of the displayed profile, derived from the canonical
+     * [UserStore]. Null means no committed record exists yet, so the server-loaded
+     * follow value from the overview response stays the fallback.
+     */
+    private val _isFollowing = MutableStateFlow<Boolean?>(null)
+    val isFollowing: StateFlow<Boolean?> = _isFollowing.asStateFlow()
+
+    /** Snapshot of the authenticated user used for render-only widget wiring. */
+    val currentUserSnapshot: UserBase?
+        get() = userRepository.cachedCurrentUser
+
     private var loadedOnce = false
+    private var displayedUserId: Long = 0L
+    private var followObservationJob: Job? = null
 
     /**
      * Loads the user overview by AniList ID or username. After the first successful load,
@@ -43,12 +64,45 @@ class UserOverviewViewModel(
             }.onSuccess { user ->
                 _state.value = UiState.Success(user)
                 loadedOnce = true
+                observeCommittedFollowState(user.id)
             }.onFailure { throwable ->
                 Timber.e(throwable, "UserOverviewViewModel load failed")
                 _state.value = UiState.Error(
                     throwable.message ?: "Failed to load user overview",
                 )
             }
+        }
+    }
+
+    /**
+     * Observes the displayed profile's committed follow state in [UserStore]. A previous
+     * observation is cancelled and replaced. Null records are ignored so the server-loaded
+     * follow value remains the fallback, and records for other users are rejected defensively.
+     */
+    private fun observeCommittedFollowState(userId: Long) {
+        if (userId <= 0L) return
+        displayedUserId = userId
+        _isFollowing.value = null
+        followObservationJob?.cancel()
+        followObservationJob = viewModelScope.launch {
+            userStore.observeUser(userId).collect { record ->
+                if (record == null || record.id != userId || userId != displayedUserId) {
+                    return@collect
+                }
+                _isFollowing.value = record.isFollowing
+            }
+        }
+    }
+
+    /**
+     * Fire-and-forget follow toggle for the displayed profile. IDs that do not match the
+     * currently displayed profile are ignored; the authoritative committed state is
+     * delivered back through [isFollowing].
+     */
+    fun toggleFollow(userId: Long) {
+        if (userId <= 0L || userId != displayedUserId) return
+        viewModelScope.launch {
+            toggleUserFollowInteractor(ToggleUserFollowCommand(userId = userId))
         }
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/UserOverviewViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/UserOverviewViewModelTest.kt
@@ -1,15 +1,32 @@
 package com.mxt.anitrend.viewmodel
 
+import com.mxt.anitrend.data.store.mutation.DefaultMutationExecutor
+import com.mxt.anitrend.data.store.mutation.DefaultMutationRegistry
+import com.mxt.anitrend.data.store.mutation.DefaultOperationIdGenerator
+import com.mxt.anitrend.data.store.mutation.KeyedMutex
+import com.mxt.anitrend.data.store.mutation.RequestSequence
+import com.mxt.anitrend.data.store.mutation.SessionEpoch
+import com.mxt.anitrend.data.store.user.InMemoryUserStore
+import com.mxt.anitrend.data.store.user.UserStore
+import com.mxt.anitrend.data.store.user.UserStoreChange
+import com.mxt.anitrend.domain.model.ToggleUserFollowCommand
+import com.mxt.anitrend.domain.model.UserRecord
+import com.mxt.anitrend.domain.user.interactor.ToggleUserFollowInteractor
 import com.mxt.anitrend.model.entity.anilist.User
+import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.repository.UserRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -17,17 +34,22 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserOverviewViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var userRepository: UserRepository
+    private lateinit var toggleUserFollowInteractor: ToggleUserFollowInteractor
+    private lateinit var userStore: InMemoryUserStore
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         userRepository = mock(UserRepository::class.java)
+        toggleUserFollowInteractor = mock(ToggleUserFollowInteractor::class.java)
+        userStore = InMemoryUserStore()
     }
 
     @After
@@ -35,9 +57,21 @@ class UserOverviewViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun viewModel(): UserOverviewViewModel = UserOverviewViewModel(
+        userRepository = userRepository,
+        toggleUserFollowInteractor = toggleUserFollowInteractor,
+        userStore = userStore,
+    )
+
+    private suspend fun stubOverview(userId: Long) {
+        doReturn(Result.success(User().apply { id = userId }))
+            .`when`(userRepository)
+            .getUserOverview(id = userId, userName = null, asHtml = false)
+    }
+
     @Test
     fun `initial state is Loading`() = runTest {
-        val vm = UserOverviewViewModel(userRepository = userRepository)
+        val vm = viewModel()
         assertTrue(vm.state.value is UserOverviewViewModel.UiState.Loading)
     }
 
@@ -47,7 +81,7 @@ class UserOverviewViewModelTest {
         doReturn(Result.success(user))
             .`when`(userRepository)
             .getUserOverview(id = 1L, userName = "user", asHtml = false)
-        val vm = UserOverviewViewModel(userRepository = userRepository)
+        val vm = viewModel()
 
         vm.load(userId = 1L, userName = "user")
 
@@ -60,7 +94,7 @@ class UserOverviewViewModelTest {
         doReturn(Result.failure<User>(RuntimeException("Overview failed")))
             .`when`(userRepository)
             .getUserOverview(id = null, userName = "user", asHtml = false)
-        val vm = UserOverviewViewModel(userRepository = userRepository)
+        val vm = viewModel()
 
         vm.load(userId = 0L, userName = "user")
 
@@ -74,7 +108,7 @@ class UserOverviewViewModelTest {
         doReturn(Result.success(user))
             .`when`(userRepository)
             .getUserOverview(id = 1L, userName = null, asHtml = false)
-        val vm = UserOverviewViewModel(userRepository = userRepository)
+        val vm = viewModel()
 
         vm.load(userId = 1L, userName = "")
         vm.load(userId = 1L, userName = "")
@@ -88,10 +122,188 @@ class UserOverviewViewModelTest {
         doReturn(Result.success(user))
             .`when`(userRepository)
             .getUserOverview(id = null, userName = null, asHtml = false)
-        val vm = UserOverviewViewModel(userRepository = userRepository)
+        val vm = viewModel()
 
         vm.load()
 
         verify(userRepository).getUserOverview(id = null, userName = null, asHtml = false)
+    }
+
+    @Test
+    fun `toggleFollow delegates exact command for displayed profile`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val vm = viewModel()
+
+        vm.load(userId = 7L, userName = "")
+        vm.toggleFollow(7L)
+        advanceUntilIdle()
+
+        verify(toggleUserFollowInteractor).invoke(ToggleUserFollowCommand(userId = 7L))
+    }
+
+    @Test
+    fun `toggleFollow ignores user id that does not match displayed profile`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val vm = viewModel()
+
+        vm.load(userId = 7L, userName = "")
+        vm.toggleFollow(8L)
+        advanceUntilIdle()
+
+        verifyNoInteractions(toggleUserFollowInteractor)
+    }
+
+    @Test
+    fun `toggleFollow ignores call before any profile is loaded`() = runTest(testDispatcher) {
+        val vm = viewModel()
+
+        vm.toggleFollow(7L)
+        advanceUntilIdle()
+
+        verifyNoInteractions(toggleUserFollowInteractor)
+    }
+
+    @Test
+    fun `matching user record updates exposed committed follow state`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val vm = viewModel()
+
+        vm.load(userId = 7L, userName = "")
+        advanceUntilIdle()
+        assertNull(vm.isFollowing.value)
+
+        userStore.apply(
+            UserStoreChange.UserUpserted(
+                UserRecord(
+                    id = 7L,
+                    name = "user-7",
+                    avatar = null,
+                    banner = null,
+                    isFollowing = true,
+                    revision = 1L,
+                ),
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(true, vm.isFollowing.value)
+    }
+
+    @Test
+    fun `preloaded committed record wins over server overview value`() = runTest(testDispatcher) {
+        val overviewUser = User().apply { id = 7L }
+        assertFalse(overviewUser.isFollowing)
+        doReturn(Result.success(overviewUser))
+            .`when`(userRepository)
+            .getUserOverview(id = 7L, userName = null, asHtml = false)
+        userStore.apply(
+            UserStoreChange.UserUpserted(
+                UserRecord(
+                    id = 7L,
+                    name = "user-7",
+                    avatar = null,
+                    banner = null,
+                    isFollowing = true,
+                    revision = 1L,
+                ),
+            ),
+        )
+        val vm = viewModel()
+
+        vm.load(userId = 7L, userName = "")
+        advanceUntilIdle()
+
+        assertEquals(true, vm.isFollowing.value)
+    }
+
+    @Test
+    fun `failed toggle keeps exposed follow state unchanged`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val interactor = ToggleUserFollowInteractor(
+            userRepository = userRepository,
+            mutationExecutor = DefaultMutationExecutor(
+                applicationScope = backgroundScope,
+                keyedMutex = KeyedMutex(backgroundScope),
+                mutationRegistry = DefaultMutationRegistry(),
+                operationIdGenerator = DefaultOperationIdGenerator(),
+                sessionEpoch = SessionEpoch(),
+            ),
+            userStore = userStore,
+            requestSequence = RequestSequence(),
+        )
+        val vm = UserOverviewViewModel(
+            userRepository = userRepository,
+            toggleUserFollowInteractor = interactor,
+            userStore = userStore,
+        )
+        doReturn(Result.failure<UserBase>(IllegalStateException("boom")))
+            .`when`(userRepository)
+            .toggleFollow(7L)
+
+        vm.load(userId = 7L, userName = "")
+        vm.toggleFollow(7L)
+        advanceUntilIdle()
+
+        assertNull(vm.isFollowing.value)
+        assertTrue(userStore.state.value.usersById.isEmpty())
+    }
+
+    @Test
+    fun `null record is ignored so server loaded follow value stays the fallback`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val store = mock(UserStore::class.java)
+        doReturn(flowOf(null))
+            .`when`(store)
+            .observeUser(7L)
+        val vm = UserOverviewViewModel(
+            userRepository = userRepository,
+            toggleUserFollowInteractor = toggleUserFollowInteractor,
+            userStore = store,
+        )
+
+        vm.load(userId = 7L, userName = "")
+        advanceUntilIdle()
+
+        assertNull(vm.isFollowing.value)
+    }
+
+    @Test
+    fun `record for another user is ignored by follow state observation`() = runTest(testDispatcher) {
+        stubOverview(userId = 7L)
+        val store = mock(UserStore::class.java)
+        doReturn(
+            flowOf(
+                UserRecord(
+                    id = 8L,
+                    name = "user-8",
+                    avatar = null,
+                    banner = null,
+                    isFollowing = true,
+                    revision = 1L,
+                ),
+            ),
+        )
+            .`when`(store)
+            .observeUser(7L)
+        val vm = UserOverviewViewModel(
+            userRepository = userRepository,
+            toggleUserFollowInteractor = toggleUserFollowInteractor,
+            userStore = store,
+        )
+
+        vm.load(userId = 7L, userName = "")
+        advanceUntilIdle()
+
+        assertNull(vm.isFollowing.value)
+    }
+
+    @Test
+    fun `current user snapshot comes from repository cache`() = runTest {
+        val currentUser = User().apply { id = 42L }
+        doReturn(currentUser).`when`(userRepository).cachedCurrentUser
+
+        val vm = viewModel()
+
+        assertEquals(42L, vm.currentUserSnapshot?.id)
     }
 }


### PR DESCRIPTION
## Description

Restore the profile follow/unfollow CTA by moving follow mutation and committed state ownership into UserOverviewViewModel. The fragment now only binds and renders the CTA, with lifecycle cleanup and initial store-state reconciliation.

## Validation

- ./gradlew :app:compileAppDebugKotlin :app:testAppDebugUnitTest --tests "com.mxt.anitrend.viewmodel.UserOverviewViewModelTest" --tests "com.mxt.anitrend.viewmodel.UserSearchViewModelFollowStateTest" --no-daemon
- git diff --check
