### PR TITLE
refactor(navigation): standardize activity and fragment arguments

### DIFF
--- a/app/src/androidTest/java/com/mxt/anitrend/navigation/FragmentBundleRoundTripTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/navigation/FragmentBundleRoundTripTest.kt
@@ -1,0 +1,247 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.mxt.anitrend.navigation
+
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mxt.anitrend.domain.model.MediaSummaryRecord
+import com.mxt.anitrend.domain.model.ReviewRecord
+import com.mxt.anitrend.domain.model.UserSummaryRecord
+import com.mxt.anitrend.navigation.extension.ARG_REVIEW_SCREEN
+import com.mxt.anitrend.navigation.extension.ARG_USER_LIST_SCREEN
+import com.mxt.anitrend.navigation.extension.asBundle
+import com.mxt.anitrend.extension.parcelable
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
+import com.mxt.anitrend.navigation.model.ReviewScreenParam
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
+import com.mxt.anitrend.navigation.model.StudioScreenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
+import com.mxt.anitrend.navigation.model.UserListScreenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.view.fragment.detail.CharacterOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.MediaOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.StudioMediaFragment
+import com.mxt.anitrend.view.fragment.detail.UserFeedFragment
+import com.mxt.anitrend.view.fragment.detail.UserOverviewFragment
+import com.mxt.anitrend.view.fragment.group.MediaFormatFragment
+import com.mxt.anitrend.view.fragment.settings.SettingsCategoryLegacyFragment
+import com.mxt.anitrend.view.fragment.youtube.YouTubeEmbedFragment
+import com.mxt.anitrend.view.sheet.BottomReviewReader
+import com.mxt.anitrend.view.sheet.BottomSheetListUsers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Real-Bundle writer-reader round trips on an Android runtime: bundles built by
+ * the production typed writers (asBundle / putScreenParam) or legacy writers are
+ * read back through the production `fromBundle` parsers.
+ */
+@RunWith(AndroidJUnit4::class)
+class FragmentBundleRoundTripTest {
+
+    // ── typed writer → typed reader ──
+
+    @Test
+    fun mediaParamBundleRoundTripsThroughMediaOverviewParser() {
+        val param = MediaScreenParam(mediaId = 21L, mediaType = "ANIME")
+        assertEquals(param, MediaOverviewFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun characterParamBundleRoundTripsThroughCharacterOverviewParser() {
+        val param = CharacterScreenParam(characterId = 31L)
+        assertEquals(param, CharacterOverviewFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun studioParamBundleRoundTripsThroughStudioMediaParser() {
+        val param = StudioScreenParam(studioId = 41L)
+        assertEquals(param.studioId, StudioMediaFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun userParamBundleRoundTripsThroughUserOverviewParser() {
+        val param = UserScreenParam(userId = 51L, initialName = "Raki")
+        assertEquals(param, UserOverviewFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun characterParamBundleRoundTripsThroughMediaFormatParser() {
+        val param = CharacterScreenParam(characterId = 61L)
+        assertEquals(param.characterId, MediaFormatFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun trailerParamBundleRoundTripsThroughYoutubeEmbedParser() {
+        val param = TrailerScreenParam(trailerId = "abc", site = "youtube")
+        assertEquals(param, YouTubeEmbedFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun settingsCategoryParamBundleRoundTripsThroughSettingsParser() {
+        val param = SettingsCategoryScreenParam(categoryId = "general")
+        assertEquals(param, SettingsCategoryLegacyFragment.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun userListParamBundleRoundTripsThroughSheetParser() {
+        val param = UserListScreenParam(userId = 71L, requestType = 2)
+        assertEquals(param, BottomSheetListUsers.fromBundle(param.asBundle()))
+    }
+
+    @Test
+    fun reviewParamBundleRoundTripsThroughReviewReaderParser() {
+        val param = ReviewScreenParam(reviewId = 7L, mediaId = 100L, mediaType = "ANIME", userId = 42L)
+        assertEquals(param, BottomReviewReader.fromBundle(param.asBundle()))
+    }
+
+    // ── legacy writer → typed reader (compatibility bridge) ──
+
+    @Test
+    fun legacyMediaExtrasAreBridgedByMediaOverviewParser() {
+        val bundle = Bundle().apply {
+            putLong(KeyUtil.arg_id, 5L)
+            putString(KeyUtil.arg_mediaType, "MANGA")
+        }
+        assertEquals(MediaScreenParam(mediaId = 5L, mediaType = "MANGA"), MediaOverviewFragment.fromBundle(bundle))
+    }
+
+    @Test
+    fun absentLegacyExtrasResolveToExactDefaults() {
+        val empty = Bundle()
+        // Pre-refactor getters: id 0, type null.
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaOverviewFragment.fromBundle(empty))
+        assertEquals(0L, StudioMediaFragment.fromBundle(empty))
+        // Negative ids pass through exactly.
+        val negative = Bundle().apply { putLong(KeyUtil.arg_id, -3L) }
+        assertEquals(MediaScreenParam(mediaId = -3L, mediaType = null), MediaOverviewFragment.fromBundle(negative))
+    }
+
+    @Test
+    fun typedParamWinsOverLegacyExtras() {
+        val bundle = MediaScreenParam(mediaId = 77L, mediaType = "ANIME").asBundle().apply {
+            putLong(KeyUtil.arg_id, 5L)
+            putString(KeyUtil.arg_mediaType, "MANGA")
+        }
+        assertEquals(MediaScreenParam(mediaId = 77L, mediaType = "ANIME"), MediaOverviewFragment.fromBundle(bundle))
+    }
+
+    @Test
+    fun invalidTypedParamFallsBackToLegacyExtras() {
+        val bundle = MediaScreenParam(mediaId = 0L).asBundle().apply {
+            putLong(KeyUtil.arg_id, 5L)
+        }
+        assertEquals(MediaScreenParam(mediaId = 5L, mediaType = null), MediaOverviewFragment.fromBundle(bundle))
+    }
+
+    @Test
+    fun userFeedLegacyContainsKeySemanticsArePreserved() {
+        val byId = Bundle().apply { putLong(KeyUtil.arg_id, 9L) }
+        assertEquals(UserScreenParam(userId = 9L), UserFeedFragment.fromBundle(byId))
+
+        val byName = Bundle().apply { putString(KeyUtil.arg_userName, "Raki") }
+        assertEquals(UserScreenParam(userId = 0L, initialName = "Raki"), UserFeedFragment.fromBundle(byName))
+    }
+
+    @Test
+    fun reviewReaderLegacyArgModelBridgeWorks() {
+        val param = ReviewScreenParam(reviewId = 9L)
+        val bundle = Bundle().apply {
+            putParcelable(KeyUtil.arg_model, param)
+        }
+        assertEquals(param, BottomReviewReader.fromBundle(bundle))
+    }
+
+    // ── production Builder outputs: stable and legacy keys + parsing ──
+
+    @Test
+    fun userListBuilderWritesStableAndLegacyKeysAndParsesBack() {
+        val sheet = BottomSheetListUsers.Builder()
+            .setUserId(5L)
+            .setModelCount(3)
+            .setRequestType(2)
+            .build()
+        val bundle = sheet.arguments ?: error("missing arguments")
+
+        // Stable typed key written by the production builder.
+        assertEquals(UserListScreenParam(userId = 5L, requestType = 2), bundle.screenParam<UserListScreenParam>())
+        assertEquals(ARG_USER_LIST_SCREEN, screenParamKey<UserListScreenParam>())
+        // Legacy keys retained for pre-migration readers.
+        assertEquals(5L, bundle.getLong(KeyUtil.arg_userId))
+        assertEquals(2, bundle.getInt(KeyUtil.arg_request_type))
+        assertEquals(3, bundle.getInt(KeyUtil.arg_model))
+        // Production reader parses the builder output.
+        assertEquals(UserListScreenParam(userId = 5L, requestType = 2), BottomSheetListUsers.fromBundle(bundle))
+    }
+
+    @Test
+    fun userListBuilderNegativeUserIdSurvivesThroughReader() {
+        val sheet = BottomSheetListUsers.Builder()
+            .setUserId(-5L)
+            .setRequestType(1)
+            .build()
+        val bundle = sheet.arguments ?: error("missing arguments")
+
+        // The builder-derived typed param is invalid (non-positive id), so the reader
+        // must fall back to the exact raw legacy value, negative id included.
+        assertEquals(-5L, bundle.getLong(KeyUtil.arg_userId))
+        assertEquals(UserListScreenParam(userId = -5L, requestType = 1), BottomSheetListUsers.fromBundle(bundle))
+    }
+
+    @Test
+    fun userListValidTypedParamTakesPrecedenceOverLegacy() {
+        val bundle = Bundle().apply {
+            putParcelable(screenParamKey<UserListScreenParam>(), UserListScreenParam(userId = 9L, requestType = 1))
+            putLong(KeyUtil.arg_userId, 5L)
+            putInt(KeyUtil.arg_request_type, 2)
+        }
+        assertEquals(UserListScreenParam(userId = 9L, requestType = 1), BottomSheetListUsers.fromBundle(bundle))
+    }
+
+    @Test
+    fun reviewReaderBuilderWritesStableAndLegacyKeysAndParsesBack() {
+        val review = ReviewRecord(
+            id = 7L,
+            summary = "summary",
+            mediaType = "ANIME",
+            body = "body",
+            rating = 80,
+            ratingAmount = 10,
+            userRating = null,
+            score = 80,
+            isPrivate = false,
+            createdAt = 1L,
+            user = UserSummaryRecord(id = 42L, name = "Raki", avatar = null, siteUrl = null),
+            media = MediaSummaryRecord(
+                id = 100L,
+                titleRomaji = null,
+                titleEnglish = null,
+                titleOriginal = null,
+                coverImage = null,
+                type = "ANIME",
+                episodes = 0,
+                chapters = 0,
+                volumes = 0,
+                status = null,
+                siteUrl = null,
+            ),
+            revision = 0L,
+        )
+        val expected = ReviewScreenParam(reviewId = 7L, mediaId = 100L, mediaType = "ANIME", userId = 42L)
+        val reader = BottomReviewReader.Builder().setReview(review).build()
+        val bundle = reader.arguments ?: error("missing arguments")
+
+        // Stable key written by the production builder.
+        assertEquals(expected, bundle.screenParam<ReviewScreenParam>())
+        assertEquals(ARG_REVIEW_SCREEN, screenParamKey<ReviewScreenParam>())
+        // Legacy bridge key retained.
+        assertEquals(expected, bundle.parcelable<ReviewScreenParam>(KeyUtil.arg_model))
+        // Production reader parses the builder output.
+        assertEquals(expected, BottomReviewReader.fromBundle(bundle))
+    }
+}

--- a/app/src/androidTest/java/com/mxt/anitrend/navigation/ScreenParamRoundTripTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/navigation/ScreenParamRoundTripTest.kt
@@ -6,12 +6,20 @@ import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.mxt.anitrend.navigation.extension.asBundle
 import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
 import com.mxt.anitrend.navigation.model.CommentScreenParam
-import com.mxt.anitrend.navigation.model.FeedComposerScreenParam
+import com.mxt.anitrend.navigation.model.GiphyPreviewScreenParam
+import com.mxt.anitrend.navigation.model.ImagePreviewScreenParam
 import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.navigation.model.ReviewScreenParam
+import com.mxt.anitrend.navigation.model.ScreenParam
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
 import com.mxt.anitrend.navigation.model.StudioScreenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
+import com.mxt.anitrend.navigation.model.UserListScreenParam
 import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.navigation.model.VideoPlayerScreenParam
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -61,25 +69,51 @@ class ScreenParamRoundTripTest {
     }
 
     @Test
-    fun feedComposerScreenParamBundleRoundTripRetainsAllFields() {
-        val original = FeedComposerScreenParam(
-            feedId = 12L,
-            draftText = "draft",
-            recipientId = 8L,
-            recipientName = "Raki",
-        )
-        assertEquals(original, original.asBundle().screenParam<FeedComposerScreenParam>())
+    fun characterScreenParamBundleRoundTripRetainsAllFields() {
+        val original = CharacterScreenParam(characterId = 123L)
+        assertEquals(original, original.asBundle().screenParam<CharacterScreenParam>())
     }
 
     @Test
-    fun feedComposerScreenParamNullFieldsSurviveRoundTrip() {
-        val original = FeedComposerScreenParam()
-        val restored = original.asBundle().screenParam<FeedComposerScreenParam>()
-        assertEquals(original, restored)
-        assertNull(restored?.feedId)
-        assertNull(restored?.draftText)
-        assertNull(restored?.recipientId)
-        assertNull(restored?.recipientName)
+    fun staffScreenParamBundleRoundTripRetainsAllFields() {
+        val original = StaffScreenParam(staffId = 456L)
+        assertEquals(original, original.asBundle().screenParam<StaffScreenParam>())
+    }
+
+    @Test
+    fun imagePreviewScreenParamBundleRoundTripRetainsAllFields() {
+        val original = ImagePreviewScreenParam(url = "https://example.com/image.png")
+        assertEquals(original, original.asBundle().screenParam<ImagePreviewScreenParam>())
+    }
+
+    @Test
+    fun giphyPreviewScreenParamBundleRoundTripRetainsAllFields() {
+        val original = GiphyPreviewScreenParam(url = "https://example.com/preview.gif")
+        assertEquals(original, original.asBundle().screenParam<GiphyPreviewScreenParam>())
+    }
+
+    @Test
+    fun videoPlayerScreenParamBundleRoundTripRetainsAllFields() {
+        val original = VideoPlayerScreenParam(url = "https://example.com/video.mp4")
+        assertEquals(original, original.asBundle().screenParam<VideoPlayerScreenParam>())
+    }
+
+    @Test
+    fun userListScreenParamBundleRoundTripRetainsAllFields() {
+        val original = UserListScreenParam(userId = 15L, requestType = 2)
+        assertEquals(original, original.asBundle().screenParam<UserListScreenParam>())
+    }
+
+    @Test
+    fun trailerScreenParamBundleRoundTripRetainsAllFields() {
+        val original = TrailerScreenParam(trailerId = "abc123", site = "youtube")
+        assertEquals(original, original.asBundle().screenParam<TrailerScreenParam>())
+    }
+
+    @Test
+    fun settingsCategoryScreenParamBundleRoundTripRetainsAllFields() {
+        val original = SettingsCategoryScreenParam(categoryId = "general")
+        assertEquals(original, original.asBundle().screenParam<SettingsCategoryScreenParam>())
     }
 
     @Test

--- a/app/src/androidTest/java/com/mxt/anitrend/ui/EntryPointFixtures.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/ui/EntryPointFixtures.kt
@@ -2,6 +2,12 @@ package com.mxt.anitrend.ui
 
 import android.content.Context
 import android.content.Intent
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
+import com.mxt.anitrend.navigation.model.GiphyPreviewScreenParam
+import com.mxt.anitrend.navigation.model.ImagePreviewScreenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.navigation.model.VideoPlayerScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.activity.base.AboutActivity
 import com.mxt.anitrend.view.activity.base.GiphyPreviewActivity
@@ -96,7 +102,7 @@ internal object EntryPointFixtures {
                 .setType("text/plain")
                 .putExtra(Intent.EXTRA_TEXT, "https://example.com")
         }),
-    )
+    ) + typedMigratedEntries(context)
 
     fun authenticated(context: Context): List<EntryPoint> = listOf(
         // SplashActivity is intentionally excluded from render smoke tests because it immediately routes onward and performs startup side effects rather than exposing a stable UI surface.
@@ -160,6 +166,34 @@ internal object EntryPointFixtures {
                 .setClass(it, SharedContentActivity::class.java)
                 .setType("text/plain")
                 .putExtra(Intent.EXTRA_TEXT, "https://example.com")
+        }),
+    ) + typedMigratedEntries(context)
+
+    /**
+     * Typed [ScreenParam] entry points for the Phase 1 migrated destinations.
+     * The legacy-extra entries above stay in place to prove the fromIntent bridge;
+     * these prove the typed navigation path end to end. MediaBrowseActivity is
+     * intentionally absent: it has no destination identity (its title and filters
+     * stay on the legacy extras until Phase 2).
+     */
+    private fun typedMigratedEntries(context: Context): List<EntryPoint> = listOf(
+        EntryPoint("ProfileActivity-typed", {
+            ProfileActivity.newIntent(context, UserScreenParam(userId = 1L, initialName = "test-user"))
+        }),
+        EntryPoint("CharacterActivity-typed", {
+            CharacterActivity.newIntent(context, CharacterScreenParam(characterId = 1L))
+        }),
+        EntryPoint("StaffActivity-typed", {
+            StaffActivity.newIntent(context, StaffScreenParam(staffId = 1L))
+        }),
+        EntryPoint("ImagePreviewActivity-typed", {
+            ImagePreviewActivity.newIntent(context, ImagePreviewScreenParam(url = "https://example.com/image.png"))
+        }),
+        EntryPoint("GiphyPreviewActivity-typed", {
+            GiphyPreviewActivity.newIntent(context, GiphyPreviewScreenParam(url = "https://example.com/preview.gif"))
+        }),
+        EntryPoint("VideoPlayerActivity-typed", {
+            VideoPlayerActivity.newIntent(context, VideoPlayerScreenParam(url = "https://example.com/video.mp4"))
         }),
     )
 }

--- a/app/src/main/java/com/mxt/anitrend/base/custom/sheet/BottomSheetBase.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/sheet/BottomSheetBase.kt
@@ -79,6 +79,8 @@ abstract class BottomSheetBase<T> :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Toolbar presentation state (string-resource ids), not navigation identity:
+        // intentionally kept on the legacy bundle channel like other presentation reads.
         arguments?.let { args ->
             mTitle = args.getInt(KeyUtil.arg_title)
             mText = args.getInt(KeyUtil.arg_text)

--- a/app/src/main/java/com/mxt/anitrend/navigation/extension/NavigationArgs.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/extension/NavigationArgs.kt
@@ -17,36 +17,31 @@ object NavigationArgs {
      * Mirrors `Bundle.getBoolean(key, default)`: the stored value when the key is
      * present, otherwise [default].
      */
-    fun booleanWithDefault(containsKey: Boolean, value: Boolean, default: Boolean): Boolean =
-        if (containsKey) value else default
+    fun booleanWithDefault(containsKey: Boolean, value: Boolean, default: Boolean): Boolean = if (containsKey) value else default
 
     /**
      * Mirrors `Bundle.getInt(key, default)`: the stored value when the key is
      * present, otherwise [default].
      */
-    fun intWithDefault(containsKey: Boolean, value: Int, default: Int): Int =
-        if (containsKey) value else default
+    fun intWithDefault(containsKey: Boolean, value: Int, default: Int): Int = if (containsKey) value else default
 
     /**
      * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getBoolean(key) else null`
      * pattern: absent keys resolve to null, present keys resolve to the stored value.
      */
-    fun optionalBoolean(containsKey: Boolean, value: Boolean): Boolean? =
-        if (containsKey) value else null
+    fun optionalBoolean(containsKey: Boolean, value: Boolean): Boolean? = if (containsKey) value else null
 
     /**
      * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getString(key) else null`
      * pattern: absent keys resolve to null, present keys resolve to the stored value.
      */
-    fun optionalString(containsKey: Boolean, value: String?): String? =
-        if (containsKey) value else null
+    fun optionalString(containsKey: Boolean, value: String?): String? = if (containsKey) value else null
 
     /**
      * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getInt(key) else null`
      * pattern: absent keys resolve to null, present keys resolve to the stored value.
      */
-    fun optionalInt(containsKey: Boolean, value: Int): Int? =
-        if (containsKey) value else null
+    fun optionalInt(containsKey: Boolean, value: Int): Int? = if (containsKey) value else null
 
     /**
      * Mirrors the tri-state string-array-list pattern used by browse filters: absent
@@ -54,18 +49,15 @@ object NavigationArgs {
      * to the stored list. Empty lists are normalized to null downstream by the
      * ViewModel so an explicit empty list is never sent as real filter input.
      */
-    fun optionalStringList(containsKey: Boolean, value: List<String>?): List<String>? =
-        if (containsKey) value else null
+    fun optionalStringList(containsKey: Boolean, value: List<String>?): List<String>? = if (containsKey) value else null
 
     /**
      * Mirrors `bundle.getString(key)?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() }`.
      */
-    fun resolveActivityType(raw: String?): ActivityType? =
-        raw?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() }
+    fun resolveActivityType(raw: String?): ActivityType? = raw?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() }
 
     /**
      * Mirrors `bundle.getString(key)?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }`.
      */
-    fun resolveMediaType(raw: String?): MediaType? =
-        raw?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }
+    fun resolveMediaType(raw: String?): MediaType? = raw?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }
 }

--- a/app/src/main/java/com/mxt/anitrend/navigation/extension/NavigationArgs.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/extension/NavigationArgs.kt
@@ -1,0 +1,71 @@
+package com.mxt.anitrend.navigation.extension
+
+import com.mxt.anitrend.graphql.generated.ActivityType
+import com.mxt.anitrend.graphql.generated.MediaType
+
+/**
+ * Production parsing helpers for fragment navigation bundles.
+ *
+ * Fragment destinations that carry no stable identity (feed lists, browse filters)
+ * keep their values on the legacy bundle channel, but every read must go through
+ * these helpers so the exact `containsKey` / default semantics are captured in one
+ * reviewable place and are JVM-testable without a real [android.os.Bundle].
+ */
+object NavigationArgs {
+
+    /**
+     * Mirrors `Bundle.getBoolean(key, default)`: the stored value when the key is
+     * present, otherwise [default].
+     */
+    fun booleanWithDefault(containsKey: Boolean, value: Boolean, default: Boolean): Boolean =
+        if (containsKey) value else default
+
+    /**
+     * Mirrors `Bundle.getInt(key, default)`: the stored value when the key is
+     * present, otherwise [default].
+     */
+    fun intWithDefault(containsKey: Boolean, value: Int, default: Int): Int =
+        if (containsKey) value else default
+
+    /**
+     * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getBoolean(key) else null`
+     * pattern: absent keys resolve to null, present keys resolve to the stored value.
+     */
+    fun optionalBoolean(containsKey: Boolean, value: Boolean): Boolean? =
+        if (containsKey) value else null
+
+    /**
+     * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getString(key) else null`
+     * pattern: absent keys resolve to null, present keys resolve to the stored value.
+     */
+    fun optionalString(containsKey: Boolean, value: String?): String? =
+        if (containsKey) value else null
+
+    /**
+     * Mirrors the tri-state `if (bundle.containsKey(key)) bundle.getInt(key) else null`
+     * pattern: absent keys resolve to null, present keys resolve to the stored value.
+     */
+    fun optionalInt(containsKey: Boolean, value: Int): Int? =
+        if (containsKey) value else null
+
+    /**
+     * Mirrors the tri-state string-array-list pattern used by browse filters: absent
+     * keys resolve to null (semantically absent GraphQL input), present keys resolve
+     * to the stored list. Empty lists are normalized to null downstream by the
+     * ViewModel so an explicit empty list is never sent as real filter input.
+     */
+    fun optionalStringList(containsKey: Boolean, value: List<String>?): List<String>? =
+        if (containsKey) value else null
+
+    /**
+     * Mirrors `bundle.getString(key)?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() }`.
+     */
+    fun resolveActivityType(raw: String?): ActivityType? =
+        raw?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() }
+
+    /**
+     * Mirrors `bundle.getString(key)?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }`.
+     */
+    fun resolveMediaType(raw: String?): MediaType? =
+        raw?.let { runCatching { MediaType.valueOf(it) }.getOrNull() }
+}

--- a/app/src/main/java/com/mxt/anitrend/navigation/extension/ScreenParamExt.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/extension/ScreenParamExt.kt
@@ -4,13 +4,20 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
 import com.mxt.anitrend.navigation.model.CommentScreenParam
-import com.mxt.anitrend.navigation.model.FeedComposerScreenParam
+import com.mxt.anitrend.navigation.model.GiphyPreviewScreenParam
+import com.mxt.anitrend.navigation.model.ImagePreviewScreenParam
 import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.navigation.model.ReviewScreenParam
 import com.mxt.anitrend.navigation.model.ScreenParam
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
 import com.mxt.anitrend.navigation.model.StudioScreenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
+import com.mxt.anitrend.navigation.model.UserListScreenParam
 import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.navigation.model.VideoPlayerScreenParam
 
 /**
  * Stable wire keys for the representative screen parameter family.
@@ -24,8 +31,15 @@ const val ARG_USER_SCREEN = "arg.user.screen"
 const val ARG_MEDIA_SCREEN = "arg.media.screen"
 const val ARG_COMMENT_SCREEN = "arg.comment.screen"
 const val ARG_STUDIO_SCREEN = "arg.studio.screen"
-const val ARG_FEED_COMPOSER_SCREEN = "arg.feed.composer.screen"
 const val ARG_REVIEW_SCREEN = "arg.review.screen"
+const val ARG_CHARACTER_SCREEN = "arg.character.screen"
+const val ARG_STAFF_SCREEN = "arg.staff.screen"
+const val ARG_IMAGE_PREVIEW_SCREEN = "arg.image.preview.screen"
+const val ARG_GIPHY_PREVIEW_SCREEN = "arg.giphy.preview.screen"
+const val ARG_VIDEO_PLAYER_SCREEN = "arg.video.player.screen"
+const val ARG_USER_LIST_SCREEN = "arg.user.list.screen"
+const val ARG_TRAILER_SCREEN = "arg.trailer.screen"
+const val ARG_SETTINGS_CATEGORY_SCREEN = "arg.settings.category.screen"
 
 /**
  * Resolves the stable bundle key used for [T].
@@ -39,8 +53,15 @@ inline fun <reified T : ScreenParam> screenParamKey(): String = when (T::class) 
     MediaScreenParam::class -> ARG_MEDIA_SCREEN
     CommentScreenParam::class -> ARG_COMMENT_SCREEN
     StudioScreenParam::class -> ARG_STUDIO_SCREEN
-    FeedComposerScreenParam::class -> ARG_FEED_COMPOSER_SCREEN
     ReviewScreenParam::class -> ARG_REVIEW_SCREEN
+    CharacterScreenParam::class -> ARG_CHARACTER_SCREEN
+    StaffScreenParam::class -> ARG_STAFF_SCREEN
+    ImagePreviewScreenParam::class -> ARG_IMAGE_PREVIEW_SCREEN
+    GiphyPreviewScreenParam::class -> ARG_GIPHY_PREVIEW_SCREEN
+    VideoPlayerScreenParam::class -> ARG_VIDEO_PLAYER_SCREEN
+    UserListScreenParam::class -> ARG_USER_LIST_SCREEN
+    TrailerScreenParam::class -> ARG_TRAILER_SCREEN
+    SettingsCategoryScreenParam::class -> ARG_SETTINGS_CATEGORY_SCREEN
     else -> T::class.java.name
 }
 

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/CharacterScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/CharacterScreenParam.kt
@@ -1,0 +1,13 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for character destinations.
+ *
+ * @property characterId Stable AniList character id; the destination resolves current state by this id.
+ */
+@Parcelize
+data class CharacterScreenParam(
+    val characterId: Long,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/FeedComposerScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/FeedComposerScreenParam.kt
@@ -1,20 +1,22 @@
 package com.mxt.anitrend.navigation.model
 
+import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * Navigation parameter for the feed composer bottom sheet.
+ * Legacy parcelable draft argument for the feed composer bottom sheet.
  *
- * Carries only the identity and draft state required to reconstruct the editor:
- * - [feedId] is the stable feed id being edited, or null when composing a new feed.
- * - [draftText] is the initial editor text taken from the feed being edited.
- * - [recipientId] and [recipientName] identify the message recipient for message-feed
- *   mode (new message, or editing a previously sent message).
- *
- * It deliberately does not carry a canonical
+ * This is NOT identity navigation: it is a local draft/navigation bundle carried on
+ * the legacy `arg_model` parcelable channel (see BottomSheetComposer), predating the
+ * ScreenParam wire-key contract. It deliberately does not carry a canonical
  * [com.mxt.anitrend.model.entity.anilist.FeedList] or
- * [com.mxt.anitrend.model.entity.base.UserBase]. The destination resolves current
- * state by identity and the save routes through the domain interactor and store.
+ * [com.mxt.anitrend.model.entity.base.UserBase]; the save routes through the domain
+ * interactor and store.
+ *
+ * @property feedId Stable feed id being edited, or null when composing a new feed.
+ * @property draftText Initial editor text taken from the feed being edited.
+ * @property recipientId Stable recipient user id for message-feed mode.
+ * @property recipientName Recipient display name for message-feed mode.
  */
 @Parcelize
 data class FeedComposerScreenParam(
@@ -22,4 +24,4 @@ data class FeedComposerScreenParam(
     val draftText: String? = null,
     val recipientId: Long? = null,
     val recipientName: String? = null,
-) : ScreenParam
+) : Parcelable

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/GiphyPreviewScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/GiphyPreviewScreenParam.kt
@@ -1,0 +1,13 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the Giphy preview destination.
+ *
+ * @property url Stable Giphy media URL to preview.
+ */
+@Parcelize
+data class GiphyPreviewScreenParam(
+    val url: String,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/ImagePreviewScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/ImagePreviewScreenParam.kt
@@ -1,0 +1,13 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the image preview destination.
+ *
+ * @property url Stable content URL to preview.
+ */
+@Parcelize
+data class ImagePreviewScreenParam(
+    val url: String,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/SettingsCategoryScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/SettingsCategoryScreenParam.kt
@@ -1,0 +1,13 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the legacy settings category destination.
+ *
+ * @property categoryId Stable settings category id resolved by the destination.
+ */
+@Parcelize
+data class SettingsCategoryScreenParam(
+    val categoryId: String,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/StaffScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/StaffScreenParam.kt
@@ -1,0 +1,17 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for staff destinations.
+ *
+ * Identity-only: carries the stable staff id. The tri-state `onList` media-list
+ * filter stays on the legacy `arg_onList` transitional channel until the pager
+ * fragments migrate to typed arguments (Phase 2).
+ *
+ * @property staffId Stable AniList staff id; the destination resolves current state by this id.
+ */
+@Parcelize
+data class StaffScreenParam(
+    val staffId: Long,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/TrailerScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/TrailerScreenParam.kt
@@ -1,0 +1,19 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the YouTube embed destination.
+ *
+ * Identity-only: the embed resolves its video URL from the stable trailer id and
+ * site, so the [com.mxt.anitrend.model.entity.anilist.meta.MediaTrailer] entity is
+ * never parceled into the fragment bundle.
+ *
+ * @property trailerId Stable trailer id (e.g. YouTube video id).
+ * @property site Trailer host site (e.g. "youtube").
+ */
+@Parcelize
+data class TrailerScreenParam(
+    val trailerId: String,
+    val site: String,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/UserListScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/UserListScreenParam.kt
@@ -1,0 +1,16 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the user list bottom sheet (followers/following).
+ *
+ * @property userId Stable AniList user id whose connections are listed.
+ * @property requestType Request discriminator selecting the connection query
+ * (followers vs following).
+ */
+@Parcelize
+data class UserListScreenParam(
+    val userId: Long,
+    val requestType: Int = 0,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/UserScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/UserScreenParam.kt
@@ -6,7 +6,8 @@ import kotlinx.parcelize.Parcelize
  * Navigation parameter for user destinations.
  *
  * @property userId Stable AniList user id; the destination resolves current state by this id.
- * @property initialName Optional display name shown before data loads.
+ * @property initialName Optional user name. Shown before data loads and used as the
+ * lookup identity when [userId] is absent (e.g. name-based deep links).
  */
 @Parcelize
 data class UserScreenParam(

--- a/app/src/main/java/com/mxt/anitrend/navigation/model/VideoPlayerScreenParam.kt
+++ b/app/src/main/java/com/mxt/anitrend/navigation/model/VideoPlayerScreenParam.kt
@@ -1,0 +1,13 @@
+package com.mxt.anitrend.navigation.model
+
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Navigation parameter for the video player destination.
+ *
+ * @property url Stable content URL to play.
+ */
+@Parcelize
+data class VideoPlayerScreenParam(
+    val url: String,
+) : ScreenParam

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivity.kt
@@ -17,6 +17,9 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityGiphyPreviewBinding
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.GiphyPreviewScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -26,18 +29,52 @@ class GiphyPreviewActivity :
     CommonActivity(),
     RequestListener<Drawable> {
 
-    data class Args(val modelUrl: String)
-
     companion object {
-        fun newIntent(context: Context, modelUrl: String): Intent = Intent(context, GiphyPreviewActivity::class.java).apply {
-            putExtra(KeyUtil.arg_model, modelUrl)
+        fun newIntent(context: Context, param: GiphyPreviewScreenParam): Intent = Intent(context, GiphyPreviewActivity::class.java).apply {
+            putScreenParam(param)
+            // Interim boundary: keep the legacy wire key alongside the typed param
+            // until all pre-bridge callers and fixtures migrate.
+            putExtra(KeyUtil.arg_model, param.url)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
-        fun fromIntent(intent: Intent): Args? = parseArgs(intent.getStringExtra(KeyUtil.arg_model))
+        /**
+         * Compatibility overload preserving the legacy URL-based callers. Bridges
+         * into the typed parameter so navigation always uses [GiphyPreviewScreenParam].
+         */
+        fun newIntent(context: Context, modelUrl: String): Intent = newIntent(context, GiphyPreviewScreenParam(url = modelUrl))
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Pre-bridge callers still write the
+         * legacy [KeyUtil.arg_model] extra, so that value is bridged here via
+         * [resolve]. The bridge is a scalar conversion point inside the activity,
+         * not a parcel path for any remote model.
+         */
+        fun fromIntent(intent: Intent): GiphyPreviewScreenParam? = resolve(
+            typed = intent.screenParam<GiphyPreviewScreenParam>(),
+            legacyUrl = intent.getStringExtra(KeyUtil.arg_model),
+        )
+
+        /**
+         * Production parsing rule for the Giphy preview destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * non-empty url. Otherwise the legacy [KeyUtil.arg_model] extra is bridged
+         * via [parseUrl]. Blank strings remain valid, preserving the pre-refactor
+         * `isNullOrEmpty` contract.
+         */
+        @VisibleForTesting
+        internal fun resolve(typed: GiphyPreviewScreenParam?, legacyUrl: String?): GiphyPreviewScreenParam? {
+            typed?.let { param ->
+                return if (param.url.isNotEmpty()) param else null
+            }
+            return parseUrl(legacyUrl)
+        }
 
         @VisibleForTesting
-        internal fun parseArgs(raw: String?): Args? = if (!raw.isNullOrEmpty()) Args(raw) else null
+        internal fun parseUrl(raw: String?): GiphyPreviewScreenParam? = if (!raw.isNullOrEmpty()) GiphyPreviewScreenParam(url = raw) else null
     }
 
     private lateinit var binding: ActivityGiphyPreviewBinding
@@ -59,7 +96,7 @@ class GiphyPreviewActivity :
         if (args != null) {
             Glide
                 .with(this)
-                .load(args.modelUrl)
+                .load(args.url)
                 .listener(this)
                 .into(binding.previewImage)
         } else {

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivity.kt
@@ -21,6 +21,9 @@ import androidx.core.net.toUri
 import com.bumptech.glide.Glide
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityImagePreviewBinding
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.ImagePreviewScreenParam
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -29,18 +32,52 @@ import timber.log.Timber
 
 class ImagePreviewActivity : CommonActivity() {
 
-    data class Args(val modelUrl: String)
-
     companion object {
-        fun newIntent(context: Context, modelUrl: String): Intent = Intent(context, ImagePreviewActivity::class.java).apply {
-            putExtra(KeyUtil.arg_model, modelUrl)
+        fun newIntent(context: Context, param: ImagePreviewScreenParam): Intent = Intent(context, ImagePreviewActivity::class.java).apply {
+            putScreenParam(param)
+            // Interim boundary: keep the legacy wire key alongside the typed param
+            // until all pre-bridge callers and fixtures migrate.
+            putExtra(KeyUtil.arg_model, param.url)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
-        fun fromIntent(intent: Intent): Args? = parseArgs(intent.getStringExtra(KeyUtil.arg_model))
+        /**
+         * Compatibility overload preserving the legacy URL-based callers. Bridges
+         * into the typed parameter so navigation always uses [ImagePreviewScreenParam].
+         */
+        fun newIntent(context: Context, modelUrl: String): Intent = newIntent(context, ImagePreviewScreenParam(url = modelUrl))
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Pre-bridge callers still write the
+         * legacy [KeyUtil.arg_model] extra, so that value is bridged here via
+         * [resolve]. The bridge is a scalar conversion point inside the activity,
+         * not a parcel path for any remote model.
+         */
+        fun fromIntent(intent: Intent): ImagePreviewScreenParam? = resolve(
+            typed = intent.screenParam<ImagePreviewScreenParam>(),
+            legacyUrl = intent.getStringExtra(KeyUtil.arg_model),
+        )
+
+        /**
+         * Production parsing rule for the image preview destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * non-empty url. Otherwise the legacy [KeyUtil.arg_model] extra is bridged
+         * via [parseUrl]. Blank strings remain valid, preserving the pre-refactor
+         * `isNullOrEmpty` contract.
+         */
+        @VisibleForTesting
+        internal fun resolve(typed: ImagePreviewScreenParam?, legacyUrl: String?): ImagePreviewScreenParam? {
+            typed?.let { param ->
+                return if (param.url.isNotEmpty()) param else null
+            }
+            return parseUrl(legacyUrl)
+        }
 
         @VisibleForTesting
-        internal fun parseArgs(raw: String?): Args? = if (!raw.isNullOrEmpty()) Args(raw) else null
+        internal fun parseUrl(raw: String?): ImagePreviewScreenParam? = if (!raw.isNullOrEmpty()) ImagePreviewScreenParam(url = raw) else null
 
         private const val REQUEST_PERMISSION = 102
     }
@@ -74,8 +111,8 @@ class ImagePreviewActivity : CommonActivity() {
 
         val args = fromIntent(intent)
         if (args != null) {
-            imageUri = args.modelUrl
-            Glide.with(this).load(args.modelUrl).into(binding.previewImage)
+            imageUri = args.url
+            Glide.with(this).load(args.url).into(binding.previewImage)
         } else {
             NotifyUtil.makeText(
                 this,

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivity.kt
@@ -11,6 +11,9 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.ActivityVideoPlayerBinding
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.VideoPlayerScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.view.activity.CommonActivity
@@ -18,22 +21,52 @@ import timber.log.Timber
 
 class VideoPlayerActivity : CommonActivity() {
 
-    /**
-     * Navigation args for [VideoPlayerActivity]. Use [newIntent] to build and
-     * [fromIntent] to read. Wire format key: [KeyUtil.arg_model].
-     */
-    data class Args(val contentLink: String)
-
     companion object {
-        fun newIntent(context: Context, contentLink: String): Intent = Intent(context, VideoPlayerActivity::class.java).apply {
-            putExtra(KeyUtil.arg_model, contentLink)
+        fun newIntent(context: Context, param: VideoPlayerScreenParam): Intent = Intent(context, VideoPlayerActivity::class.java).apply {
+            putScreenParam(param)
+            // Interim boundary: keep the legacy wire key alongside the typed param
+            // until all pre-bridge callers and fixtures migrate.
+            putExtra(KeyUtil.arg_model, param.url)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
-        fun fromIntent(intent: Intent): Args? = parseArgs(intent.getStringExtra(KeyUtil.arg_model))
+        /**
+         * Compatibility overload preserving the legacy URL-based callers. Bridges
+         * into the typed parameter so navigation always uses [VideoPlayerScreenParam].
+         */
+        fun newIntent(context: Context, contentLink: String): Intent = newIntent(context, VideoPlayerScreenParam(url = contentLink))
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Pre-bridge callers still write the
+         * legacy [KeyUtil.arg_model] extra, so that value is bridged here via
+         * [resolve]. The bridge is a scalar conversion point inside the activity,
+         * not a parcel path for any remote model.
+         */
+        fun fromIntent(intent: Intent): VideoPlayerScreenParam? = resolve(
+            typed = intent.screenParam<VideoPlayerScreenParam>(),
+            legacyUrl = intent.getStringExtra(KeyUtil.arg_model),
+        )
+
+        /**
+         * Production parsing rule for the video player destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * non-empty url. Otherwise the legacy [KeyUtil.arg_model] extra is bridged
+         * via [parseUrl]. Blank strings remain valid, preserving the pre-refactor
+         * `isNullOrEmpty` contract.
+         */
+        @VisibleForTesting
+        internal fun resolve(typed: VideoPlayerScreenParam?, legacyUrl: String?): VideoPlayerScreenParam? {
+            typed?.let { param ->
+                return if (param.url.isNotEmpty()) param else null
+            }
+            return parseUrl(legacyUrl)
+        }
 
         @VisibleForTesting
-        internal fun parseArgs(raw: String?): Args? = if (!raw.isNullOrEmpty()) Args(raw) else null
+        internal fun parseUrl(raw: String?): VideoPlayerScreenParam? = if (!raw.isNullOrEmpty()) VideoPlayerScreenParam(url = raw) else null
     }
 
     private var contentLink: String? = null
@@ -48,8 +81,8 @@ class VideoPlayerActivity : CommonActivity() {
 
         val args = fromIntent(intent)
         if (args != null) {
-            contentLink = args.contentLink
-            startPlayer(args.contentLink)
+            contentLink = args.url
+            startPlayer(args.url)
         } else {
             NotifyUtil.makeText(
                 this,

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/CharacterActivity.kt
@@ -1,5 +1,6 @@
 package com.mxt.anitrend.view.activity.detail
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
@@ -7,6 +8,7 @@ import android.view.MenuItem
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -18,6 +20,9 @@ import com.mxt.anitrend.base.custom.view.widget.FavouriteWidgetRenderState
 import com.mxt.anitrend.databinding.ActivityCharacterBinding
 import com.mxt.anitrend.domain.model.CharacterRecord
 import com.mxt.anitrend.extension.KoinExt
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -34,6 +39,54 @@ import java.util.Locale
  * character activity
  */
 class CharacterActivity : CommonActivity() {
+
+    companion object {
+        fun newIntent(context: Context, param: CharacterScreenParam): Intent = Intent(context, CharacterActivity::class.java).apply {
+            putScreenParam(param)
+            // Interim boundary: the pager and its fragments still consume the legacy
+            // wire key from the activity extras, so keep it alongside the typed param.
+            putExtra(KeyUtil.arg_id, param.characterId)
+        }
+
+        /**
+         * Compatibility overload preserving the legacy id-based callers. Bridges into
+         * the typed parameter so navigation always uses [CharacterScreenParam].
+         */
+        fun newIntent(context: Context, id: Long): Intent = newIntent(context, CharacterScreenParam(characterId = id))
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Deep links (injected by
+         * [IntentBundleUtil.checkIntentData]) and pre-bridge callers still write the
+         * legacy [KeyUtil.arg_id] extra, so that value is bridged here into
+         * [CharacterScreenParam] via [resolve]. The bridge is a scalar conversion
+         * point inside the activity, not a parcel path for the character entity.
+         *
+         * A null result keeps the pre-refactor invalid-ID behaviour: the activity
+         * renders its in-layout error state (via the ViewModel) instead of finishing.
+         */
+        fun fromIntent(intent: Intent): CharacterScreenParam? = resolve(
+            typed = intent.screenParam<CharacterScreenParam>(),
+            legacyId = intent.getLongExtra(KeyUtil.arg_id, -1),
+        )
+
+        /**
+         * Production parsing rule for the character destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * positive id. Otherwise the legacy [KeyUtil.arg_id] extra is bridged when
+         * positive. Missing or non-positive ids resolve to null so the activity
+         * keeps its default (invalid) state.
+         */
+        @VisibleForTesting
+        internal fun resolve(typed: CharacterScreenParam?, legacyId: Long): CharacterScreenParam? {
+            typed?.let { param ->
+                return if (param.characterId > 0) param else null
+            }
+            return if (legacyId > 0) CharacterScreenParam(characterId = legacyId) else null
+        }
+    }
 
     private lateinit var binding: ActivityCharacterBinding
 
@@ -58,8 +111,12 @@ class CharacterActivity : CommonActivity() {
             characterViewModel.load(characterId)
         }
 
-        if (intent.hasExtra(KeyUtil.arg_id)) {
-            characterId = intent.getLongExtra(KeyUtil.arg_id, -1)
+        // Resolve the destination through the typed parameter, falling back to the
+        // legacy wire key for deep links and pre-bridge callers. A null result keeps
+        // the pre-refactor invalid-ID behaviour: the id stays 0 and the ViewModel
+        // renders the in-layout error state.
+        fromIntent(intent)?.let { args ->
+            characterId = args.characterId
         }
 
         observeViewModel()

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaBrowseActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/MediaBrowseActivity.kt
@@ -19,6 +19,9 @@ class MediaBrowseActivity : CommonActivity() {
         setSupportActionBar(binding.customToolbar.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
+        // The browse destination has no identity of its own; the toolbar title and
+        // all browse filters travel through the legacy extras (transitional channel)
+        // until the fragment arguments migrate to typed parameters (Phase 2).
         intent.getStringExtra(KeyUtil.arg_activity_tag)?.let { tag ->
             supportActionBar?.title = MarkDownUtil.convert(this, tag)
         }

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/ProfileActivity.kt
@@ -1,5 +1,6 @@
 package com.mxt.anitrend.view.activity.detail
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
@@ -8,6 +9,7 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -21,6 +23,9 @@ import com.mxt.anitrend.base.custom.view.image.WideImageView
 import com.mxt.anitrend.databinding.ActivityProfileBinding
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.IntentBundleUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -41,6 +46,81 @@ import java.util.Locale
 class ProfileActivity :
     CommonActivity(),
     View.OnClickListener {
+
+    companion object {
+        fun newIntent(context: Context, param: UserScreenParam): Intent = Intent(context, ProfileActivity::class.java).apply {
+            putScreenParam(param)
+            // Interim boundary: the pager fragments and the profile stats widget still
+            // consume the legacy wire keys from the activity extras, so keep them
+            // alongside the typed param.
+            putExtra(KeyUtil.arg_id, param.userId)
+            putExtra(KeyUtil.arg_userName, param.initialName)
+        }
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Deep links (injected by
+         * [IntentBundleUtil.checkIntentData]) and pre-bridge callers still write the
+         * legacy [KeyUtil.arg_id] and [KeyUtil.arg_userName] extras, so those values
+         * are bridged here into [UserScreenParam] via [resolve]. The bridge is a
+         * scalar conversion point inside the activity, not a parcel path for the
+         * user entity.
+         */
+        fun fromIntent(intent: Intent): UserScreenParam? = resolve(
+            typed = intent.screenParam<UserScreenParam>(),
+            legacyId = intent.getLongExtra(KeyUtil.arg_id, -1),
+            legacyName = intent.getStringExtra(KeyUtil.arg_userName),
+        )
+
+        /**
+         * Production parsing rule for the profile destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * positive user id or a non-blank name. Otherwise the legacy [KeyUtil.arg_id]
+         * and [KeyUtil.arg_userName] extras are bridged when either carries identity.
+         * A null result keeps the pre-refactor no-identity behaviour: the pager stays
+         * hidden and the error state is rendered in onResume.
+         */
+        @VisibleForTesting
+        internal fun resolve(
+            typed: UserScreenParam?,
+            legacyId: Long,
+            legacyName: String?,
+        ): UserScreenParam? {
+            typed?.let { param ->
+                return if (param.userId > 0L || !param.initialName.isNullOrBlank()) param else null
+            }
+            return if (legacyId > 0L || !legacyName.isNullOrBlank()) {
+                UserScreenParam(userId = if (legacyId > 0L) legacyId else 0L, initialName = legacyName)
+            } else {
+                null
+            }
+        }
+
+        /**
+         * Resolves the legacy media-list redirect from the launch intent.
+         *
+         * Deep links (e.g. anilist.co/user/{name}/animelist) inject
+         * [KeyUtil.arg_mediaType] before onCreate; when present, the profile
+         * forwards its full extras to MediaListActivity instead of rendering
+         * profile content. This is a scalar conversion point inside the activity,
+         * not part of the identity parameter.
+         */
+        fun redirectToMediaList(intent: Intent): Boolean = hasMediaListRedirect(intent)
+
+        /**
+         * Production parsing rule for the media-list redirect: mirrors the exact
+         * legacy `Intent.hasExtra(KeyUtil.arg_mediaType)` semantics. The routing
+         * decision depends only on key presence in the extras bundle, never on the
+         * stored value's type or nullness: an explicitly present null or a non-String
+         * value (e.g. a numeric extra) still triggers the redirect, exactly as the
+         * legacy `hasExtra` check did, whereas a `getStringExtra`-based check would
+         * have missed those cases.
+         */
+        @VisibleForTesting
+        internal fun hasMediaListRedirect(intent: Intent): Boolean = intent.hasExtra(KeyUtil.arg_mediaType)
+    }
 
     private lateinit var binding: ActivityProfileBinding
 
@@ -73,13 +153,17 @@ class ProfileActivity :
             profileViewModel.load(userId, userName)
         }
 
-        if (intent.hasExtra(KeyUtil.arg_id)) {
-            userId = intent.getLongExtra(KeyUtil.arg_id, -1)
+        // Resolve the destination through the typed parameter, falling back to the
+        // legacy wire keys for deep links and pre-bridge callers. A null result keeps
+        // the existing no-identity behaviour: the pager stays hidden and the error
+        // state is rendered in onResume.
+        fromIntent(intent)?.let { args ->
+            userId = args.userId
+            userName = args.initialName
         }
-        if (intent.hasExtra(KeyUtil.arg_userName)) {
-            userName = intent.getStringExtra(KeyUtil.arg_userName)
-        }
-        if (intent.hasExtra(KeyUtil.arg_mediaType)) {
+        // Legacy deep-link routing: animelist/mangalist profile links forward the
+        // full extras to MediaListActivity instead of rendering profile content.
+        if (redirectToMediaList(intent)) {
             val intent =
                 Intent(this, MediaListActivity::class.java).apply {
                     putExtras(this@ProfileActivity.intent.extras ?: Bundle())

--- a/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/detail/StaffActivity.kt
@@ -1,5 +1,6 @@
 package com.mxt.anitrend.view.activity.detail
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
@@ -7,6 +8,7 @@ import android.view.MenuItem
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -19,6 +21,9 @@ import com.mxt.anitrend.databinding.ActivityStaffBinding
 import com.mxt.anitrend.domain.model.StaffRecord
 import com.mxt.anitrend.extension.KoinExt
 import com.mxt.anitrend.extension.serializableExtra
+import com.mxt.anitrend.navigation.extension.putScreenParam
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.IntentBundleUtil
@@ -38,6 +43,53 @@ import java.util.Locale
  * staff activity
  */
 class StaffActivity : CommonActivity() {
+
+    companion object {
+        fun newIntent(context: Context, param: StaffScreenParam): Intent = Intent(context, StaffActivity::class.java).apply {
+            putScreenParam(param)
+        }
+
+        /**
+         * Compatibility overload preserving the legacy id-based callers. Bridges into
+         * the typed parameter so navigation always uses [StaffScreenParam].
+         */
+        fun newIntent(context: Context, id: Long): Intent = newIntent(context, StaffScreenParam(staffId = id))
+
+        /**
+         * Resolves the typed parameter from the intent.
+         *
+         * The typed parameter is read first. Deep links (injected by
+         * [IntentBundleUtil.checkIntentData]) and pre-bridge callers still write the
+         * legacy [KeyUtil.arg_id] extra, so that value is bridged here into
+         * [StaffScreenParam] via [resolve]. The bridge is a scalar conversion point
+         * inside the activity, not a parcel path for the staff entity. The tri-state
+         * [KeyUtil.arg_onList] filter stays on the legacy transitional channel and is
+         * read directly by the activity.
+         *
+         * A null result keeps the pre-refactor invalid-ID behaviour: the activity
+         * renders its in-layout error state (via the ViewModel) instead of finishing.
+         */
+        fun fromIntent(intent: Intent): StaffScreenParam? = resolve(
+            typed = intent.screenParam<StaffScreenParam>(),
+            legacyId = intent.getLongExtra(KeyUtil.arg_id, -1),
+        )
+
+        /**
+         * Production parsing rule for the staff destination.
+         *
+         * A present typed parameter wins; it is accepted only when it carries a
+         * positive id. Otherwise the legacy [KeyUtil.arg_id] extra is bridged when
+         * positive. Missing or non-positive ids resolve to null so the activity
+         * keeps its default (invalid) state.
+         */
+        @VisibleForTesting
+        internal fun resolve(typed: StaffScreenParam?, legacyId: Long): StaffScreenParam? {
+            typed?.let { param ->
+                return if (param.staffId > 0) param else null
+            }
+            return if (legacyId > 0) StaffScreenParam(staffId = legacyId) else null
+        }
+    }
 
     private lateinit var binding: ActivityStaffBinding
 
@@ -67,8 +119,13 @@ class StaffActivity : CommonActivity() {
             staffViewModel.load(staffId)
         }
 
-        if (intent.hasExtra(KeyUtil.arg_id)) {
-            staffId = intent.getLongExtra(KeyUtil.arg_id, -1)
+        // Resolve the destination through the typed parameter, falling back to the
+        // legacy wire key for deep links and pre-bridge callers. A null result keeps
+        // the pre-refactor invalid-ID behaviour: the id stays 0 and the ViewModel
+        // renders the in-layout error state. The onList filter is read directly from
+        // the legacy transitional channel.
+        fromIntent(intent)?.let { args ->
+            staffId = args.staffId
         }
         onList = intent.serializableExtra(KeyUtil.arg_onList)
 

--- a/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/index/MainActivity.kt
@@ -11,6 +11,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.core.net.toUri
 import androidx.core.view.GravityCompat
@@ -47,7 +48,7 @@ import com.mxt.anitrend.extension.LAZY_MODE_UNSAFE
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.extension.requestNotificationsPermission
-import com.mxt.anitrend.extension.startNewActivity
+import com.mxt.anitrend.navigation.model.UserScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -226,7 +227,7 @@ class MainActivity :
         }
 
         if (savedInstanceState == null) {
-            redirectShortcut = intent.getIntExtra(KeyUtil.arg_redirect, 0)
+            redirectShortcut = fromIntent(intent)
         }
         mNavigationView.itemBackground = getCompatDrawable(R.drawable.nav_background)
         mNavigationView.setNavigationItemSelectedListener(this)
@@ -641,10 +642,13 @@ class MainActivity :
             if (settings.isAuthenticated) {
                 val user = mainViewModel.currentUser()
                 if (user != null) {
-                    startNewActivity<ProfileActivity>(
-                        Bundle().apply {
-                            putString(KeyUtil.arg_userName, user.name)
-                        },
+                    // Name-only identity preserves the legacy redirect behaviour:
+                    // the profile resolves the current user by name, not by id.
+                    startActivity(
+                        ProfileActivity.newIntent(
+                            this,
+                            UserScreenParam(userId = 0L, initialName = user.name),
+                        ),
                     )
                 } else {
                     NotifyUtil
@@ -681,5 +685,31 @@ class MainActivity :
 
     companion object {
         private const val KEY_SEARCH_VIEW_QUERY = "SEARCH_VIEW_QUERY"
+
+        /**
+         * The legacy shortcut redirect channel is an int nav-item id targeting a
+         * drawer tab; it is launch state, not entity identity, so it stays a scalar
+         * wire value instead of a [com.mxt.anitrend.navigation.model.ScreenParam].
+         */
+        const val NO_REDIRECT = 0
+
+        /**
+         * Reads the legacy shortcut redirect target from the launch intent.
+         *
+         * Legacy launcher shortcuts (and pre-update persisted shortcut intents)
+         * write [KeyUtil.arg_redirect] with a drawer nav-item id. The value is
+         * normalized via [resolveRedirect]; the saved-state channel keeps using the
+         * same legacy key and is handled separately in onSaveInstanceState/onCreate.
+         */
+        fun fromIntent(intent: Intent): Int = resolveRedirect(intent.getIntExtra(KeyUtil.arg_redirect, NO_REDIRECT))
+
+        /**
+         * Production parsing rule for the shortcut redirect: only positive nav-item
+         * ids are valid redirects. Missing (0) or garbage (non-positive) values
+         * resolve to [NO_REDIRECT], preserving the pre-refactor default behaviour
+         * for absent extras and guarding against invalid nav ids.
+         */
+        @VisibleForTesting
+        internal fun resolveRedirect(rawRedirect: Int): Int = if (rawRedirect > 0) rawRedirect else NO_REDIRECT
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/BrowseReviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/BrowseReviewFragment.kt
@@ -7,6 +7,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -61,14 +62,23 @@ class BrowseReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<Review
                 arguments = args
             }
         }
+
+        /**
+         * Documented legacy channel: the review media type is filter state, not
+         * identity. It stays on arg_mediaType (set per tab by ReviewPageAdapter)
+         * until a browse-review state model is designed. Reads mirror the
+         * pre-refactor getter exactly (absent → null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyType(bundle?.getString(KeyUtil.arg_mediaType))
+
+        @VisibleForTesting
+        internal fun resolveLegacyType(raw: String?): String? = raw
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaType = args.getString(KeyUtil.arg_mediaType)
-        }
+        mediaType = fromBundle(arguments)
         isPager = true
         mColumnSize = R.integer.single_list_x1
         isFilterableEnabled = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CharacterOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CharacterOverviewFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -14,6 +15,8 @@ import com.mxt.anitrend.binding.htmlText
 import com.mxt.anitrend.databinding.FragmentCharacterOverviewBinding
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.anilist.MediaCharacter
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.viewmodel.CharacterOverviewViewModel
@@ -35,12 +38,35 @@ class CharacterOverviewFragment : Fragment() {
         fun newInstance(args: Bundle): CharacterOverviewFragment = CharacterOverviewFragment().apply {
             arguments = args
         }
+
+        /**
+         * Resolves the character identity from the fragment arguments.
+         *
+         * The typed [CharacterScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] extra is bridged with its exact raw value (0 or
+         * negative ids pass through, mirroring the pre-refactor getter).
+         */
+        fun fromBundle(bundle: Bundle?): CharacterScreenParam? = resolve(
+            typed = bundle?.screenParam<CharacterScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: CharacterScreenParam?, legacyId: Long): CharacterScreenParam? {
+            typed?.let { param ->
+                if (param.characterId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy value.
+            }
+            return CharacterScreenParam(characterId = legacyId)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            characterId = args.getLong(KeyUtil.arg_id)
+        // Resolve the destination through the typed character parameter, falling back
+        // to the legacy wire key forwarded by the pager/activity for pre-bridge callers.
+        fromBundle(arguments)?.let { args ->
+            characterId = args.characterId
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/CommentFragment.kt
@@ -67,11 +67,19 @@ class CommentFragment : FragmentBaseComment() {
         fun newInstance(params: Bundle): CommentFragment = CommentFragment().apply {
             arguments = params
         }
+
+        /**
+         * Documented legacy channel: the comment host activity (CommentActivity)
+         * writes only the legacy arg_id extra, so the thread-id read stays on the
+         * transitional channel. Reads mirror the pre-refactor getter exactly
+         * (absent resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): Long = bundle?.getLong(KeyUtil.arg_id) ?: 0L
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        userActivityId = arguments?.getLong(KeyUtil.arg_id) ?: 0L
+        userActivityId = fromBundle(arguments)
         mColumnSize = R.integer.single_list_x1
         setInflateMenu(R.menu.custom_menu)
 

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaFeedFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaFeedFragment.kt
@@ -2,9 +2,13 @@ package com.mxt.anitrend.view.fragment.detail
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.mxt.anitrend.navigation.extension.NavigationArgs
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.fragment.list.FeedListFragment
 import com.mxt.anitrend.viewmodel.MediaFeedViewModel
@@ -17,6 +21,8 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
  */
 class MediaFeedFragment : FeedListFragment() {
     private val mediaFeedViewModel: MediaFeedViewModel by viewModel()
+
+    private var mediaId: Long = 0
 
     companion object {
         @JvmStatic
@@ -31,12 +37,34 @@ class MediaFeedFragment : FeedListFragment() {
                 arguments = args
             }
         }
+
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_mediaId] extra is bridged with its exact raw value
+         * (0 or negative ids pass through, mirroring the pre-refactor getter).
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyMediaId = bundle?.getLong(KeyUtil.arg_mediaId, 0) ?: 0,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyMediaId: Long): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy value.
+            }
+            return MediaScreenParam(mediaId = legacyMediaId)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         isMenuDisabled = true
         isFeed = false
+        mediaId = fromBundle(arguments)?.mediaId ?: 0
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -64,10 +92,10 @@ class MediaFeedFragment : FeedListFragment() {
     override fun makeRequest() {
         val args = arguments ?: return
         mediaFeedViewModel.load(
-            mediaId = args.getLong(KeyUtil.arg_mediaId, 0),
-            isFollowing = args.getBoolean(KeyUtil.arg_isFollowing, true),
+            mediaId = mediaId,
+            isFollowing = NavigationArgs.booleanWithDefault(args.containsKey(KeyUtil.arg_isFollowing), args.getBoolean(KeyUtil.arg_isFollowing), default = true),
             page = mScrollListener.currentPage,
-            pageLimit = args.getInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT),
+            pageLimit = NavigationArgs.intWithDefault(args.containsKey(KeyUtil.arg_page_limit), args.getInt(KeyUtil.arg_page_limit), KeyUtil.PAGING_LIMIT),
             currentUserId = currentUserId(),
         )
     }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaOverviewFragment.kt
@@ -31,6 +31,9 @@ import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.anilist.Genre
 import com.mxt.anitrend.model.entity.anilist.MediaTag
 import com.mxt.anitrend.model.entity.anilist.meta.MediaTrailer
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -43,6 +46,7 @@ import com.mxt.anitrend.viewmodel.MediaOverviewViewModel
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import androidx.annotation.VisibleForTesting
 
 /**
  * Created by max on 2017/12/31.
@@ -71,9 +75,11 @@ class MediaOverviewFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (arguments != null) {
-            mediaId = arguments?.getLong(KeyUtil.arg_id) ?: 0
-            mediaType = arguments?.getString(KeyUtil.arg_mediaType)
+        // Resolve the destination through the typed media parameter, falling back to
+        // the legacy wire keys forwarded by the pager/activity for pre-bridge callers.
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
     }
 
@@ -152,8 +158,15 @@ class MediaOverviewFragment : Fragment() {
         val ctx = requireContext()
         val trailer = record.trailer?.let { MediaTrailer(id = it.id, site = it.site) }
         if (activity != null && trailer != null && CompatUtil.equals(trailer.site, "youtube")) {
+            // Identity-only navigation: the trailer entity is never parceled; only the
+            // stable trailer id and site travel in TrailerScreenParam.
             childFragmentManager.beginTransaction()
-                .replace(R.id.youtube_view, YouTubeEmbedFragment.newInstance(trailer))
+                .replace(
+                    R.id.youtube_view,
+                    YouTubeEmbedFragment.newInstance(
+                        TrailerScreenParam(trailerId = trailer.id.orEmpty(), site = trailer.site.orEmpty()),
+                    ),
+                )
                 .commit()
         } else {
             binding.youtubeView.visibility = View.GONE
@@ -367,6 +380,30 @@ class MediaOverviewFragment : Fragment() {
             val fragment = MediaOverviewFragment()
             fragment.arguments = args
             return fragment
+        }
+
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStaffFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStaffFragment.kt
@@ -16,6 +16,9 @@ import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.group.RecyclerItem
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.collection.GroupingUtil
@@ -38,6 +41,31 @@ class MediaStaffFragment : FragmentBaseList<RecyclerItem, ConnectionContainer<Ed
     private val mediaStaffViewModel: MediaStaffViewModel by viewModel()
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): MediaStaffFragment = MediaStaffFragment().apply {
             arguments = args
@@ -47,9 +75,9 @@ class MediaStaffFragment : FragmentBaseList<RecyclerItem, ConnectionContainer<Ed
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStaffFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStaffFragment.kt
@@ -65,7 +65,6 @@ class MediaStaffFragment : FragmentBaseList<RecyclerItem, ConnectionContainer<Ed
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): MediaStaffFragment = MediaStaffFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStatsFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStatsFragment.kt
@@ -39,6 +39,9 @@ import com.mxt.anitrend.model.entity.anilist.meta.ScoreDistribution
 import com.mxt.anitrend.model.entity.anilist.meta.StatusDistribution
 import com.mxt.anitrend.util.ChartUtil
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
@@ -74,6 +77,31 @@ class MediaStatsFragment : Fragment() {
     private val mediaStatsViewModel: MediaStatsViewModel by viewModel()
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): MediaStatsFragment = MediaStatsFragment().apply {
             arguments = args
@@ -82,9 +110,9 @@ class MediaStatsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStatsFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MediaStatsFragment.kt
@@ -101,7 +101,6 @@ class MediaStatsFragment : Fragment() {
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): MediaStatsFragment = MediaStatsFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MessageFeedFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/MessageFeedFragment.kt
@@ -39,14 +39,20 @@ class MessageFeedFragment : FeedListFragment() {
                 arguments = args
             }
         }
+
+        /**
+         * Documented legacy channel: the message host activity and pager write only
+         * legacy wire extras (arg_userId, arg_message_type), so the identity read
+         * stays on the transitional channel. Reads mirror the pre-refactor getter
+         * exactly (absent resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): Long = bundle?.getLong(KeyUtil.arg_userId) ?: 0L
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            messageType = args.getInt(KeyUtil.arg_message_type)
-            userId = args.getLong(KeyUtil.arg_userId)
-        }
+        userId = fromBundle(arguments)
+        messageType = arguments?.getInt(KeyUtil.arg_message_type) ?: 0
         isMenuDisabled = true
         isFeed = false
     }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
@@ -74,7 +74,6 @@ class ReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<ReviewRecord
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): ReviewFragment = ReviewFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
@@ -17,6 +17,9 @@ import com.mxt.anitrend.domain.model.ReviewRecord
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
@@ -47,6 +50,31 @@ class ReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<ReviewRecord
     private var reviewAdapter: ReviewAdapter? = null
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): ReviewFragment = ReviewFragment().apply {
             arguments = args
@@ -56,9 +84,9 @@ class ReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<ReviewRecord
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         reviewAdapter =
             ReviewAdapter(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/StaffOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/StaffOverviewFragment.kt
@@ -35,13 +35,20 @@ class StaffOverviewFragment : Fragment() {
         fun newInstance(args: Bundle): StaffOverviewFragment = StaffOverviewFragment().apply {
             arguments = args
         }
+
+        /**
+         * Documented legacy channel: the staff pager builds fresh bundles from the
+         * legacy arg_id/arg_onList extras (StaffActivity.buildPagerParams), so the
+         * identity read stays on the transitional channel. Reads mirror the
+         * pre-refactor getter exactly (absent resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): Long = bundle?.getLong(KeyUtil.arg_id) ?: 0L
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            staffId = args.getLong(KeyUtil.arg_id)
-        }
+        // Documented legacy channel: see fromBundle.
+        staffId = fromBundle(arguments)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/StudioMediaFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/StudioMediaFragment.kt
@@ -6,6 +6,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -15,6 +16,8 @@ import com.mxt.anitrend.base.custom.fragment.FragmentBaseList
 import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.StudioScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -40,13 +43,34 @@ class StudioMediaFragment : FragmentBaseList<MediaBase, ConnectionContainer<Page
         fun newInstance(args: Bundle): StudioMediaFragment = StudioMediaFragment().apply {
             arguments = args
         }
+
+        /**
+         * Resolves the studio identity from the fragment arguments.
+         *
+         * The typed [StudioScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] extra is bridged with its exact raw value (0 or
+         * negative ids pass through, mirroring the pre-refactor getter).
+         */
+        fun fromBundle(bundle: Bundle?): Long? = resolve(
+            typed = bundle?.screenParam<StudioScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: StudioScreenParam?, legacyId: Long): Long? {
+            typed?.let { param ->
+                if (param.studioId > 0) return param.studioId
+                // Typed param present but invalid: fall through to the legacy raw value.
+            }
+            return legacyId
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            id = args.getLong(KeyUtil.arg_id)
+        fromBundle(arguments)?.let { args ->
+            id = args
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserFeedFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserFeedFragment.kt
@@ -2,10 +2,13 @@ package com.mxt.anitrend.view.fragment.detail
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.mxt.anitrend.graphql.generated.ActivityType
+import com.mxt.anitrend.navigation.extension.NavigationArgs
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
 import com.mxt.anitrend.repository.UserRepository
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
@@ -36,16 +39,42 @@ class UserFeedFragment : FeedListFragment() {
                 arguments = args
             }
         }
+
+        /**
+         * Resolves the user identity from the fragment arguments.
+         *
+         * The typed [UserScreenParam] wins when present; otherwise the legacy
+         * containsKey semantics are preserved exactly: an explicit `arg_id` extra
+         * resolves by id, otherwise the `arg_userName` extra resolves by name.
+         */
+        fun fromBundle(bundle: Bundle?): UserScreenParam? = resolve(
+            typed = bundle?.screenParam<UserScreenParam>(),
+            hasLegacyId = bundle?.containsKey(KeyUtil.arg_id) == true,
+            legacyId = bundle?.getLong(KeyUtil.arg_id, 0L) ?: 0L,
+            legacyName = bundle?.getString(KeyUtil.arg_userName),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(
+            typed: UserScreenParam?,
+            hasLegacyId: Boolean,
+            legacyId: Long,
+            legacyName: String?,
+        ): UserScreenParam? {
+            typed?.let { return it }
+            return if (hasLegacyId) {
+                UserScreenParam(userId = legacyId)
+            } else {
+                UserScreenParam(userId = 0L, initialName = legacyName)
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            if (args.containsKey(KeyUtil.arg_id)) {
-                userId = args.getLong(KeyUtil.arg_id)
-            } else {
-                userName = args.getString(KeyUtil.arg_userName)
-            }
+        fromBundle(arguments)?.let { args ->
+            userId = args.userId
+            userName = args.initialName
         }
         isMenuDisabled = true
         isFeed = false
@@ -90,10 +119,10 @@ class UserFeedFragment : FeedListFragment() {
             userFeedViewModel.load(
                 userId = userId.toInt(),
                 page = mScrollListener.currentPage,
-                pageLimit = args.getInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT),
-                isFollowing = if (args.containsKey(KeyUtil.arg_isFollowing)) args.getBoolean(KeyUtil.arg_isFollowing) else null,
-                type = args.getString(KeyUtil.arg_type)?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() },
-                isMixed = if (args.containsKey(KeyUtil.arg_isMixed)) args.getBoolean(KeyUtil.arg_isMixed) else null,
+                pageLimit = NavigationArgs.intWithDefault(args.containsKey(KeyUtil.arg_page_limit), args.getInt(KeyUtil.arg_page_limit), KeyUtil.PAGING_LIMIT),
+                isFollowing = NavigationArgs.optionalBoolean(args.containsKey(KeyUtil.arg_isFollowing), args.getBoolean(KeyUtil.arg_isFollowing)),
+                type = NavigationArgs.resolveActivityType(args.getString(KeyUtil.arg_type)),
+                isMixed = NavigationArgs.optionalBoolean(args.containsKey(KeyUtil.arg_isMixed), args.getBoolean(KeyUtil.arg_isMixed)),
                 currentUserId = currentUserId(),
             )
         }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -18,6 +19,8 @@ import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.anilist.User
 import com.mxt.anitrend.model.entity.base.StatsRing
 import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
 import com.mxt.anitrend.repository.UserRepository
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -52,13 +55,32 @@ class UserOverviewFragment : Fragment() {
             fragment.arguments = args
             return fragment
         }
+
+        /**
+         * Resolves the user identity from the fragment arguments.
+         *
+         * The typed [UserScreenParam] wins when present; otherwise the legacy
+         * [KeyUtil.arg_id] / [KeyUtil.arg_userName] extras are bridged with their
+         * exact pre-refactor defaults (id 0, empty name).
+         */
+        fun fromBundle(bundle: Bundle?): UserScreenParam? = resolve(
+            typed = bundle?.screenParam<UserScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id, 0L) ?: 0L,
+            legacyName = bundle?.getString(KeyUtil.arg_userName, "") ?: "",
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: UserScreenParam?, legacyId: Long, legacyName: String): UserScreenParam? {
+            typed?.let { return it }
+            return UserScreenParam(userId = legacyId, initialName = legacyName)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            userId = args.getLong(KeyUtil.arg_id, 0L)
-            userName = args.getString(KeyUtil.arg_userName, "")
+        fromBundle(arguments)?.let { args ->
+            userId = args.userId
+            userName = args.initialName.orEmpty()
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/CharacterFavouriteFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/CharacterFavouriteFragment.kt
@@ -31,6 +31,10 @@ class CharacterFavouriteFragment : FragmentBaseList<RecyclerItem, ConnectionCont
     private val characterFavouritesViewModel: CharacterFavouritesViewModel by viewModel()
 
     companion object {
+        // Documented legacy channel: the favourites host activity writes only the
+        // legacy wire extras (arg_id), so the read stays on the transitional channel
+        // until the host navigates with typed parameters.
+
         @JvmStatic
         fun newInstance(params: Bundle): CharacterFavouriteFragment {
             val args = Bundle(params)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/MediaFavouriteFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/MediaFavouriteFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.favourite
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -38,6 +39,27 @@ class MediaFavouriteFragment : FragmentBaseList<MediaBase, ConnectionContainer<F
     private val mediaFavouritesViewModel: MediaFavouritesViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the favourites host activity writes only legacy
+         * wire extras (arg_id / arg_mediaType). The media-type value is filter state,
+         * not identity, so both values stay on the legacy channel. Reads mirror the
+         * pre-refactor getters exactly (absent id resolves to 0, type to null).
+         */
+        fun fromBundle(bundle: Bundle?): MediaFavouritesLegacyArgs? = resolve(
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        /** Exact legacy read result for the media favourites destination. */
+        data class MediaFavouritesLegacyArgs(
+            val userId: Long,
+            val mediaType: String?,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(legacyId: Long, legacyType: String?): MediaFavouritesLegacyArgs =
+            MediaFavouritesLegacyArgs(userId = legacyId, mediaType = legacyType)
+
         @JvmStatic
         fun newInstance(
             params: Bundle,
@@ -55,9 +77,9 @@ class MediaFavouriteFragment : FragmentBaseList<MediaBase, ConnectionContainer<F
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            userId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            userId = args.userId
+            mediaType = args.mediaType
         }
         val ctx = requireContext()
         mAdapter = MediaAdapter(ctx, true)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/MediaFavouriteFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/MediaFavouriteFragment.kt
@@ -57,8 +57,7 @@ class MediaFavouriteFragment : FragmentBaseList<MediaBase, ConnectionContainer<F
         )
 
         @VisibleForTesting
-        internal fun resolve(legacyId: Long, legacyType: String?): MediaFavouritesLegacyArgs =
-            MediaFavouritesLegacyArgs(userId = legacyId, mediaType = legacyType)
+        internal fun resolve(legacyId: Long, legacyType: String?): MediaFavouritesLegacyArgs = MediaFavouritesLegacyArgs(userId = legacyId, mediaType = legacyType)
 
         @JvmStatic
         fun newInstance(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/StaffFavouriteFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/StaffFavouriteFragment.kt
@@ -29,6 +29,10 @@ class StaffFavouriteFragment : FragmentBaseList<StaffBase, ConnectionContainer<F
     private val staffFavouritesViewModel: StaffFavouritesViewModel by viewModel()
 
     companion object {
+        // Documented legacy channel: the favourites host activity writes only the
+        // legacy wire extras (arg_id), so the read stays on the transitional channel
+        // until the host navigates with typed parameters.
+
         @JvmStatic
         fun newInstance(params: Bundle): StaffFavouriteFragment {
             val args = Bundle(params)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/StudioFavouriteFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/favourite/StudioFavouriteFragment.kt
@@ -27,6 +27,10 @@ class StudioFavouriteFragment : FragmentBaseList<StudioBase, ConnectionContainer
     private val studioFavouritesViewModel: StudioFavouritesViewModel by viewModel()
 
     companion object {
+        // Documented legacy channel: the favourites host activity writes only the
+        // legacy wire extras (arg_id), so the read stays on the transitional channel
+        // until the host navigates with typed parameters.
+
         @JvmStatic
         fun newInstance(params: Bundle): StudioFavouriteFragment {
             val args = Bundle(params)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/CharacterActorsFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/CharacterActorsFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -17,6 +18,8 @@ import com.mxt.anitrend.model.entity.base.StaffBase
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.group.RecyclerItem
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -46,13 +49,35 @@ class CharacterActorsFragment : FragmentBaseList<RecyclerItem, ConnectionContain
         fun newInstance(args: Bundle): CharacterActorsFragment = CharacterActorsFragment().apply {
             arguments = args
         }
+
+        /**
+         * Resolves the character identity from the fragment arguments.
+         *
+         * The typed [CharacterScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] extra is bridged with its exact raw value (0 or
+         * negative ids pass through, mirroring the pre-refactor getter).
+         */
+        fun fromBundle(bundle: Bundle?): CharacterScreenParam? = resolve(
+            typed = bundle?.screenParam<CharacterScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: CharacterScreenParam?, legacyId: Long): CharacterScreenParam? {
+            typed?.let { param ->
+                if (param.characterId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy value.
+            }
+            return CharacterScreenParam(characterId = legacyId)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val args = arguments
-        if (args != null) {
-            id = args.getLong(KeyUtil.arg_id)
+        // Resolve the destination through the typed character parameter, falling back
+        // to the legacy wire key forwarded by the pager/activity for pre-bridge callers.
+        fromBundle(arguments)?.let { args ->
+            id = args.characterId
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaAnimeRoleFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaAnimeRoleFragment.kt
@@ -31,40 +31,27 @@ class MediaAnimeRoleFragment : FragmentBaseList<RecyclerItem, ConnectionContaine
     private var id: Long = 0
     private var onList: Boolean? = null
 
-    @KeyUtil.MediaType
-    private var mediaType: String? = null
-
-    @KeyUtil.RequestType
-    private var requestType: Int = 0
-
     private val mediaAnimeRoleViewModel: MediaAnimeRoleViewModel by viewModel()
 
     companion object {
         @JvmStatic
-        fun newInstance(
-            params: Bundle,
-            @KeyUtil.MediaType mediaType: String,
-            @KeyUtil.RequestType requestType: Int,
-        ): MediaAnimeRoleFragment {
-            val args =
-                Bundle(params).apply {
-                    putString(KeyUtil.arg_mediaType, mediaType)
-                    putInt(KeyUtil.arg_request_type, requestType)
-                }
-            return MediaAnimeRoleFragment().apply {
-                arguments = args
-            }
+        fun newInstance(params: Bundle): MediaAnimeRoleFragment = MediaAnimeRoleFragment().apply {
+            arguments = params
         }
+
+        /**
+         * Documented legacy channel: the hosting pager adapters (character/staff)
+         * write only legacy wire extras, so the owner-id read stays on the
+         * transitional channel. Reads mirror the pre-refactor getter exactly
+         * (absent resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): Long = bundle?.getLong(KeyUtil.arg_id) ?: 0L
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            requestType = args.getInt(KeyUtil.arg_request_type)
-            id = args.getLong(KeyUtil.arg_id)
-            onList = args.serializable(KeyUtil.arg_onList)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
-        }
+        id = fromBundle(arguments)
+        onList = arguments?.serializable(KeyUtil.arg_onList)
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true
         val ctx = requireContext()

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaCharacterFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaCharacterFragment.kt
@@ -65,7 +65,6 @@ class MediaCharacterFragment : FragmentBaseList<RecyclerItem, ConnectionContaine
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): MediaCharacterFragment = MediaCharacterFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaCharacterFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaCharacterFragment.kt
@@ -16,6 +16,9 @@ import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.group.RecyclerItem
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import com.mxt.anitrend.util.collection.GroupingUtil
@@ -38,6 +41,31 @@ class MediaCharacterFragment : FragmentBaseList<RecyclerItem, ConnectionContaine
     private val mediaCharacterViewModel: MediaCharacterViewModel by viewModel()
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): MediaCharacterFragment = MediaCharacterFragment().apply {
             arguments = args
@@ -47,9 +75,9 @@ class MediaCharacterFragment : FragmentBaseList<RecyclerItem, ConnectionContaine
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaFormatFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaFormatFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.group
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,6 +15,9 @@ import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.model.entity.group.RecyclerItem
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
@@ -55,13 +59,46 @@ class MediaFormatFragment : FragmentBaseList<RecyclerItem, ConnectionContainer<P
                 arguments = args
             }
         }
+
+        /**
+         * Resolves the owner identity from the fragment arguments.
+         *
+         * The format tab is shared by the character and staff detail pagers. The
+         * character pager forwards CharacterActivity's intent extras (typed
+         * [CharacterScreenParam] + legacy arg_id); the staff pager forwards
+         * StaffActivity's intent extras (typed [StaffScreenParam] + legacy arg_id)
+         * when present, or fresh legacy bundles otherwise. The typed identity of the
+         * hosting family wins when present and valid; otherwise the exact raw legacy
+         * id is used (0 or negative values pass through, mirroring the pre-refactor
+         * getter). requestType / mediaType / onList stay on the legacy pager channels.
+         */
+        fun fromBundle(bundle: Bundle?): Long? = resolve(
+            character = bundle?.screenParam<CharacterScreenParam>(),
+            staff = bundle?.screenParam<StaffScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(character: CharacterScreenParam?, staff: StaffScreenParam?, legacyId: Long): Long? {
+            character?.let { param ->
+                if (param.characterId > 0) return param.characterId
+                // Typed param present but invalid: fall through to the next source.
+            }
+            staff?.let { param ->
+                if (param.staffId > 0) return param.staffId
+                // Typed param present but invalid: fall through to the exact raw legacy value.
+            }
+            return legacyId
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let { args ->
             requestType = args.getInt(KeyUtil.arg_request_type)
-            id = args.getLong(KeyUtil.arg_id)
+        }
+        fromBundle(arguments)?.let { args ->
+            id = args
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRecommendationsFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRecommendationsFragment.kt
@@ -63,7 +63,6 @@ class MediaRecommendationsFragment : FragmentBaseList<RecommendationItemUiModel,
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): MediaRecommendationsFragment = MediaRecommendationsFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRecommendationsFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRecommendationsFragment.kt
@@ -14,6 +14,9 @@ import com.mxt.anitrend.domain.model.RecommendationItemUiModel
 import com.mxt.anitrend.domain.model.RecommendationPageResult
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
@@ -36,6 +39,31 @@ class MediaRecommendationsFragment : FragmentBaseList<RecommendationItemUiModel,
     private var recommendationAdapter: RecommendationAdapter? = null
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): MediaRecommendationsFragment = MediaRecommendationsFragment().apply {
             arguments = args
@@ -45,9 +73,9 @@ class MediaRecommendationsFragment : FragmentBaseList<RecommendationItemUiModel,
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         isPager = true
         mColumnSize = R.integer.grid_giphy_x3

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRelationFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRelationFragment.kt
@@ -16,6 +16,9 @@ import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.group.RecyclerItem
 import com.mxt.anitrend.util.CompatUtil
+import androidx.annotation.VisibleForTesting
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.Settings
@@ -41,6 +44,31 @@ class MediaRelationFragment : FragmentBaseList<RecyclerItem, ConnectionContainer
     private val mediaRelationViewModel: MediaRelationViewModel by viewModel()
 
     companion object {
+        /**
+         * Resolves the media identity from the fragment arguments.
+         *
+         * The typed [MediaScreenParam] wins when present and valid; otherwise the
+         * legacy [KeyUtil.arg_id] / [KeyUtil.arg_mediaType] extras are bridged with
+         * their exact raw values (0 or negative ids pass through, mirroring the
+         * pre-refactor getter). A typed param present but invalid falls back to the
+         * legacy raw values.
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            typed = bundle?.screenParam<MediaScreenParam>(),
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: MediaScreenParam?, legacyId: Long, legacyType: String?): MediaScreenParam? {
+            typed?.let { param ->
+                if (param.mediaId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        }
+
+
         @JvmStatic
         fun newInstance(args: Bundle): MediaRelationFragment = MediaRelationFragment().apply {
             arguments = args
@@ -50,9 +78,9 @@ class MediaRelationFragment : FragmentBaseList<RecyclerItem, ConnectionContainer
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         mColumnSize = R.integer.grid_giphy_x3
         mAdapter = GroupSeriesAdapter(ctx)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRelationFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaRelationFragment.kt
@@ -68,7 +68,6 @@ class MediaRelationFragment : FragmentBaseList<RecyclerItem, ConnectionContainer
             return MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
         }
 
-
         @JvmStatic
         fun newInstance(args: Bundle): MediaRelationFragment = MediaRelationFragment().apply {
             arguments = args

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaStaffRoleFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/group/MediaStaffRoleFragment.kt
@@ -44,15 +44,20 @@ class MediaStaffRoleFragment : FragmentBaseList<RecyclerItem, ConnectionContaine
         fun newInstance(args: Bundle): MediaStaffRoleFragment = MediaStaffRoleFragment().apply {
             arguments = args
         }
+
+        /**
+         * Documented legacy channel: the hosting pager adapters (media/staff) write
+         * only legacy wire extras, so the owner-id read stays on the transitional
+         * channel. Reads mirror the pre-refactor getter exactly (absent resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): Long = bundle?.getLong(KeyUtil.arg_id) ?: 0L
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            id = args.getLong(KeyUtil.arg_id)
-            onList = args.serializable(KeyUtil.arg_onList)
-        }
+        id = fromBundle(arguments)
+        onList = arguments?.serializable(KeyUtil.arg_onList)
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true
         mAdapter = GroupSeriesAdapter(ctx)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/FeedListFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/FeedListFragment.kt
@@ -18,7 +18,7 @@ import com.mxt.anitrend.data.mapper.toPageInfo
 import com.mxt.anitrend.data.mapper.toUserBase
 import com.mxt.anitrend.domain.model.FeedItemUiModel
 import com.mxt.anitrend.domain.model.PageInfoRecord
-import com.mxt.anitrend.graphql.generated.ActivityType
+import com.mxt.anitrend.navigation.extension.NavigationArgs
 import com.mxt.anitrend.model.entity.anilist.FeedList
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.util.CompatUtil
@@ -164,10 +164,10 @@ open class FeedListFragment : FragmentBaseList<FeedList, PageContainer<FeedList>
         val args = arguments ?: return
         feedListViewModel.load(
             page = mScrollListener.currentPage,
-            pageLimit = args.getInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT),
-            isFollowing = if (args.containsKey(KeyUtil.arg_isFollowing)) args.getBoolean(KeyUtil.arg_isFollowing) else null,
-            type = args.getString(KeyUtil.arg_type)?.let { runCatching { ActivityType.valueOf(it) }.getOrNull() },
-            isMixed = if (args.containsKey(KeyUtil.arg_isMixed)) args.getBoolean(KeyUtil.arg_isMixed) else null,
+            pageLimit = NavigationArgs.intWithDefault(args.containsKey(KeyUtil.arg_page_limit), args.getInt(KeyUtil.arg_page_limit), KeyUtil.PAGING_LIMIT),
+            isFollowing = NavigationArgs.optionalBoolean(args.containsKey(KeyUtil.arg_isFollowing), args.getBoolean(KeyUtil.arg_isFollowing)),
+            type = NavigationArgs.resolveActivityType(args.getString(KeyUtil.arg_type)),
+            isMixed = NavigationArgs.optionalBoolean(args.containsKey(KeyUtil.arg_isMixed), args.getBoolean(KeyUtil.arg_isMixed)),
             currentUserId = currentUserId(),
         )
     }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaBrowseFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaBrowseFragment.kt
@@ -13,7 +13,7 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.recycler.index.MediaAdapter
 import com.mxt.anitrend.base.custom.fragment.FragmentBaseList
 import com.mxt.anitrend.extension.parcelable
-import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.navigation.extension.NavigationArgs
 import com.mxt.anitrend.model.entity.anilist.Genre
 import com.mxt.anitrend.model.entity.anilist.MediaTag
 import com.mxt.anitrend.model.entity.base.MediaBase
@@ -297,34 +297,37 @@ open class MediaBrowseFragment : FragmentBaseList<MediaBase, PageContainer<Media
     }
 
     override fun makeRequest() {
-        val type = requestArgs.getString(KeyUtil.arg_mediaType)?.let {
-            runCatching { MediaType.valueOf(it) }.getOrNull()
-        }
+        // All filter reads go through NavigationArgs so the exact containsKey /
+        // null-versus-empty semantics are captured in production helpers and are
+        // JVM-testable. The browse destination has no stable identity of its own;
+        // every value stays on the legacy bundle channel until a Phase 2+ browse
+        // configuration model is introduced.
+        val type = NavigationArgs.resolveMediaType(requestArgs.getString(KeyUtil.arg_mediaType))
         val isAdult: Boolean? =
             if (!settings.displayAdultContent) {
                 false
             } else {
-                requestArgs.takeIf { it.containsKey(KeyUtil.arg_isAdult) }?.getBoolean(KeyUtil.arg_isAdult)
+                NavigationArgs.optionalBoolean(requestArgs.containsKey(KeyUtil.arg_isAdult), requestArgs.getBoolean(KeyUtil.arg_isAdult))
             }
 
         // Bundle values are explicit caller intent. Settings only provide fallback defaults
         // when filtering is enabled and the caller did not provide that query value.
         val season =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_season) }?.getString(KeyUtil.arg_season)
+            NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_season), requestArgs.getString(KeyUtil.arg_season))
         var format =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_format) }?.getString(KeyUtil.arg_format)
+            NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_format), requestArgs.getString(KeyUtil.arg_format))
         var seasonYear =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_seasonYear) }?.getInt(KeyUtil.arg_seasonYear)
+            NavigationArgs.optionalInt(requestArgs.containsKey(KeyUtil.arg_seasonYear), requestArgs.getInt(KeyUtil.arg_seasonYear))
         var startDateLike =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_startDateLike) }?.getString(KeyUtil.arg_startDateLike)
+            NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_startDateLike), requestArgs.getString(KeyUtil.arg_startDateLike))
         var status =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_status) }?.getString(KeyUtil.arg_status)
+            NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_status), requestArgs.getString(KeyUtil.arg_status))
         var genres: List<String>? =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_genres) }?.getStringArrayList(KeyUtil.arg_genres)
+            NavigationArgs.optionalStringList(requestArgs.containsKey(KeyUtil.arg_genres), requestArgs.getStringArrayList(KeyUtil.arg_genres))
         var tags: List<String>? =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_tags) }?.getStringArrayList(KeyUtil.arg_tags)
+            NavigationArgs.optionalStringList(requestArgs.containsKey(KeyUtil.arg_tags), requestArgs.getStringArrayList(KeyUtil.arg_tags))
         var sort =
-            requestArgs.takeIf { it.containsKey(KeyUtil.arg_sort) }?.getString(KeyUtil.arg_sort)
+            NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_sort), requestArgs.getString(KeyUtil.arg_sort))
 
         if (isFilterableEnabled) {
             if (mediaBrowseUtil?.isBasicFilter != true) {
@@ -361,7 +364,7 @@ open class MediaBrowseFragment : FragmentBaseList<MediaBase, PageContainer<Media
         mediaBrowseViewModel.load(
             type = type,
             page = mScrollListener.currentPage,
-            pageLimit = requestArgs.getInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT),
+            pageLimit = NavigationArgs.intWithDefault(requestArgs.containsKey(KeyUtil.arg_page_limit), requestArgs.getInt(KeyUtil.arg_page_limit), KeyUtil.PAGING_LIMIT),
             season = season,
             sort = sort,
             isAdult = isAdult,

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaLatestList.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaLatestList.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mxt.anitrend.R
 import com.mxt.anitrend.adapter.recycler.index.MediaLatestAdapter
-import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.model.entity.base.MediaBase
+import com.mxt.anitrend.navigation.extension.NavigationArgs
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
@@ -63,20 +63,18 @@ class MediaLatestList : MediaBrowseFragment() {
     }
 
     override fun makeRequest() {
-        val type = requestArgs.getString(KeyUtil.arg_mediaType)?.let {
-            runCatching { MediaType.valueOf(it) }.getOrNull()
-        }
-        val sort = requestArgs.getString(KeyUtil.arg_sort)
+        val type = NavigationArgs.resolveMediaType(requestArgs.getString(KeyUtil.arg_mediaType))
+        val sort = NavigationArgs.optionalString(requestArgs.containsKey(KeyUtil.arg_sort), requestArgs.getString(KeyUtil.arg_sort))
         val isAdult: Boolean? =
             if (!settings.displayAdultContent) {
                 false
             } else {
-                requestArgs.takeIf { it.containsKey(KeyUtil.arg_isAdult) }?.getBoolean(KeyUtil.arg_isAdult)
+                NavigationArgs.optionalBoolean(requestArgs.containsKey(KeyUtil.arg_isAdult), requestArgs.getBoolean(KeyUtil.arg_isAdult))
             }
         mediaLatestViewModel.load(
             type = type,
             page = mScrollListener.currentPage,
-            pageLimit = requestArgs.getInt(KeyUtil.arg_page_limit, KeyUtil.PAGING_LIMIT),
+            pageLimit = NavigationArgs.intWithDefault(requestArgs.containsKey(KeyUtil.arg_page_limit), requestArgs.getInt(KeyUtil.arg_page_limit), KeyUtil.PAGING_LIMIT),
             sort = sort,
             isAdult = isAdult,
         )

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaListFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaListFragment.kt
@@ -79,8 +79,7 @@ open class MediaListFragment : FragmentBaseList<MediaListItemUiModel, MediaListC
         )
 
         @VisibleForTesting
-        internal fun resolve(legacyId: Long, legacyName: String?): UserScreenParam =
-            UserScreenParam(userId = legacyId, initialName = legacyName)
+        internal fun resolve(legacyId: Long, legacyName: String?): UserScreenParam = UserScreenParam(userId = legacyId, initialName = legacyName)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaListFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/MediaListFragment.kt
@@ -7,6 +7,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -19,6 +20,7 @@ import com.mxt.anitrend.domain.medialist.model.MediaListRecord
 import com.mxt.anitrend.domain.model.MediaListItemUiModel
 import com.mxt.anitrend.domain.model.buildIncrementMediaProgressCommand
 import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.navigation.model.UserScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.DialogUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -64,13 +66,30 @@ open class MediaListFragment : FragmentBaseList<MediaListItemUiModel, MediaListC
                 arguments = args
             }
         }
+
+        /**
+         * Documented legacy channel: the media-list host activity (MediaListActivity)
+         * writes only legacy wire extras (arg_id, arg_userName, arg_mediaType,
+         * arg_statusIn), so the identity read stays on the transitional channel.
+         * Reads mirror the pre-refactor getters exactly (absent id resolves to 0).
+         */
+        fun fromBundle(bundle: Bundle?): UserScreenParam? = resolve(
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyName = bundle?.getString(KeyUtil.arg_userName),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(legacyId: Long, legacyName: String?): UserScreenParam =
+            UserScreenParam(userId = legacyId, initialName = legacyName)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        fromBundle(arguments)?.let { args ->
+            userId = args.userId
+            userName = args.initialName
+        }
         arguments?.let { args ->
-            userId = args.getLong(KeyUtil.arg_id)
-            userName = args.getString(KeyUtil.arg_userName)
             statusIn = args.getString(KeyUtil.arg_statusIn)
             mediaType = args.getString(KeyUtil.arg_mediaType)
         }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/WatchListFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/WatchListFragment.kt
@@ -81,8 +81,7 @@ class WatchListFragment :
         )
 
         @VisibleForTesting
-        internal fun resolve(legacyId: Long, legacyType: String?): MediaScreenParam =
-            MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
+        internal fun resolve(legacyId: Long, legacyType: String?): MediaScreenParam = MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/list/WatchListFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/list/WatchListFragment.kt
@@ -2,6 +2,7 @@ package com.mxt.anitrend.view.fragment.list
 
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.mxt.anitrend.BuildConfig
@@ -10,6 +11,7 @@ import com.mxt.anitrend.adapter.recycler.index.EpisodeAdapter
 import com.mxt.anitrend.base.custom.fragment.FragmentChannelBase
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.model.entity.anilist.ExternalLink
+import com.mxt.anitrend.navigation.model.MediaScreenParam
 import com.mxt.anitrend.repository.CrunchyrollRepository
 import com.mxt.anitrend.repository.MediaRepository
 import com.mxt.anitrend.util.KeyUtil
@@ -66,14 +68,32 @@ class WatchListFragment :
                 arguments = args
             }
         }
+
+        /**
+         * Documented legacy channel: the airing pager host (MainActivity) writes no
+         * typed media parameter, so the media identity stays on the legacy arg_id /
+         * arg_mediaType extras. Reads mirror the pre-refactor getters exactly
+         * (absent resolves to id 0 / null type).
+         */
+        fun fromBundle(bundle: Bundle?): MediaScreenParam? = resolve(
+            legacyId = bundle?.getLong(KeyUtil.arg_id) ?: 0L,
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(legacyId: Long, legacyType: String?): MediaScreenParam =
+            MediaScreenParam(mediaId = legacyId, mediaType = legacyType)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            mediaId = args.getLong(KeyUtil.arg_id)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        // Documented legacy channel: see fromBundle. The popular flag and the
+        // external-links list stay on the legacy channel (read by FragmentChannelBase)
+        // because they are presentation/data state, not destination identity.
+        fromBundle(arguments)?.let { args ->
+            mediaId = args.mediaId
+            mediaType = args.mediaType
         }
         mAdapter = EpisodeAdapter(ctx)
         mAdapter?.setClickListener(clickListener)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/CharacterSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/CharacterSearchFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.search
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -29,6 +30,16 @@ class CharacterSearchFragment : FragmentBaseList<RecyclerItem, PageContainer<Cha
     private val characterSearchViewModel: CharacterSearchViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the search query is caller state, not identity.
+         * It stays on arg_search until a search-state model is designed. Reads mirror
+         * the pre-refactor getter exactly (absent resolves to null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyQuery(bundle?.getString(KeyUtil.arg_search))
+
+        @VisibleForTesting
+        internal fun resolveLegacyQuery(raw: String?): String? = raw
+
         @JvmStatic
         fun newInstance(args: Bundle): CharacterSearchFragment = CharacterSearchFragment().apply {
             arguments = args
@@ -38,9 +49,7 @@ class CharacterSearchFragment : FragmentBaseList<RecyclerItem, PageContainer<Cha
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            searchQuery = args.getString(KeyUtil.arg_search)
-        }
+        searchQuery = fromBundle(arguments)
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true
         mAdapter = GroupCharacterAdapter(ctx)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/MediaSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/MediaSearchFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.search
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -38,6 +39,27 @@ class MediaSearchFragment : FragmentBaseList<MediaBase, PageContainer<MediaBase>
     private val mediaSearchViewModel: MediaSearchViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the search query is caller state, not identity.
+         * It stays on arg_search (with the media type for the media destination) until
+         * a search-state model is designed. Reads mirror the pre-refactor getters
+         * exactly (absent values resolve to null).
+         */
+        fun fromBundle(bundle: Bundle?): SearchQueryLegacyArgs? = resolve(
+            legacyQuery = bundle?.getString(KeyUtil.arg_search),
+            legacyType = bundle?.getString(KeyUtil.arg_mediaType),
+        )
+
+        /** Exact legacy read result for the media search destination. */
+        data class SearchQueryLegacyArgs(
+            val searchQuery: String?,
+            val mediaType: String?,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(legacyQuery: String?, legacyType: String?): SearchQueryLegacyArgs =
+            SearchQueryLegacyArgs(searchQuery = legacyQuery, mediaType = legacyType)
+
         @JvmStatic
         fun newInstance(
             bundle: Bundle,
@@ -55,9 +77,9 @@ class MediaSearchFragment : FragmentBaseList<MediaBase, PageContainer<MediaBase>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            searchQuery = args.getString(KeyUtil.arg_search)
-            mediaType = args.getString(KeyUtil.arg_mediaType)
+        fromBundle(arguments)?.let { args ->
+            searchQuery = args.searchQuery
+            mediaType = args.mediaType
         }
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/MediaSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/MediaSearchFragment.kt
@@ -57,8 +57,7 @@ class MediaSearchFragment : FragmentBaseList<MediaBase, PageContainer<MediaBase>
         )
 
         @VisibleForTesting
-        internal fun resolve(legacyQuery: String?, legacyType: String?): SearchQueryLegacyArgs =
-            SearchQueryLegacyArgs(searchQuery = legacyQuery, mediaType = legacyType)
+        internal fun resolve(legacyQuery: String?, legacyType: String?): SearchQueryLegacyArgs = SearchQueryLegacyArgs(searchQuery = legacyQuery, mediaType = legacyType)
 
         @JvmStatic
         fun newInstance(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/StaffSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/StaffSearchFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.search
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -27,6 +28,16 @@ class StaffSearchFragment : FragmentBaseList<StaffBase, PageContainer<StaffBase>
     private val staffSearchViewModel: StaffSearchViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the search query is caller state, not identity.
+         * It stays on arg_search until a search-state model is designed. Reads mirror
+         * the pre-refactor getter exactly (absent resolves to null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyQuery(bundle?.getString(KeyUtil.arg_search))
+
+        @VisibleForTesting
+        internal fun resolveLegacyQuery(raw: String?): String? = raw
+
         @JvmStatic
         fun newInstance(args: Bundle): StaffSearchFragment = StaffSearchFragment().apply {
             arguments = args
@@ -36,9 +47,7 @@ class StaffSearchFragment : FragmentBaseList<StaffBase, PageContainer<StaffBase>
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            searchQuery = args.getString(KeyUtil.arg_search)
-        }
+        searchQuery = fromBundle(arguments)
         mColumnSize = R.integer.grid_giphy_x3
         isPager = true
         mAdapter = StaffAdapter(ctx)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/StudioSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/StudioSearchFragment.kt
@@ -2,6 +2,7 @@ package com.mxt.anitrend.view.fragment.search
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -26,6 +27,16 @@ class StudioSearchFragment : FragmentBaseList<StudioBase, PageContainer<StudioBa
     private val studioSearchViewModel: StudioSearchViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the search query is caller state, not identity.
+         * It stays on arg_search until a search-state model is designed. Reads mirror
+         * the pre-refactor getter exactly (absent resolves to null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyQuery(bundle?.getString(KeyUtil.arg_search))
+
+        @VisibleForTesting
+        internal fun resolveLegacyQuery(raw: String?): String? = raw
+
         @JvmStatic
         fun newInstance(args: Bundle): StudioSearchFragment = StudioSearchFragment().apply {
             arguments = args
@@ -35,9 +46,7 @@ class StudioSearchFragment : FragmentBaseList<StudioBase, PageContainer<StudioBa
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            searchQuery = args.getString(KeyUtil.arg_search)
-        }
+        searchQuery = fromBundle(arguments)
         mColumnSize = R.integer.grid_list_x2
         isPager = true
         mAdapter = StudioAdapter(ctx)

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/search/UserSearchFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/search/UserSearchFragment.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.fragment.search
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -31,6 +32,16 @@ class UserSearchFragment : FragmentBaseList<UserBase, PageContainer<UserBase>>()
     private val userSearchViewModel: UserSearchViewModel by viewModel()
 
     companion object {
+        /**
+         * Documented legacy channel: the search query is caller state, not identity.
+         * It stays on arg_search until a search-state model is designed. Reads mirror
+         * the pre-refactor getter exactly (absent resolves to null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyQuery(bundle?.getString(KeyUtil.arg_search))
+
+        @VisibleForTesting
+        internal fun resolveLegacyQuery(raw: String?): String? = raw
+
         @JvmStatic
         fun newInstance(args: Bundle): UserSearchFragment = UserSearchFragment().apply {
             arguments = args
@@ -40,9 +51,7 @@ class UserSearchFragment : FragmentBaseList<UserBase, PageContainer<UserBase>>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            searchQuery = args.getString(KeyUtil.arg_search)
-        }
+        searchQuery = fromBundle(arguments)
         mColumnSize = R.integer.single_list_x1
         isPager = true
         mAdapter = UserAdapter(

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsCategoryLegacyFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsCategoryLegacyFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -16,6 +17,8 @@ import com.mxt.anitrend.databinding.FragmentSettingsM3Binding
 import com.mxt.anitrend.databinding.ItemSettingsRowSwitchBinding
 import com.mxt.anitrend.databinding.ItemSettingsRowValueBinding
 import com.mxt.anitrend.databinding.ItemSettingsSectionCardBinding
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
 import com.mxt.anitrend.presenter.base.BasePresenter
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.Settings
@@ -82,8 +85,9 @@ class SettingsCategoryLegacyFragment :
         val sectionHost = binding.settingsSections
         sectionHost.removeAllViews()
 
+        val categoryId = fromBundle(arguments)?.categoryId ?: return
         val section = SettingsCategoryRegistry.sectionFor(
-            categoryId = arguments?.getString(SettingsCategoryRegistry.ARG_CATEGORY_ID),
+            categoryId = categoryId,
             isFirebaseVisible = FirebaseApp.getApps(requireContext()).isNotEmpty(),
             isUpdateChannelVisible = resources.getBoolean(R.bool.display_update_channel_pref),
             isAdultContentVisible = resources.getBoolean(R.bool.display_adult_content_pref),
@@ -248,5 +252,22 @@ class SettingsCategoryLegacyFragment :
     /** Alpha used to communicate disabled setting rows without hiding them. */
     companion object {
         private const val DISABLED_ALPHA = 0.38f
+
+        /**
+         * Resolves the settings category from the fragment arguments.
+         *
+         * The typed [SettingsCategoryScreenParam] wins when present; otherwise the
+         * legacy [SettingsCategoryRegistry.ARG_CATEGORY_ID] extra is bridged.
+         */
+        fun fromBundle(bundle: Bundle?): SettingsCategoryScreenParam? = resolve(
+            typed = bundle?.screenParam<SettingsCategoryScreenParam>(),
+            legacyCategoryId = bundle?.getString(SettingsCategoryRegistry.ARG_CATEGORY_ID),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: SettingsCategoryScreenParam?, legacyCategoryId: String?): SettingsCategoryScreenParam? {
+            typed?.let { return it }
+            return legacyCategoryId?.let { SettingsCategoryScreenParam(categoryId = it) }
+        }
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsHubFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsHubFragment.kt
@@ -12,6 +12,8 @@ import com.google.firebase.FirebaseApp
 import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.FragmentSettingsM3Binding
 import com.mxt.anitrend.databinding.ItemSettingsCategoryCardBinding
+import com.mxt.anitrend.navigation.extension.asBundle
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
 import com.mxt.anitrend.util.Settings
 import org.koin.android.ext.android.inject
 
@@ -89,7 +91,10 @@ class SettingsHubFragment : Fragment() {
             SettingsCategoryRegistry.CUSTOMIZE -> navController.navigate(R.id.action_settings_hub_to_customize)
             else -> navController.navigate(
                 R.id.action_settings_hub_to_category,
-                bundleOf(SettingsCategoryRegistry.ARG_CATEGORY_ID to categoryId),
+                SettingsCategoryScreenParam(categoryId = categoryId).asBundle().apply {
+                    // Interim boundary: keep the legacy key for pre-bridge readers.
+                    putString(SettingsCategoryRegistry.ARG_CATEGORY_ID, categoryId)
+                },
             )
         }
     }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsHubFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/settings/SettingsHubFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.firebase.FirebaseApp

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/youtube/YouTubeEmbedFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/youtube/YouTubeEmbedFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
@@ -15,6 +16,9 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.databinding.AdapterFeedSlideBinding
 import com.mxt.anitrend.extension.parcelable
 import com.mxt.anitrend.model.entity.anilist.meta.MediaTrailer
+import com.mxt.anitrend.navigation.extension.asBundle
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.markdown.RegexUtil
@@ -37,11 +41,42 @@ class YouTubeEmbedFragment : Fragment() {
                 arguments = args
             }
         }
+
+        /**
+         * Identity-only entry point: the trailer entity is never parceled; the stable
+         * trailer id and site are enough for the embed to resolve its video URL.
+         */
+        @JvmStatic
+        fun newInstance(param: TrailerScreenParam): YouTubeEmbedFragment = YouTubeEmbedFragment().apply {
+            arguments = param.asBundle()
+        }
+
+        /**
+         * Resolves the trailer identity from the fragment arguments.
+         *
+         * The typed [TrailerScreenParam] wins when present; otherwise the legacy
+         * [KeyUtil.arg_media_trailer] entity extra is bridged by extracting only the
+         * stable id and site.
+         */
+        fun fromBundle(bundle: Bundle?): TrailerScreenParam? = resolve(
+            typed = bundle?.screenParam<TrailerScreenParam>(),
+            legacyTrailer = bundle?.parcelable(KeyUtil.arg_media_trailer),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: TrailerScreenParam?, legacyTrailer: MediaTrailer?): TrailerScreenParam? {
+            typed?.let { return it }
+            val trailer = legacyTrailer ?: return null
+            val trailerId = trailer.id ?: return null
+            return TrailerScreenParam(trailerId = trailerId, site = trailer.site.orEmpty())
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mediaTrailer = arguments?.parcelable(KeyUtil.arg_media_trailer)
+        mediaTrailer = fromBundle(arguments)?.let { param ->
+            MediaTrailer(id = param.trailerId, site = param.site)
+        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomReviewReader.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomReviewReader.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.view.sheet
 import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.custom.view.image.AspectImageView
 import com.mxt.anitrend.base.custom.view.widget.CustomRatingBar
@@ -12,6 +13,8 @@ import com.mxt.anitrend.binding.setImage
 import com.mxt.anitrend.databinding.BottomSheetReviewBinding
 import com.mxt.anitrend.domain.model.ReviewRecord
 import com.mxt.anitrend.extension.parcelable
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.extension.screenParamKey
 import com.mxt.anitrend.navigation.model.ReviewScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
@@ -37,13 +40,29 @@ class BottomReviewReader : BottomSheetBase<ReviewRecord>() {
         fun newInstance(bundle: Bundle): BottomReviewReader = BottomReviewReader().apply {
             arguments = bundle
         }
+
+        /**
+         * Resolves the review identity from the sheet arguments.
+         *
+         * The typed [ReviewScreenParam] under the stable ARG_REVIEW_SCREEN key wins
+         * when present; otherwise the legacy arg_model channel (pre-migration
+         * builders) is bridged.
+         */
+        fun fromBundle(bundle: Bundle?): ReviewScreenParam? = resolve(
+            typed = bundle?.screenParam<ReviewScreenParam>(),
+            legacy = bundle?.parcelable(KeyUtil.arg_model),
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: ReviewScreenParam?, legacy: ReviewScreenParam?): ReviewScreenParam? {
+            typed?.let { return it }
+            return legacy
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            reviewParam = args.parcelable(KeyUtil.arg_model)
-        }
+        reviewParam = fromBundle(arguments)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -95,16 +114,25 @@ class BottomReviewReader : BottomSheetBase<ReviewRecord>() {
 
         fun setReview(review: ReviewRecord): Builder {
             this.review = review
-            bundle.putParcelable(
-                KeyUtil.arg_model,
-                ReviewScreenParam(
-                    reviewId = review.id,
-                    mediaId = review.media?.id,
-                    mediaType = review.media?.type,
-                    userId = review.user?.id,
-                ),
-            )
+            val param = review.toReviewScreenParam()
+            // Stable-key write at the production entry point; the legacy arg_model
+            // channel is retained for pre-migration readers.
+            bundle.putParcelable(screenParamKey<ReviewScreenParam>(), param)
+            bundle.putParcelable(KeyUtil.arg_model, param)
             return this
         }
     }
 }
+
+/**
+ * Production writer mapping for the review reader sheet: extracts only the stable
+ * review, media, and user identities from a [ReviewRecord]. The entity itself is
+ * never parceled into the sheet bundle.
+ */
+@VisibleForTesting
+internal fun ReviewRecord.toReviewScreenParam(): ReviewScreenParam = ReviewScreenParam(
+    reviewId = id,
+    mediaId = media?.id,
+    mediaType = media?.type,
+    userId = user?.id,
+)

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetComposer.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetComposer.kt
@@ -58,6 +58,10 @@ class BottomSheetComposer :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let { args ->
+            // Documented legacy channel: the composer bundle is a local draft and
+            // navigation bundle that predates the ScreenParam wire-key contract. The
+            // FeedComposerScreenParam (feed id, recipient identity, draft text) stays
+            // on KeyUtil.arg_model; draft text is local mutation state, not identity.
             composerParam = args.parcelable(KeyUtil.arg_model)
             requestType = args.getInt(KeyUtil.arg_request_type)
         }
@@ -206,7 +210,8 @@ class BottomSheetComposer :
 
         /**
          * Typed identity/draft contract for the composer. Prefer this over the legacy
-         * entity bridges once callers can supply identity-only values.
+         * entity bridges once callers can supply identity-only values. Kept on the
+         * documented legacy arg_model channel (see onCreate).
          */
         fun setComposerParam(composerParam: FeedComposerScreenParam): Builder {
             bundle.putParcelable(KeyUtil.arg_model, composerParam)

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetListUsers.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetListUsers.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -28,6 +29,9 @@ import com.mxt.anitrend.domain.user.interactor.ToggleUserFollowInteractor
 import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.navigation.extension.screenParam
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.UserListScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.activity.detail.ProfileActivity
@@ -77,16 +81,40 @@ class BottomSheetListUsers :
         fun newInstance(bundle: Bundle): BottomSheetListUsers = BottomSheetListUsers().apply {
             arguments = bundle
         }
+
+        /**
+         * Resolves the user-list identity from the sheet arguments.
+         *
+         * The typed [UserListScreenParam] takes precedence only when valid (positive
+         * user id); otherwise the legacy [KeyUtil.arg_userId] / [KeyUtil.arg_request_type]
+         * extras are bridged with their exact raw values (absent resolves to 0,
+         * explicit zero or negative ids pass through, mirroring the pre-refactor
+         * getter). The model count stays on the legacy channel (toolbar presentation).
+         */
+        fun fromBundle(bundle: Bundle?): UserListScreenParam? = resolve(
+            typed = bundle?.screenParam<UserListScreenParam>(),
+            legacyUserId = bundle?.getLong(KeyUtil.arg_userId) ?: 0L,
+            legacyRequestType = bundle?.getInt(KeyUtil.arg_request_type) ?: 0,
+        )
+
+        @VisibleForTesting
+        internal fun resolve(typed: UserListScreenParam?, legacyUserId: Long, legacyRequestType: Int): UserListScreenParam? {
+            typed?.let { param ->
+                if (param.userId > 0) return param
+                // Typed param present but invalid: fall through to the exact raw legacy values.
+            }
+            return UserListScreenParam(userId = legacyUserId, requestType = legacyRequestType)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val ctx = requireContext()
-        arguments?.let { args ->
-            count = args.getInt(KeyUtil.arg_model)
-            userId = args.getLong(KeyUtil.arg_userId)
-            requestType = args.getInt(KeyUtil.arg_request_type)
+        fromBundle(arguments)?.let { args ->
+            userId = args.userId
+            requestType = args.requestType
         }
+        count = arguments?.getInt(KeyUtil.arg_model) ?: 0
         mAdapter = UserAdapter(
             context = ctx,
             currentUser = databaseHelper.currentUser,
@@ -358,7 +386,18 @@ class BottomSheetListUsers :
     ) = Unit
 
     class Builder : BottomSheetBuilder() {
-        override fun build(): BottomSheetBase<*> = newInstance(bundle)
+        override fun build(): BottomSheetBase<*> {
+            // Typed identity write at the production entry point, derived from the
+            // legacy setters; the legacy keys are retained for pre-migration readers.
+            bundle.putParcelable(
+                screenParamKey<UserListScreenParam>(),
+                UserListScreenParam(
+                    userId = bundle.getLong(KeyUtil.arg_userId, 0L),
+                    requestType = bundle.getInt(KeyUtil.arg_request_type, 0),
+                ),
+            )
+            return newInstance(bundle)
+        }
 
         fun setUserId(userId: Long): Builder {
             bundle.putLong(KeyUtil.arg_userId, userId)

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManage.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -566,7 +567,18 @@ class BottomSheetSeriesManage : BottomSheetDialogFragment() {
     }
 
     companion object {
-        private const val ARG_MEDIA_BASE = "arg_media_base"
+        /**
+         * Entity navigation boundary (documented Phase 2 decision): this sheet
+         * edits the media-list entry state derived from the full [MediaBase]
+         * (mediaListEntry, titles, episode/volume counts), so an identity-only
+         * param cannot reconstruct it without a repository fetch. The only caller
+         * (MediaDialogUtil) is outside the navigation-migration scope, so the
+         * entity channel is kept as a compatibility bridge with its stable wire
+         * key unchanged. Revisit when callers can supply identity-only values and
+         * the sheet resolves entry state from a store.
+         */
+        @VisibleForTesting
+        internal const val ARG_MEDIA_BASE = "arg_media_base"
 
         fun newInstance(mediaBase: MediaBase): BottomSheetSeriesManage = BottomSheetSeriesManage().apply {
             arguments = Bundle().apply {

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSpoiler.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetSpoiler.kt
@@ -2,6 +2,7 @@ package com.mxt.anitrend.view.sheet
 
 import android.app.Dialog
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.binding.richMarkDown
 import com.mxt.anitrend.databinding.BottomSheetSpoilerBinding
@@ -12,7 +13,7 @@ class BottomSheetSpoiler : BottomSheetBase<Unit>() {
     private var binding: BottomSheetSpoilerBinding? = null
 
     private val text by lazy(LazyThreadSafetyMode.NONE) {
-        arguments?.getString(KeyUtil.arg_text)
+        fromBundle(arguments)
     }
 
     /**
@@ -55,5 +56,15 @@ class BottomSheetSpoiler : BottomSheetBase<Unit>() {
             fragment.arguments = bundle
             return fragment
         }
+
+        /**
+         * Documented legacy channel: the spoiler body is rendered text, not identity.
+         * It stays on arg_text (set by [Builder.setText]) until a spoiler-state model
+         * is designed. Reads mirror the pre-refactor getter exactly (absent → null).
+         */
+        fun fromBundle(bundle: Bundle?): String? = resolveLegacyText(bundle?.getString(KeyUtil.arg_text))
+
+        @VisibleForTesting
+        internal fun resolveLegacyText(raw: String?): String? = raw
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/navigation/FeedComposerScreenParamTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/navigation/FeedComposerScreenParamTest.kt
@@ -2,8 +2,6 @@ package com.mxt.anitrend.navigation
 
 import com.mxt.anitrend.model.entity.anilist.FeedList
 import com.mxt.anitrend.model.entity.base.UserBase
-import com.mxt.anitrend.navigation.extension.ARG_FEED_COMPOSER_SCREEN
-import com.mxt.anitrend.navigation.extension.screenParamKey
 import com.mxt.anitrend.navigation.model.FeedComposerScreenParam
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,18 +9,15 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * Focused tests for the feed composer screen parameter (ADR Phase 2 lane A).
+ * Focused tests for the feed composer draft argument.
  *
- * The composer argument is a dedicated identity/draft contract: it carries only stable
- * ids and display/draft strings and never a canonical [FeedList] or [UserBase]. The
- * real parcel round trip lives in [com.mxt.anitrend.navigation.ScreenParamRoundTripTest].
+ * The composer argument is a legacy parcelable local draft contract, NOT identity
+ * navigation: it lives on the legacy `arg_model` channel (BottomSheetComposer) and
+ * carries only stable ids and display/draft strings, never a canonical [FeedList]
+ * or [UserBase]. The real parcel round trip lives in instrumentation
+ * ([com.mxt.anitrend.navigation.FragmentBundleRoundTripTest]).
  */
 class FeedComposerScreenParamTest {
-
-    @Test
-    fun `composer param resolves to stable wire key`() {
-        assertEquals(ARG_FEED_COMPOSER_SCREEN, screenParamKey<FeedComposerScreenParam>())
-    }
 
     @Test
     fun `composer param holds only identity and draft values`() {
@@ -55,5 +50,12 @@ class FeedComposerScreenParamTest {
 
         assertFalse(fieldTypes.contains(FeedList::class.java))
         assertFalse(fieldTypes.contains(UserBase::class.java))
+    }
+
+    @Test
+    fun `composer param is not part of the ScreenParam family`() {
+        // The composer draft is a legacy parcelable local argument; it must not
+        // resolve through the ScreenParam wire-key contract.
+        assertFalse(FeedComposerScreenParam::class.java.interfaces.any { it.simpleName == "ScreenParam" })
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/navigation/NavigationArgsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/navigation/NavigationArgsTest.kt
@@ -1,0 +1,114 @@
+package com.mxt.anitrend.navigation
+
+import com.mxt.anitrend.graphql.generated.ActivityType
+import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.navigation.extension.NavigationArgs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Base-behavior tests for the shared fragment navigation-bundle parsers. These
+ * capture the exact containsKey / default / null-versus-empty semantics that the
+ * migrated fragments must preserve (FeedListFragment, MediaBrowseFragment,
+ * MediaLatestList, UserFeedFragment, MediaFeedFragment, MessageFeedFragment).
+ */
+class NavigationArgsTest {
+
+    // ── intWithDefault (Bundle.getInt(key, default) semantics) ──
+
+    @Test
+    fun `intWithDefault returns stored value when key is present`() {
+        assertEquals(25, NavigationArgs.intWithDefault(containsKey = true, value = 25, default = 50))
+    }
+
+    @Test
+    fun `intWithDefault returns default when key is absent`() {
+        assertEquals(50, NavigationArgs.intWithDefault(containsKey = false, value = 0, default = 50))
+    }
+
+    // ── booleanWithDefault (Bundle.getBoolean(key, default) semantics) ──
+
+    @Test
+    fun `booleanWithDefault returns stored value when key is present`() {
+        assertEquals(false, NavigationArgs.booleanWithDefault(containsKey = true, value = false, default = true))
+    }
+
+    @Test
+    fun `booleanWithDefault returns default when key is absent`() {
+        assertEquals(true, NavigationArgs.booleanWithDefault(containsKey = false, value = false, default = true))
+    }
+
+    // ── optionalBoolean (containsKey tri-state) ──
+
+    @Test
+    fun `optionalBoolean returns null when key is absent`() {
+        assertNull(NavigationArgs.optionalBoolean(containsKey = false, value = true))
+    }
+
+    @Test
+    fun `optionalBoolean returns stored value when key is present`() {
+        assertEquals(true, NavigationArgs.optionalBoolean(containsKey = true, value = true))
+        assertEquals(false, NavigationArgs.optionalBoolean(containsKey = true, value = false))
+    }
+
+    // ── optionalString / optionalInt (containsKey tri-state) ──
+
+    @Test
+    fun `optionalString returns null when key is absent`() {
+        assertNull(NavigationArgs.optionalString(containsKey = false, value = "x"))
+    }
+
+    @Test
+    fun `optionalString returns stored value when key is present`() {
+        assertEquals("x", NavigationArgs.optionalString(containsKey = true, value = "x"))
+    }
+
+    @Test
+    fun `optionalInt returns null when key is absent`() {
+        assertNull(NavigationArgs.optionalInt(containsKey = false, value = 7))
+    }
+
+    @Test
+    fun `optionalInt returns stored value when key is present`() {
+        assertEquals(7, NavigationArgs.optionalInt(containsKey = true, value = 7))
+    }
+
+    // ── optionalStringList (GraphQL null-versus-empty boundary) ──
+
+    @Test
+    fun `optionalStringList returns null when key is absent`() {
+        // Semantically absent GraphQL list input must stay null, never an empty list.
+        assertNull(NavigationArgs.optionalStringList(containsKey = false, value = listOf("Action")))
+    }
+
+    @Test
+    fun `optionalStringList returns stored list when key is present`() {
+        assertEquals(listOf("Action"), NavigationArgs.optionalStringList(containsKey = true, value = listOf("Action")))
+    }
+
+    // ── enum coercion ──
+
+    @Test
+    fun `resolveActivityType returns null for null or unknown raw value`() {
+        assertNull(NavigationArgs.resolveActivityType(null))
+        assertNull(NavigationArgs.resolveActivityType("NOT_A_TYPE"))
+    }
+
+    @Test
+    fun `resolveActivityType coerces known raw value`() {
+        assertEquals(ActivityType.MEDIA_LIST, NavigationArgs.resolveActivityType(ActivityType.MEDIA_LIST.name))
+    }
+
+    @Test
+    fun `resolveMediaType returns null for null or unknown raw value`() {
+        assertNull(NavigationArgs.resolveMediaType(null))
+        assertNull(NavigationArgs.resolveMediaType("NOT_A_TYPE"))
+    }
+
+    @Test
+    fun `resolveMediaType coerces known raw value`() {
+        assertEquals(MediaType.ANIME, NavigationArgs.resolveMediaType(MediaType.ANIME.name))
+        assertEquals(MediaType.MANGA, NavigationArgs.resolveMediaType(MediaType.MANGA.name))
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/base/GiphyPreviewActivityTest.kt
@@ -1,5 +1,8 @@
 package com.mxt.anitrend.view.activity.base
 
+import com.mxt.anitrend.navigation.extension.ARG_GIPHY_PREVIEW_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.GiphyPreviewScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -9,51 +12,83 @@ import org.junit.Test
 
 class GiphyPreviewActivityTest {
 
-    // ── parseArgs null-safety (exercises production code) ──
+    // ── production parseUrl(): legacy wire bridge (exercises production code) ──
 
     @Test
-    fun `parseArgs returns null for empty string`() {
-        assertNull(GiphyPreviewActivity.parseArgs(""))
+    fun `parseUrl returns null for empty string`() {
+        assertNull(GiphyPreviewActivity.parseUrl(""))
     }
 
     @Test
-    fun `parseArgs returns null for null input`() {
-        assertNull(GiphyPreviewActivity.parseArgs(null))
+    fun `parseUrl returns null for null input`() {
+        assertNull(GiphyPreviewActivity.parseUrl(null))
     }
 
     @Test
-    fun `parseArgs constructs Args for non-empty modelUrl`() {
+    fun `parseUrl constructs param for non-empty modelUrl`() {
         val modelUrl = "https://media.giphy.com/abc123/giphy.gif"
-        val args = GiphyPreviewActivity.parseArgs(modelUrl)
-        assertNotNull(args)
-        assertEquals(modelUrl, args!!.modelUrl)
+        val param = GiphyPreviewActivity.parseUrl(modelUrl)
+        assertNotNull(param)
+        assertEquals(modelUrl, param!!.url)
     }
 
-    // ── wire key ──
+    @Test
+    fun `parseUrl treats blank as valid by pre-existing contract`() {
+        val blank = "   "
+        assertTrue(blank.isNullOrBlank())
+        assertTrue(!blank.isNullOrEmpty())
+
+        val param = GiphyPreviewActivity.parseUrl(blank)
+        assertNotNull(param)
+        assertEquals(blank, param!!.url)
+    }
+
+    // ── production resolve(): typed/legacy compatibility ──
+
+    @Test
+    fun `resolve prefers typed param when present and non-empty`() {
+        val result = GiphyPreviewActivity.resolve(typed = GiphyPreviewScreenParam(url = "https://typed.example/giphy.gif"), legacyUrl = "https://legacy.example/giphy.gif")
+        assertNotNull(result)
+        assertEquals("https://typed.example/giphy.gif", result!!.url)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but empty, even with valid legacy url`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(GiphyPreviewActivity.resolve(typed = GiphyPreviewScreenParam(url = ""), legacyUrl = "https://legacy.example/giphy.gif"))
+    }
+
+    @Test
+    fun `resolve falls back to legacy wire extra when typed param is absent`() {
+        val result = GiphyPreviewActivity.resolve(typed = null, legacyUrl = "https://legacy.example/giphy.gif")
+        assertNotNull(result)
+        assertEquals("https://legacy.example/giphy.gif", result!!.url)
+    }
+
+    // ── wire keys ──
 
     @Test
     fun `wire key matches KeyUtil arg_model constant`() {
         assertEquals("arg_model", KeyUtil.arg_model)
     }
 
-    // ── Args data class ──
-
     @Test
-    fun `Args holds modelUrl correctly`() {
-        val modelUrl = "https://media.giphy.com/abc123/giphy.gif"
-        val args = GiphyPreviewActivity.Args(modelUrl)
-
-        assertEquals(modelUrl, args.modelUrl)
+    fun `stable giphy preview screen key uses destination-owned namespace`() {
+        assertEquals("arg.giphy.preview.screen", ARG_GIPHY_PREVIEW_SCREEN)
     }
 
     @Test
-    fun `parseArgs treats blank as valid by pre-existing contract`() {
-        val blank = "   "
-        assertTrue(blank.isNullOrBlank())
-        assertTrue(!blank.isNullOrEmpty())
+    fun `screenParamKey resolves giphy preview param to its stable key`() {
+        assertEquals(ARG_GIPHY_PREVIEW_SCREEN, screenParamKey<GiphyPreviewScreenParam>())
+    }
 
-        val args = GiphyPreviewActivity.parseArgs(blank)
-        assertNotNull(args)
-        assertEquals(blank, args!!.modelUrl)
+    // ── parameter construction ──
+
+    @Test
+    fun `GiphyPreviewScreenParam holds url correctly`() {
+        val modelUrl = "https://media.giphy.com/abc123/giphy.gif"
+        val param = GiphyPreviewScreenParam(url = modelUrl)
+
+        assertEquals(modelUrl, param.url)
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/base/ImagePreviewActivityTest.kt
@@ -1,5 +1,8 @@
 package com.mxt.anitrend.view.activity.base
 
+import com.mxt.anitrend.navigation.extension.ARG_IMAGE_PREVIEW_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.ImagePreviewScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -9,45 +12,28 @@ import org.junit.Test
 
 class ImagePreviewActivityTest {
 
-    // ── parseArgs null-safety (exercises production code) ──
+    // ── production parseUrl(): legacy wire bridge (exercises production code) ──
 
     @Test
-    fun `parseArgs returns null for empty string`() {
-        assertNull(ImagePreviewActivity.parseArgs(""))
+    fun `parseUrl returns null for empty string`() {
+        assertNull(ImagePreviewActivity.parseUrl(""))
     }
 
     @Test
-    fun `parseArgs returns null for null input`() {
-        assertNull(ImagePreviewActivity.parseArgs(null))
+    fun `parseUrl returns null for null input`() {
+        assertNull(ImagePreviewActivity.parseUrl(null))
     }
 
     @Test
-    fun `parseArgs constructs Args for non-empty modelUrl`() {
+    fun `parseUrl constructs param for non-empty modelUrl`() {
         val modelUrl = "https://example.com/image.jpg"
-        val args = ImagePreviewActivity.parseArgs(modelUrl)
-        assertNotNull(args)
-        assertEquals(modelUrl, args!!.modelUrl)
-    }
-
-    // ── wire key ──
-
-    @Test
-    fun `wire key matches KeyUtil arg_model constant`() {
-        assertEquals("arg_model", KeyUtil.arg_model)
-    }
-
-    // ── Args data class ──
-
-    @Test
-    fun `Args holds modelUrl correctly`() {
-        val modelUrl = "https://example.com/image.jpg"
-        val args = ImagePreviewActivity.Args(modelUrl)
-
-        assertEquals(modelUrl, args.modelUrl)
+        val param = ImagePreviewActivity.parseUrl(modelUrl)
+        assertNotNull(param)
+        assertEquals(modelUrl, param!!.url)
     }
 
     @Test
-    fun `parseArgs treats blank as valid by pre-existing contract`() {
+    fun `parseUrl treats blank as valid by pre-existing contract`() {
         // Documenting: isNullOrEmpty allows blank strings, preserving the
         // original getStringExtra + null-check behaviour. A blank URL will
         // reach Glide and fail silently there (pre-existing behaviour).
@@ -55,8 +41,57 @@ class ImagePreviewActivityTest {
         assertTrue(blank.isNullOrBlank())
         assertTrue(!blank.isNullOrEmpty())
 
-        val args = ImagePreviewActivity.parseArgs(blank)
-        assertNotNull(args)
-        assertEquals(blank, args!!.modelUrl)
+        val param = ImagePreviewActivity.parseUrl(blank)
+        assertNotNull(param)
+        assertEquals(blank, param!!.url)
+    }
+
+    // ── production resolve(): typed/legacy compatibility ──
+
+    @Test
+    fun `resolve prefers typed param when present and non-empty`() {
+        val result = ImagePreviewActivity.resolve(typed = ImagePreviewScreenParam(url = "https://typed.example/image.jpg"), legacyUrl = "https://legacy.example/image.jpg")
+        assertNotNull(result)
+        assertEquals("https://typed.example/image.jpg", result!!.url)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but empty, even with valid legacy url`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(ImagePreviewActivity.resolve(typed = ImagePreviewScreenParam(url = ""), legacyUrl = "https://legacy.example/image.jpg"))
+    }
+
+    @Test
+    fun `resolve falls back to legacy wire extra when typed param is absent`() {
+        val result = ImagePreviewActivity.resolve(typed = null, legacyUrl = "https://legacy.example/image.jpg")
+        assertNotNull(result)
+        assertEquals("https://legacy.example/image.jpg", result!!.url)
+    }
+
+    // ── wire keys ──
+
+    @Test
+    fun `wire key matches KeyUtil arg_model constant`() {
+        assertEquals("arg_model", KeyUtil.arg_model)
+    }
+
+    @Test
+    fun `stable image preview screen key uses destination-owned namespace`() {
+        assertEquals("arg.image.preview.screen", ARG_IMAGE_PREVIEW_SCREEN)
+    }
+
+    @Test
+    fun `screenParamKey resolves image preview param to its stable key`() {
+        assertEquals(ARG_IMAGE_PREVIEW_SCREEN, screenParamKey<ImagePreviewScreenParam>())
+    }
+
+    // ── parameter construction ──
+
+    @Test
+    fun `ImagePreviewScreenParam holds url correctly`() {
+        val modelUrl = "https://example.com/image.jpg"
+        val param = ImagePreviewScreenParam(url = modelUrl)
+
+        assertEquals(modelUrl, param.url)
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/base/VideoPlayerActivityTest.kt
@@ -1,5 +1,8 @@
 package com.mxt.anitrend.view.activity.base
 
+import com.mxt.anitrend.navigation.extension.ARG_VIDEO_PLAYER_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.VideoPlayerScreenParam
 import com.mxt.anitrend.util.KeyUtil
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -9,51 +12,83 @@ import org.junit.Test
 
 class VideoPlayerActivityTest {
 
-    // ── parseArgs null-safety (exercises production code) ──
+    // ── production parseUrl(): legacy wire bridge (exercises production code) ──
 
     @Test
-    fun `parseArgs returns null for empty string`() {
-        assertNull(VideoPlayerActivity.parseArgs(""))
+    fun `parseUrl returns null for empty string`() {
+        assertNull(VideoPlayerActivity.parseUrl(""))
     }
 
     @Test
-    fun `parseArgs returns null for null input`() {
-        assertNull(VideoPlayerActivity.parseArgs(null))
+    fun `parseUrl returns null for null input`() {
+        assertNull(VideoPlayerActivity.parseUrl(null))
     }
 
     @Test
-    fun `parseArgs constructs Args for non-empty contentLink`() {
+    fun `parseUrl constructs param for non-empty contentLink`() {
         val link = "https://example.com/video.mp4"
-        val args = VideoPlayerActivity.parseArgs(link)
-        assertNotNull(args)
-        assertEquals(link, args!!.contentLink)
+        val param = VideoPlayerActivity.parseUrl(link)
+        assertNotNull(param)
+        assertEquals(link, param!!.url)
     }
 
-    // ── wire key ──
+    @Test
+    fun `parseUrl treats blank as valid by pre-existing contract`() {
+        val blank = "   "
+        assertTrue(blank.isNullOrBlank())
+        assertTrue(!blank.isNullOrEmpty())
+
+        val param = VideoPlayerActivity.parseUrl(blank)
+        assertNotNull(param)
+        assertEquals(blank, param!!.url)
+    }
+
+    // ── production resolve(): typed/legacy compatibility ──
+
+    @Test
+    fun `resolve prefers typed param when present and non-empty`() {
+        val result = VideoPlayerActivity.resolve(typed = VideoPlayerScreenParam(url = "https://typed.example/video.mp4"), legacyUrl = "https://legacy.example/video.mp4")
+        assertNotNull(result)
+        assertEquals("https://typed.example/video.mp4", result!!.url)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but empty, even with valid legacy url`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(VideoPlayerActivity.resolve(typed = VideoPlayerScreenParam(url = ""), legacyUrl = "https://legacy.example/video.mp4"))
+    }
+
+    @Test
+    fun `resolve falls back to legacy wire extra when typed param is absent`() {
+        val result = VideoPlayerActivity.resolve(typed = null, legacyUrl = "https://legacy.example/video.mp4")
+        assertNotNull(result)
+        assertEquals("https://legacy.example/video.mp4", result!!.url)
+    }
+
+    // ── wire keys ──
 
     @Test
     fun `wire key matches KeyUtil arg_model constant`() {
         assertEquals("arg_model", KeyUtil.arg_model)
     }
 
-    // ── Args data class ──
-
     @Test
-    fun `Args holds contentLink correctly`() {
-        val link = "https://example.com/video.mp4"
-        val args = VideoPlayerActivity.Args(link)
-
-        assertEquals(link, args.contentLink)
+    fun `stable video player screen key uses destination-owned namespace`() {
+        assertEquals("arg.video.player.screen", ARG_VIDEO_PLAYER_SCREEN)
     }
 
     @Test
-    fun `parseArgs treats blank as valid by pre-existing contract`() {
-        val blank = "   "
-        assertTrue(blank.isNullOrBlank())
-        assertTrue(!blank.isNullOrEmpty())
+    fun `screenParamKey resolves video player param to its stable key`() {
+        assertEquals(ARG_VIDEO_PLAYER_SCREEN, screenParamKey<VideoPlayerScreenParam>())
+    }
 
-        val args = VideoPlayerActivity.parseArgs(blank)
-        assertNotNull(args)
-        assertEquals(blank, args!!.contentLink)
+    // ── parameter construction ──
+
+    @Test
+    fun `VideoPlayerScreenParam holds url correctly`() {
+        val link = "https://example.com/video.mp4"
+        val param = VideoPlayerScreenParam(url = link)
+
+        assertEquals(link, param.url)
     }
 }

--- a/app/src/test/java/com/mxt/anitrend/view/activity/detail/CharacterActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/detail/CharacterActivityTest.kt
@@ -1,0 +1,80 @@
+package com.mxt.anitrend.view.activity.detail
+
+import com.mxt.anitrend.navigation.extension.ARG_CHARACTER_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
+import com.mxt.anitrend.util.KeyUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CharacterActivityTest {
+
+    // ── production resolve(): missing/invalid ids ──
+
+    @Test
+    fun `resolve returns null when no identity is supplied`() {
+        // Mirrors an intent without extras: getLongExtra(KeyUtil.arg_id, -1) → -1.
+        assertNull(CharacterActivity.resolve(typed = null, legacyId = -1))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is negative`() {
+        assertNull(CharacterActivity.resolve(typed = null, legacyId = -5))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is zero`() {
+        assertNull(CharacterActivity.resolve(typed = null, legacyId = 0))
+    }
+
+    // ── production resolve(): legacy bridge ──
+
+    @Test
+    fun `resolve bridges positive legacy id`() {
+        val result = CharacterActivity.resolve(typed = null, legacyId = 123L)
+        assertNotNull(result)
+        assertEquals(123L, result!!.characterId)
+    }
+
+    // ── production resolve(): typed-first precedence ──
+
+    @Test
+    fun `resolve returns typed param when present and positive`() {
+        val result = CharacterActivity.resolve(typed = CharacterScreenParam(characterId = 77L), legacyId = 5L)
+        assertNotNull(result)
+        assertEquals(77L, result!!.characterId)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but invalid, even with valid legacy id`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(CharacterActivity.resolve(typed = CharacterScreenParam(characterId = 0), legacyId = 5L))
+    }
+
+    // ── wire keys ──
+
+    @Test
+    fun `legacy wire key matches KeyUtil arg_id constant`() {
+        assertEquals("id", KeyUtil.arg_id)
+    }
+
+    @Test
+    fun `stable character screen key uses destination-owned namespace`() {
+        assertEquals("arg.character.screen", ARG_CHARACTER_SCREEN)
+    }
+
+    @Test
+    fun `screenParamKey resolves character param to its stable key`() {
+        assertEquals(ARG_CHARACTER_SCREEN, screenParamKey<CharacterScreenParam>())
+    }
+
+    // ── parameter construction ──
+
+    @Test
+    fun `CharacterScreenParam holds characterId correctly`() {
+        val param = CharacterScreenParam(characterId = 456L)
+        assertEquals(456L, param.characterId)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/activity/detail/ProfileActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/detail/ProfileActivityTest.kt
@@ -1,0 +1,158 @@
+package com.mxt.anitrend.view.activity.detail
+
+import android.content.Intent
+import com.mxt.anitrend.navigation.extension.ARG_USER_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.util.KeyUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+class ProfileActivityTest {
+
+    // ── production resolve(): missing/invalid identity ──
+
+    @Test
+    fun `resolve returns null when no identity is supplied`() {
+        // Mirrors an intent without extras: getLongExtra(KeyUtil.arg_id, -1) → -1
+        // and getStringExtra(KeyUtil.arg_userName) → null.
+        assertNull(ProfileActivity.resolve(typed = null, legacyId = -1, legacyName = null))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is negative and name is absent`() {
+        assertNull(ProfileActivity.resolve(typed = null, legacyId = -7, legacyName = null))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is zero and name is blank`() {
+        assertNull(ProfileActivity.resolve(typed = null, legacyId = 0, legacyName = "   "))
+    }
+
+    // ── production resolve(): legacy bridge ──
+
+    @Test
+    fun `resolve bridges positive legacy id`() {
+        val result = ProfileActivity.resolve(typed = null, legacyId = 123L, legacyName = null)
+        assertNotNull(result)
+        assertEquals(123L, result!!.userId)
+        assertNull(result.initialName)
+    }
+
+    @Test
+    fun `resolve bridges legacy user name`() {
+        val result = ProfileActivity.resolve(typed = null, legacyId = -1, legacyName = "Raki")
+        assertNotNull(result)
+        assertEquals(0L, result!!.userId)
+        assertEquals("Raki", result.initialName)
+    }
+
+    @Test
+    fun `resolve bridges legacy id and name together`() {
+        val result = ProfileActivity.resolve(typed = null, legacyId = 123L, legacyName = "Raki")
+        assertNotNull(result)
+        assertEquals(123L, result!!.userId)
+        assertEquals("Raki", result.initialName)
+    }
+
+    // ── production resolve(): typed-first precedence ──
+
+    @Test
+    fun `resolve returns typed param when present and valid`() {
+        val result = ProfileActivity.resolve(typed = UserScreenParam(userId = 77L, initialName = "Raki"), legacyId = -1, legacyName = null)
+        assertNotNull(result)
+        assertEquals(77L, result!!.userId)
+        assertEquals("Raki", result.initialName)
+    }
+
+    @Test
+    fun `resolve returns typed name-only param when present and valid`() {
+        val result = ProfileActivity.resolve(typed = UserScreenParam(userId = 0L, initialName = "Raki"), legacyId = 5L, legacyName = null)
+        assertNotNull(result)
+        assertEquals(0L, result!!.userId)
+        assertEquals("Raki", result.initialName)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but invalid, even with valid legacy identity`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(ProfileActivity.resolve(typed = UserScreenParam(userId = 0L, initialName = null), legacyId = 1, legacyName = "Raki"))
+    }
+
+    // ── production hasMediaListRedirect(): deep-link routing presence semantics ──
+    //
+    // Only hasExtra is stubbed on the mocked intent; getStringExtra stays unstubbed
+    // (returns null by default), so these tests fail if the production rule ever
+    // regresses from presence-based hasExtra semantics back to value-based parsing.
+
+    @Test
+    fun `redirect does not fire when media type extra is absent`() {
+        val intent = mock(Intent::class.java)
+        `when`(intent.hasExtra(KeyUtil.arg_mediaType)).thenReturn(false)
+        assertFalse(ProfileActivity.hasMediaListRedirect(intent))
+    }
+
+    @Test
+    fun `redirect fires for anime deep link`() {
+        val intent = mock(Intent::class.java)
+        `when`(intent.hasExtra(KeyUtil.arg_mediaType)).thenReturn(true)
+        assertTrue(ProfileActivity.hasMediaListRedirect(intent))
+    }
+
+    @Test
+    fun `redirect fires for manga deep link`() {
+        val intent = mock(Intent::class.java)
+        `when`(intent.hasExtra(KeyUtil.arg_mediaType)).thenReturn(true)
+        assertTrue(ProfileActivity.hasMediaListRedirect(intent))
+    }
+
+    @Test
+    fun `redirect fires for explicitly present null value, mirroring legacy hasExtra`() {
+        // hasExtra is value-agnostic: a key present with an explicitly null value
+        // still reports presence (getStringExtra would return null for it, which is
+        // exactly the semantic gap being closed).
+        val intent = mock(Intent::class.java)
+        `when`(intent.hasExtra(KeyUtil.arg_mediaType)).thenReturn(true)
+        assertTrue(ProfileActivity.hasMediaListRedirect(intent))
+    }
+
+    @Test
+    fun `redirect fires for non-String media type value, mirroring legacy hasExtra`() {
+        // e.g. an external intent writing a numeric extra under the media-type key:
+        // hasExtra still reports presence and the redirect fires, whereas
+        // getStringExtra would have returned null.
+        val intent = mock(Intent::class.java)
+        `when`(intent.hasExtra(KeyUtil.arg_mediaType)).thenReturn(true)
+        assertTrue(ProfileActivity.hasMediaListRedirect(intent))
+    }
+
+    // ── wire keys ──
+
+    @Test
+    fun `legacy wire keys match KeyUtil constants`() {
+        assertEquals("id", KeyUtil.arg_id)
+        assertEquals("userName", KeyUtil.arg_userName)
+        assertEquals("type", KeyUtil.arg_mediaType)
+    }
+
+    @Test
+    fun `profile reuses the user screen key namespace`() {
+        assertEquals("arg.user.screen", ARG_USER_SCREEN)
+        assertEquals(ARG_USER_SCREEN, screenParamKey<UserScreenParam>())
+    }
+
+    // ── parameter construction ──
+
+    @Test
+    fun `UserScreenParam holds userId and optional name`() {
+        val param = UserScreenParam(userId = 456L, initialName = "Raki")
+        assertEquals(456L, param.userId)
+        assertEquals("Raki", param.initialName)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/activity/detail/StaffActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/detail/StaffActivityTest.kt
@@ -1,0 +1,88 @@
+package com.mxt.anitrend.view.activity.detail
+
+import com.mxt.anitrend.navigation.extension.ARG_STAFF_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.StaffScreenParam
+import com.mxt.anitrend.util.KeyUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StaffActivityTest {
+
+    // ── production resolve(): missing/invalid ids ──
+
+    @Test
+    fun `resolve returns null when no identity is supplied`() {
+        // Mirrors an intent without extras: getLongExtra(KeyUtil.arg_id, -1) → -1.
+        assertNull(StaffActivity.resolve(typed = null, legacyId = -1))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is negative`() {
+        assertNull(StaffActivity.resolve(typed = null, legacyId = -5))
+    }
+
+    @Test
+    fun `resolve returns null when legacy id is zero`() {
+        assertNull(StaffActivity.resolve(typed = null, legacyId = 0))
+    }
+
+    // ── production resolve(): legacy bridge ──
+
+    @Test
+    fun `resolve bridges positive legacy id`() {
+        val result = StaffActivity.resolve(typed = null, legacyId = 123L)
+        assertNotNull(result)
+        assertEquals(123L, result!!.staffId)
+    }
+
+    // ── production resolve(): typed-first precedence ──
+
+    @Test
+    fun `resolve returns typed param when present and positive`() {
+        val result = StaffActivity.resolve(typed = StaffScreenParam(staffId = 77L), legacyId = 5L)
+        assertNotNull(result)
+        assertEquals(77L, result!!.staffId)
+    }
+
+    @Test
+    fun `resolve returns null when typed param is present but invalid, even with valid legacy id`() {
+        // Typed parameter wins: an invalid typed param must not fall back to legacy.
+        assertNull(StaffActivity.resolve(typed = StaffScreenParam(staffId = 0), legacyId = 5L))
+    }
+
+    // ── wire keys ──
+
+    @Test
+    fun `legacy wire key matches KeyUtil arg_id constant`() {
+        assertEquals("id", KeyUtil.arg_id)
+    }
+
+    @Test
+    fun `stable staff screen key uses destination-owned namespace`() {
+        assertEquals("arg.staff.screen", ARG_STAFF_SCREEN)
+    }
+
+    @Test
+    fun `screenParamKey resolves staff param to its stable key`() {
+        assertEquals(ARG_STAFF_SCREEN, screenParamKey<StaffScreenParam>())
+    }
+
+    // ── parameter construction ──
+
+    @Test
+    fun `StaffScreenParam holds staffId correctly`() {
+        val param = StaffScreenParam(staffId = 456L)
+        assertEquals(456L, param.staffId)
+    }
+
+    @Test
+    fun `StaffScreenParam is identity-only and does not carry the onList filter`() {
+        // The tri-state onList filter stays on the legacy arg_onList channel
+        // (read directly by the activity) until the pager fragments migrate.
+        val paramTypes = StaffScreenParam::class.java.constructors[0].parameterTypes.map { it.simpleName }
+        assertEquals(listOf("long"), paramTypes)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/activity/index/MainActivityTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/activity/index/MainActivityTest.kt
@@ -1,0 +1,36 @@
+package com.mxt.anitrend.view.activity.index
+
+import com.mxt.anitrend.R
+import com.mxt.anitrend.util.KeyUtil
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MainActivityTest {
+
+    // ── production resolveRedirect(): shortcut redirect parsing ──
+
+    @Test
+    fun `resolveRedirect returns NO_REDIRECT when extra is absent`() {
+        // Mirrors an intent without extras: getIntExtra(KeyUtil.arg_redirect, 0) → 0.
+        assertEquals(MainActivity.NO_REDIRECT, MainActivity.resolveRedirect(0))
+    }
+
+    @Test
+    fun `resolveRedirect returns NO_REDIRECT for negative garbage`() {
+        // Legacy shortcuts only write positive nav-item ids; non-positive values
+        // are normalized to no redirect instead of flowing into setCheckedItem.
+        assertEquals(MainActivity.NO_REDIRECT, MainActivity.resolveRedirect(-1))
+    }
+
+    @Test
+    fun `resolveRedirect passes through a positive nav-item id`() {
+        assertEquals(R.id.nav_myanime, MainActivity.resolveRedirect(R.id.nav_myanime))
+    }
+
+    // ── wire key ──
+
+    @Test
+    fun `legacy wire key matches KeyUtil arg_redirect constant`() {
+        assertEquals("arg_redirect", KeyUtil.arg_redirect)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentMediaFamilyArgsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentMediaFamilyArgsTest.kt
@@ -1,0 +1,199 @@
+package com.mxt.anitrend.view.fragment
+
+import com.mxt.anitrend.navigation.model.CharacterScreenParam
+import com.mxt.anitrend.navigation.model.MediaScreenParam
+import com.mxt.anitrend.navigation.model.StaffScreenParam
+import com.mxt.anitrend.navigation.model.UserScreenParam
+import com.mxt.anitrend.view.fragment.detail.CharacterOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.MediaFeedFragment
+import com.mxt.anitrend.view.fragment.detail.MediaOverviewFragment
+import com.mxt.anitrend.view.fragment.detail.MediaStaffFragment
+import com.mxt.anitrend.view.fragment.detail.MediaStatsFragment
+import com.mxt.anitrend.view.fragment.detail.ReviewFragment
+import com.mxt.anitrend.view.fragment.detail.StudioMediaFragment
+import com.mxt.anitrend.view.fragment.detail.UserFeedFragment
+import com.mxt.anitrend.view.fragment.detail.UserOverviewFragment
+import com.mxt.anitrend.view.fragment.group.CharacterActorsFragment
+import com.mxt.anitrend.view.fragment.group.MediaCharacterFragment
+import com.mxt.anitrend.view.fragment.group.MediaFormatFragment
+import com.mxt.anitrend.view.fragment.group.MediaRecommendationsFragment
+import com.mxt.anitrend.view.fragment.group.MediaRelationFragment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Compatibility tests for the media/user/character/studio family fragment parsers.
+ * All cases invoke the production `resolve` functions; absent, zero/negative,
+ * typed-first precedence, and legacy-fallback behavior are pinned exactly.
+ */
+class FragmentMediaFamilyArgsTest {
+
+    // ── media family (MediaScreenParam): absent / zero / negative legacy values ──
+
+    @Test
+    fun `media family resolve passes absent legacy id through as zero`() {
+        // Pre-refactor: getLong(arg_id) resolves to 0 when absent.
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaOverviewFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaStatsFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaRelationFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaCharacterFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaRecommendationsFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), MediaStaffFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+        assertEquals(MediaScreenParam(mediaId = 0L, mediaType = null), ReviewFragment.resolve(typed = null, legacyId = 0L, legacyType = null))
+    }
+
+    @Test
+    fun `media family resolve passes negative legacy id through exactly`() {
+        // Pre-refactor getter contract: negative ids are not normalized away.
+        assertEquals(MediaScreenParam(mediaId = -5L, mediaType = "ANIME"), MediaRelationFragment.resolve(typed = null, legacyId = -5L, legacyType = "ANIME"))
+    }
+
+    @Test
+    fun `media family resolve bridges positive legacy id and type`() {
+        val result = MediaRelationFragment.resolve(typed = null, legacyId = 123L, legacyType = "ANIME")
+        assertNotNull(result)
+        assertEquals(MediaScreenParam(mediaId = 123L, mediaType = "ANIME"), result)
+    }
+
+    @Test
+    fun `media family resolve bridges legacy id without type`() {
+        assertEquals(MediaScreenParam(mediaId = 123L, mediaType = null), MediaCharacterFragment.resolve(typed = null, legacyId = 123L, legacyType = null))
+    }
+
+    // ── media family: typed-first precedence and legacy fallback ──
+
+    @Test
+    fun `media family resolve prefers typed param when present and valid`() {
+        val typed = MediaScreenParam(mediaId = 77L, mediaType = "MANGA")
+        assertEquals(typed, MediaOverviewFragment.resolve(typed = typed, legacyId = 5L, legacyType = "ANIME"))
+    }
+
+    @Test
+    fun `media family resolve falls back to raw legacy when typed param is invalid`() {
+        // Typed param present but invalid (id 0) must not win; the exact raw legacy
+        // values are used instead.
+        assertEquals(
+            MediaScreenParam(mediaId = 5L, mediaType = "ANIME"),
+            MediaStatsFragment.resolve(typed = MediaScreenParam(mediaId = 0L), legacyId = 5L, legacyType = "ANIME"),
+        )
+        assertEquals(
+            MediaScreenParam(mediaId = -2L, mediaType = null),
+            MediaStatsFragment.resolve(typed = MediaScreenParam(mediaId = 0L), legacyId = -2L, legacyType = null),
+        )
+    }
+
+    // ── MediaFeedFragment (legacy key arg_mediaId) ──
+
+    @Test
+    fun `media feed resolve passes absent legacy id through as zero`() {
+        assertEquals(MediaScreenParam(mediaId = 0L), MediaFeedFragment.resolve(typed = null, legacyMediaId = 0L))
+    }
+
+    @Test
+    fun `media feed resolve bridges legacy media id and prefers typed param`() {
+        assertEquals(MediaScreenParam(mediaId = 42L), MediaFeedFragment.resolve(typed = null, legacyMediaId = 42L))
+        assertEquals(
+            MediaScreenParam(mediaId = 9L),
+            MediaFeedFragment.resolve(typed = MediaScreenParam(mediaId = 9L), legacyMediaId = 42L),
+        )
+    }
+
+    // ── character family (CharacterScreenParam via CharacterActivity) ──
+
+    @Test
+    fun `character overview resolve passes absent and negative legacy ids through exactly`() {
+        assertEquals(CharacterScreenParam(characterId = 0L), CharacterOverviewFragment.resolve(typed = null, legacyId = 0L))
+        assertEquals(CharacterScreenParam(characterId = -3L), CharacterOverviewFragment.resolve(typed = null, legacyId = -3L))
+    }
+
+    @Test
+    fun `character overview resolve bridges legacy id and prefers typed param`() {
+        assertEquals(CharacterScreenParam(characterId = 8L), CharacterOverviewFragment.resolve(typed = null, legacyId = 8L))
+        val typed = CharacterScreenParam(characterId = 3L)
+        assertEquals(typed, CharacterOverviewFragment.resolve(typed = typed, legacyId = 8L))
+    }
+
+    @Test
+    fun `character actors resolve bridges legacy id and falls back when typed invalid`() {
+        assertEquals(CharacterScreenParam(characterId = 8L), CharacterActorsFragment.resolve(typed = null, legacyId = 8L))
+        assertEquals(
+            CharacterScreenParam(characterId = 8L),
+            CharacterActorsFragment.resolve(typed = CharacterScreenParam(characterId = 0L), legacyId = 8L),
+        )
+    }
+
+    // ── studio family (StudioScreenParam via StudioActivity) ──
+
+    @Test
+    fun `studio media resolve passes absent and negative legacy ids through exactly`() {
+        assertEquals(0L, StudioMediaFragment.resolve(typed = null, legacyId = 0L))
+        assertEquals(-4L, StudioMediaFragment.resolve(typed = null, legacyId = -4L))
+    }
+
+    @Test
+    fun `studio media resolve bridges legacy id and prefers typed param`() {
+        assertEquals(6L, StudioMediaFragment.resolve(typed = null, legacyId = 6L))
+        assertEquals(7L, StudioMediaFragment.resolve(typed = com.mxt.anitrend.navigation.model.StudioScreenParam(studioId = 7L), legacyId = 6L))
+        // Invalid typed param falls back to the raw legacy value.
+        assertEquals(6L, StudioMediaFragment.resolve(typed = com.mxt.anitrend.navigation.model.StudioScreenParam(studioId = 0L), legacyId = 6L))
+    }
+
+    // ── media format (shared character/staff pager tab) ──
+
+    @Test
+    fun `media format resolve passes absent and negative legacy ids through exactly`() {
+        assertEquals(0L, MediaFormatFragment.resolve(character = null, staff = null, legacyId = 0L))
+        assertEquals(-2L, MediaFormatFragment.resolve(character = null, staff = null, legacyId = -2L))
+    }
+
+    @Test
+    fun `media format resolve reads typed identity from character or staff pager`() {
+        assertEquals(9L, MediaFormatFragment.resolve(character = CharacterScreenParam(characterId = 9L), staff = null, legacyId = 3L))
+        assertEquals(8L, MediaFormatFragment.resolve(character = null, staff = StaffScreenParam(staffId = 8L), legacyId = 3L))
+        // Character identity takes precedence when both typed sources are present.
+        assertEquals(
+            9L,
+            MediaFormatFragment.resolve(character = CharacterScreenParam(characterId = 9L), staff = StaffScreenParam(staffId = 8L), legacyId = 3L),
+        )
+    }
+
+    @Test
+    fun `media format resolve falls back to raw legacy when typed invalid`() {
+        assertEquals(3L, MediaFormatFragment.resolve(character = CharacterScreenParam(characterId = 0L), staff = null, legacyId = 3L))
+        assertEquals(3L, MediaFormatFragment.resolve(character = null, staff = StaffScreenParam(staffId = 0L), legacyId = 3L))
+        assertEquals(-3L, MediaFormatFragment.resolve(character = CharacterScreenParam(characterId = 0L), staff = null, legacyId = -3L))
+    }
+
+    // ── user family (UserScreenParam via ProfileActivity) ──
+
+    @Test
+    fun `user overview resolve keeps exact legacy defaults`() {
+        // Pre-refactor: getLong(arg_id, 0L) and getString(arg_userName, "").
+        assertEquals(UserScreenParam(userId = 0L, initialName = ""), UserOverviewFragment.resolve(typed = null, legacyId = 0L, legacyName = ""))
+        assertEquals(UserScreenParam(userId = 5L, initialName = "Raki"), UserOverviewFragment.resolve(typed = null, legacyId = 5L, legacyName = "Raki"))
+    }
+
+    @Test
+    fun `user overview resolve prefers typed param`() {
+        val typed = UserScreenParam(userId = 9L, initialName = "Raki")
+        assertEquals(typed, UserOverviewFragment.resolve(typed = typed, legacyId = 5L, legacyName = "Other"))
+    }
+
+    @Test
+    fun `user feed resolve preserves containsKey id-versus-name semantics`() {
+        // Pre-refactor: containsKey(arg_id) ? getLong(arg_id) : getString(arg_userName).
+        assertEquals(UserScreenParam(userId = 5L), UserFeedFragment.resolve(typed = null, hasLegacyId = true, legacyId = 5L, legacyName = "Raki"))
+        assertEquals(
+            UserScreenParam(userId = 0L, initialName = "Raki"),
+            UserFeedFragment.resolve(typed = null, hasLegacyId = false, legacyId = 0L, legacyName = "Raki"),
+        )
+    }
+
+    @Test
+    fun `user feed resolve prefers typed param over legacy`() {
+        val typed = UserScreenParam(userId = 9L)
+        assertEquals(typed, UserFeedFragment.resolve(typed = typed, hasLegacyId = true, legacyId = 5L, legacyName = null))
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentMediaFamilyArgsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentMediaFamilyArgsTest.kt
@@ -20,7 +20,6 @@ import com.mxt.anitrend.view.fragment.group.MediaRecommendationsFragment
 import com.mxt.anitrend.view.fragment.group.MediaRelationFragment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**

--- a/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentSearchFavouritesSheetsArgsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/fragment/FragmentSearchFavouritesSheetsArgsTest.kt
@@ -1,0 +1,141 @@
+package com.mxt.anitrend.view.fragment
+
+import com.mxt.anitrend.navigation.model.SettingsCategoryScreenParam
+import com.mxt.anitrend.navigation.model.TrailerScreenParam
+import com.mxt.anitrend.navigation.model.UserListScreenParam
+import com.mxt.anitrend.model.entity.anilist.meta.MediaTrailer
+import com.mxt.anitrend.view.fragment.detail.BrowseReviewFragment
+import com.mxt.anitrend.view.fragment.favourite.MediaFavouriteFragment
+import com.mxt.anitrend.view.fragment.search.MediaSearchFragment
+import com.mxt.anitrend.view.fragment.search.UserSearchFragment
+import com.mxt.anitrend.view.fragment.settings.SettingsCategoryLegacyFragment
+import com.mxt.anitrend.view.fragment.youtube.YouTubeEmbedFragment
+import com.mxt.anitrend.view.sheet.BottomSheetListUsers
+import com.mxt.anitrend.view.sheet.BottomSheetSpoiler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Compatibility tests for the documented legacy-channel parsers (search, spoiler,
+ * browse-review, media-favourites) and the typed sheet/fragment parsers that have
+ * real production writers (user list, settings category, YouTube embed).
+ */
+class FragmentSearchFavouritesSheetsArgsTest {
+
+    // ── documented legacy channel: search query (not identity) ──
+
+    @Test
+    fun `user search legacy parser passes raw query through exactly`() {
+        assertEquals("Raki", UserSearchFragment.resolveLegacyQuery("Raki"))
+        assertNull(UserSearchFragment.resolveLegacyQuery(null))
+    }
+
+    @Test
+    fun `media search legacy parser passes raw query and type through exactly`() {
+        assertEquals("Naruto", MediaSearchFragment.resolve(legacyQuery = "Naruto", legacyType = "ANIME").searchQuery)
+        assertEquals("ANIME", MediaSearchFragment.resolve(legacyQuery = "Naruto", legacyType = "ANIME").mediaType)
+        assertEquals(null, MediaSearchFragment.resolve(legacyQuery = null, legacyType = null).searchQuery)
+        assertEquals(null, MediaSearchFragment.resolve(legacyQuery = null, legacyType = null).mediaType)
+    }
+
+    // ── documented legacy channel: spoiler rendered text (not identity) ──
+
+    @Test
+    fun `spoiler legacy parser passes raw text through exactly`() {
+        assertEquals("spoiler", BottomSheetSpoiler.resolveLegacyText("spoiler"))
+        assertNull(BottomSheetSpoiler.resolveLegacyText(null))
+    }
+
+    // ── documented legacy channel: browse-review media type (not identity) ──
+
+    @Test
+    fun `browse review legacy parser passes raw type through exactly`() {
+        assertEquals("MANGA", BrowseReviewFragment.resolveLegacyType("MANGA"))
+        assertNull(BrowseReviewFragment.resolveLegacyType(null))
+    }
+
+    // ── documented legacy channel: media favourites (identity host writes legacy) ──
+
+    @Test
+    fun `media favourites legacy parser passes raw id and type through exactly`() {
+        val args = MediaFavouriteFragment.resolve(legacyId = 4L, legacyType = "ANIME")
+        assertEquals(4L, args.userId)
+        assertEquals("ANIME", args.mediaType)
+        // Zero id passes through exactly (pre-refactor getter contract).
+        assertEquals(0L, MediaFavouriteFragment.resolve(legacyId = 0L, legacyType = null).userId)
+        assertEquals(-1L, MediaFavouriteFragment.resolve(legacyId = -1L, legacyType = null).userId)
+    }
+
+    // ── user list sheet (typed writer in Builder.build) ──
+
+    @Test
+    fun `user list sheet resolve passes absent and negative legacy user ids through exactly`() {
+        // Pre-refactor getter contract: absent resolves to 0, negative ids are not normalized.
+        assertEquals(
+            UserListScreenParam(userId = 0L, requestType = 0),
+            BottomSheetListUsers.resolve(typed = null, legacyUserId = 0L, legacyRequestType = 0),
+        )
+        assertEquals(
+            UserListScreenParam(userId = -5L, requestType = 1),
+            BottomSheetListUsers.resolve(typed = null, legacyUserId = -5L, legacyRequestType = 1),
+        )
+    }
+
+    @Test
+    fun `user list sheet resolve bridges legacy user id and request type`() {
+        assertEquals(
+            UserListScreenParam(userId = 15L, requestType = 2),
+            BottomSheetListUsers.resolve(typed = null, legacyUserId = 15L, legacyRequestType = 2),
+        )
+    }
+
+    @Test
+    fun `user list sheet resolve prefers typed param when valid`() {
+        val typed = UserListScreenParam(userId = 9L, requestType = 1)
+        assertEquals(typed, BottomSheetListUsers.resolve(typed = typed, legacyUserId = 15L, legacyRequestType = 2))
+    }
+
+    @Test
+    fun `user list sheet resolve keeps raw legacy when typed param is invalid`() {
+        // Typed param present but invalid (non-positive id) must not win; the exact
+        // raw legacy values remain unchanged, including negative user ids.
+        assertEquals(
+            UserListScreenParam(userId = -5L, requestType = 1),
+            BottomSheetListUsers.resolve(typed = UserListScreenParam(userId = 0L), legacyUserId = -5L, legacyRequestType = 1),
+        )
+    }
+
+    // ── settings category (typed writer in SettingsHubFragment) ──
+
+    @Test
+    fun `settings category resolve bridges legacy category id`() {
+        assertEquals(
+            SettingsCategoryScreenParam(categoryId = "general"),
+            SettingsCategoryLegacyFragment.resolve(typed = null, legacyCategoryId = "general"),
+        )
+        assertNull(SettingsCategoryLegacyFragment.resolve(typed = null, legacyCategoryId = null))
+    }
+
+    // ── YouTube embed: identity-only, entity bridge ──
+
+    @Test
+    fun `youtube embed resolve returns null when no identity is supplied`() {
+        assertNull(YouTubeEmbedFragment.resolve(typed = null, legacyTrailer = null))
+        assertNull(YouTubeEmbedFragment.resolve(typed = null, legacyTrailer = MediaTrailer(id = null, site = "youtube")))
+    }
+
+    @Test
+    fun `youtube embed resolve extracts identity from legacy trailer entity`() {
+        val result = YouTubeEmbedFragment.resolve(typed = null, legacyTrailer = MediaTrailer(id = "abc123", site = "youtube"))
+        assertNotNull(result)
+        assertEquals(TrailerScreenParam(trailerId = "abc123", site = "youtube"), result)
+    }
+
+    @Test
+    fun `youtube embed resolve prefers typed param`() {
+        val typed = TrailerScreenParam(trailerId = "typed", site = "youtube")
+        assertEquals(typed, YouTubeEmbedFragment.resolve(typed = typed, legacyTrailer = MediaTrailer(id = "legacy", site = "youtube")))
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/sheet/BottomReviewReaderTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/sheet/BottomReviewReaderTest.kt
@@ -1,0 +1,103 @@
+package com.mxt.anitrend.view.sheet
+
+import com.mxt.anitrend.domain.model.MediaSummaryRecord
+import com.mxt.anitrend.domain.model.ReviewRecord
+import com.mxt.anitrend.domain.model.UserSummaryRecord
+import com.mxt.anitrend.navigation.extension.ARG_REVIEW_SCREEN
+import com.mxt.anitrend.navigation.extension.screenParamKey
+import com.mxt.anitrend.navigation.model.ReviewScreenParam
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Writer/reader compatibility tests for the review reader sheet. The writer
+ * mapping extracts only stable identities from the review record, and the reader
+ * resolves typed-first with a legacy arg_model bridge.
+ */
+class BottomReviewReaderTest {
+
+    private fun reviewRecord() = ReviewRecord(
+        id = 7L,
+        summary = "summary",
+        mediaType = "ANIME",
+        body = "body",
+        rating = 80,
+        ratingAmount = 10,
+        userRating = null,
+        score = 80,
+        isPrivate = false,
+        createdAt = 1L,
+        user = UserSummaryRecord(id = 42L, name = "Raki", avatar = null, siteUrl = null),
+        media = MediaSummaryRecord(
+            id = 100L,
+            titleRomaji = null,
+            titleEnglish = null,
+            titleOriginal = null,
+            coverImage = null,
+            type = "ANIME",
+            episodes = 0,
+            chapters = 0,
+            volumes = 0,
+            status = null,
+            siteUrl = null,
+        ),
+        revision = 0L,
+    )
+
+    // ── writer mapping: entity → identity-only param ──
+
+    @Test
+    fun `writer mapping extracts only stable identities`() {
+        val param = reviewRecord().toReviewScreenParam()
+        assertEquals(
+            ReviewScreenParam(reviewId = 7L, mediaId = 100L, mediaType = "ANIME", userId = 42L),
+            param,
+        )
+    }
+
+    @Test
+    fun `writer mapping tolerates absent nested identities`() {
+        val bare = ReviewRecord(
+            id = 1L,
+            summary = null,
+            mediaType = null,
+            body = null,
+            rating = 0,
+            ratingAmount = 0,
+            userRating = null,
+            score = 0,
+            isPrivate = false,
+            createdAt = 0L,
+            user = null,
+            media = null,
+            revision = 0L,
+        )
+        assertEquals(ReviewScreenParam(reviewId = 1L), bare.toReviewScreenParam())
+    }
+
+    @Test
+    fun `writer uses the stable review screen key`() {
+        assertEquals(ARG_REVIEW_SCREEN, screenParamKey<ReviewScreenParam>())
+    }
+
+    // ── reader: typed-first precedence and legacy bridge ──
+
+    @Test
+    fun `reader prefers typed param when present`() {
+        val typed = ReviewScreenParam(reviewId = 3L)
+        val legacy = ReviewScreenParam(reviewId = 9L)
+        assertEquals(typed, BottomReviewReader.resolve(typed = typed, legacy = legacy))
+    }
+
+    @Test
+    fun `reader falls back to legacy arg_model param when typed absent`() {
+        val legacy = ReviewScreenParam(reviewId = 9L)
+        assertEquals(legacy, BottomReviewReader.resolve(typed = null, legacy = legacy))
+    }
+
+    @Test
+    fun `reader returns null when nothing is supplied`() {
+        assertNull(BottomReviewReader.resolve(typed = null, legacy = null))
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManageTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/sheet/BottomSheetSeriesManageTest.kt
@@ -1,0 +1,16 @@
+package com.mxt.anitrend.view.sheet
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Documents the deliberate entity navigation boundary of the manage-list sheet:
+ * the stable wire key is a compatibility contract and must not change.
+ */
+class BottomSheetSeriesManageTest {
+
+    @Test
+    fun `entity navigation wire key is stable`() {
+        assertEquals("arg_media_base", BottomSheetSeriesManage.ARG_MEDIA_BASE)
+    }
+}


### PR DESCRIPTION
## Description

Standardize activity and fragment navigation arguments around typed parcelable parameters and stable destination-owned keys.

- Migrates activity and fragment identity arguments with legacy compatibility bridges.
- Preserves defaults, nullability, zero/negative IDs, and pager/filter semantics.
- Adds production parsers, bundle round-trip coverage, and builder contract tests.

## Validation

- ./gradlew :app:compileAppDebugKotlin --no-daemon
- ./gradlew :app:compileAppDebugAndroidTestKotlin --no-daemon
- 60 focused JVM tests
- ./gradlew :app:testAppDebugUnitTest --no-daemon
- git diff --check

Instrumentation tests compile but were not executed because no emulator was available.