### PR TITLE
fix(ui): stabilize social interaction state

### DIFF
--- a/app/src/androidTest/java/com/mxt/anitrend/koin/KoinModuleResolutionTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/koin/KoinModuleResolutionTest.kt
@@ -23,7 +23,7 @@ class KoinModuleResolutionTest {
 
     @Suppress("DEPRECATION")
     @Test
-    fun `verify all Koin modules resolve correctly`() {
+    fun verifyAllKoinModulesResolveCorrectly() {
         startKoin {
             androidContext(ApplicationProvider.getApplicationContext())
             modules(appModules)

--- a/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetListUsersDialogStateTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetListUsersDialogStateTest.kt
@@ -190,27 +190,23 @@ class BottomSheetListUsersDialogStateTest {
             .show(activity.supportFragmentManager, SHEET_TAG)
     }
 
-    private fun install(repository: UserRepository): Module =
-        module {
-            single<UserRepository> { repository }
-        }.also { module ->
-            overrideModules += module
-            loadKoinModules(module)
-        }
+    private fun install(repository: UserRepository): Module = module {
+        single<UserRepository> { repository }
+    }.also { module ->
+        overrideModules += module
+        loadKoinModules(module)
+    }
 
-    private fun sheetFragment(activity: FragmentActivity): BottomSheetListUsers? =
-        activity.supportFragmentManager.findFragmentByTag(SHEET_TAG) as? BottomSheetListUsers
+    private fun sheetFragment(activity: FragmentActivity): BottomSheetListUsers? = activity.supportFragmentManager.findFragmentByTag(SHEET_TAG) as? BottomSheetListUsers
 
-    private fun progressLayout(sheet: BottomSheetListUsers?): ProgressLayout? =
-        sheet?.dialog?.findViewById(R.id.stateLayout)
+    private fun progressLayout(sheet: BottomSheetListUsers?): ProgressLayout? = sheet?.dialog?.findViewById(R.id.stateLayout)
 
     private fun clearScrollListeners(sheet: BottomSheetListUsers?) {
         sheet?.dialog?.findViewById<StatefulRecyclerView>(R.id.recyclerView)
             ?.clearOnScrollListeners()
     }
 
-    private fun adapterItemCount(sheet: BottomSheetListUsers?): Int? =
-        sheet?.dialog?.findViewById<StatefulRecyclerView>(R.id.recyclerView)?.adapter?.itemCount
+    private fun adapterItemCount(sheet: BottomSheetListUsers?): Int? = sheet?.dialog?.findViewById<StatefulRecyclerView>(R.id.recyclerView)?.adapter?.itemCount
 
     private inline fun <T> readOnMain(crossinline block: () -> T): T {
         var result: T? = null
@@ -237,10 +233,9 @@ class BottomSheetListUsersDialogStateTest {
         this.id = id
     }
 
-    private fun containerOf(vararg users: UserBase): PageContainer<UserBase> =
-        PageContainer<UserBase>().apply {
-            pageData = users.toList()
-        }
+    private fun containerOf(vararg users: UserBase): PageContainer<UserBase> = PageContainer<UserBase>().apply {
+        pageData = users.toList()
+    }
 
     private companion object {
         const val SHEET_TAG = "users-list-sheet-state-test"

--- a/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetListUsersDialogStateTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetListUsersDialogStateTest.kt
@@ -1,0 +1,250 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.mxt.anitrend.sheet
+
+import android.os.SystemClock
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.button.MaterialButton
+import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.recycler.StatefulRecyclerView
+import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.repository.UserRepository
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.view.sheet.BottomSheetListUsers
+import com.mxt.anitrend.widget.ProgressLayout
+import com.mxt.anitrend.widget.ProgressLayoutTestActivity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.unloadKoinModules
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Dialog-level regression seam for [BottomSheetListUsers] state delivery.
+ *
+ * The sheet attaches its content via `onCreateDialog` + `dialog.setContentView` and
+ * never creates a fragment view, so state collection must run on the fragment
+ * lifecycle, not `viewLifecycleOwner`. These tests launch the real dialog against the
+ * real Koin graph with a stubbed [UserRepository] and assert that the terminal
+ * ViewModel states actually leave the loading state and render into the dialog:
+ * success renders rows, failure shows the error/retry view, and retry re-dispatches.
+ *
+ * Without the lifecycle fix the collector never runs, the spinner persists forever,
+ * and every poll below times out.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class BottomSheetListUsersDialogStateTest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val overrideModules = mutableListOf<Module>()
+
+    @After
+    fun tearDown() {
+        overrideModules.forEach(::unloadKoinModules)
+        overrideModules.clear()
+    }
+
+    @Test
+    fun loadingSpinnerShownWhileRequestPending_thenSuccessRendersRows() {
+        val gate = CompletableDeferred<Unit>()
+        var followersResult: Result<PageContainer<UserBase>> =
+            Result.success(containerOf(user(2L, "user-2"), user(7L, "user-7")))
+        var followerCalls = 0
+        val repository = mockk<UserRepository>()
+        coEvery {
+            repository.getFollowers(1L, any(), any(), any())
+        } coAnswers {
+            followerCalls++
+            gate.await()
+            followersResult
+        }
+        coEvery {
+            repository.getFollowing(any(), any(), any(), any())
+        } returns Result.success(PageContainer())
+        install(repository)
+
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            var activity: FragmentActivity? = null
+            scenario.onActivity { host ->
+                activity = host
+                showFollowersSheet(host)
+            }
+
+            // While the request is in flight the dialog must render the loading
+            // spinner (the state that used to persist forever before the fix).
+            waitUntil("loading spinner shown while request is pending") {
+                progressLayout(sheetFragment(activity!!))?.isLoading == true
+            }
+
+            // Isolate state delivery from pagination: the real RecyclerScrollListener
+            // fires onLoadMore as soon as rows render, which would add a second
+            // repository call. Clear it before releasing the pending response.
+            instrumentation.runOnMainSync {
+                clearScrollListeners(sheetFragment(activity!!))
+            }
+
+            gate.complete(Unit)
+
+            waitUntil("success renders rows and leaves loading") {
+                val sheet = sheetFragment(activity!!)
+                progressLayout(sheet)?.isContent == true && adapterItemCount(sheet) == 2
+            }
+            val progressIsLoading =
+                readOnMain { progressLayout(sheetFragment(activity!!))?.isLoading ?: true }
+            assertFalse("loading spinner must be cleared after success", progressIsLoading)
+            assertEquals(1, followerCalls)
+            coVerify(exactly = 1) { repository.getFollowers(1L, any(), any(), any()) }
+        }
+    }
+
+    @Test
+    fun failureLeavesLoading_showsErrorAndRetry() {
+        var followersResult: Result<PageContainer<UserBase>> =
+            Result.failure(RuntimeException("network down"))
+        val repository = mockk<UserRepository>()
+        coEvery {
+            repository.getFollowers(1L, any(), any(), any())
+        } coAnswers {
+            followersResult
+        }
+        coEvery {
+            repository.getFollowing(any(), any(), any(), any())
+        } returns Result.success(PageContainer())
+        install(repository)
+
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            var activity: FragmentActivity? = null
+            scenario.onActivity { host ->
+                activity = host
+                showFollowersSheet(host)
+            }
+
+            waitUntil("error state renders") {
+                progressLayout(sheetFragment(activity!!))?.isError == true
+            }
+
+            val progressIsLoading =
+                readOnMain { progressLayout(sheetFragment(activity!!))?.isLoading ?: true }
+            val errorText =
+                readOnMain {
+                    sheetFragment(activity!!)?.dialog
+                        ?.findViewById<TextView>(R.id.progressStateErrorText)
+                        ?.text?.toString()
+                }
+            val retryVisible =
+                readOnMain {
+                    sheetFragment(activity!!)?.dialog
+                        ?.findViewById<MaterialButton>(R.id.progressStateErrorAction)
+                        ?.visibility == View.VISIBLE
+                }
+            assertFalse("loading spinner must be cleared after error", progressIsLoading)
+            assertEquals("network down", errorText)
+            assertTrue("retry button must be visible", retryVisible)
+
+            // Backend recovers: retry must re-dispatch the request and render rows.
+            // Clear the scroll listeners first so the retried rows cannot trigger
+            // onLoadMore and add a third repository call.
+            instrumentation.runOnMainSync {
+                followersResult = Result.success(containerOf(user(2L, "user-2")))
+                clearScrollListeners(sheetFragment(activity!!))
+                sheetFragment(activity!!)?.dialog
+                    ?.findViewById<MaterialButton>(R.id.progressStateErrorAction)
+                    ?.performClick()
+            }
+
+            waitUntil("retry re-dispatches and renders rows") {
+                val sheet = sheetFragment(activity!!)
+                progressLayout(sheet)?.isContent == true && adapterItemCount(sheet) == 1
+            }
+            coVerify(exactly = 2) { repository.getFollowers(1L, any(), any(), any()) }
+        }
+    }
+
+    private fun showFollowersSheet(activity: FragmentActivity) {
+        BottomSheetListUsers
+            .Builder()
+            .setUserId(1L)
+            .setRequestType(KeyUtil.USER_FOLLOWERS_REQ)
+            .setModelCount(2)
+            .setTitle(R.string.title_bottom_sheet_likes)
+            .build()
+            .let { it as BottomSheetListUsers }
+            .show(activity.supportFragmentManager, SHEET_TAG)
+    }
+
+    private fun install(repository: UserRepository): Module =
+        module {
+            single<UserRepository> { repository }
+        }.also { module ->
+            overrideModules += module
+            loadKoinModules(module)
+        }
+
+    private fun sheetFragment(activity: FragmentActivity): BottomSheetListUsers? =
+        activity.supportFragmentManager.findFragmentByTag(SHEET_TAG) as? BottomSheetListUsers
+
+    private fun progressLayout(sheet: BottomSheetListUsers?): ProgressLayout? =
+        sheet?.dialog?.findViewById(R.id.stateLayout)
+
+    private fun clearScrollListeners(sheet: BottomSheetListUsers?) {
+        sheet?.dialog?.findViewById<StatefulRecyclerView>(R.id.recyclerView)
+            ?.clearOnScrollListeners()
+    }
+
+    private fun adapterItemCount(sheet: BottomSheetListUsers?): Int? =
+        sheet?.dialog?.findViewById<StatefulRecyclerView>(R.id.recyclerView)?.adapter?.itemCount
+
+    private inline fun <T> readOnMain(crossinline block: () -> T): T {
+        var result: T? = null
+        instrumentation.runOnMainSync { result = block() }
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    private fun waitUntil(description: String, condition: () -> Boolean) {
+        val deadline = SystemClock.uptimeMillis() + TIMEOUT_MS
+        while (SystemClock.uptimeMillis() < deadline) {
+            var satisfied = false
+            instrumentation.runOnMainSync { satisfied = condition() }
+            if (satisfied) return
+            SystemClock.sleep(POLL_MS)
+        }
+        fail("Timed out waiting for: $description")
+    }
+
+    private fun user(
+        id: Long,
+        name: String,
+    ): UserBase = UserBase(name = name).apply {
+        this.id = id
+    }
+
+    private fun containerOf(vararg users: UserBase): PageContainer<UserBase> =
+        PageContainer<UserBase>().apply {
+            pageData = users.toList()
+        }
+
+    private companion object {
+        const val SHEET_TAG = "users-list-sheet-state-test"
+        const val TIMEOUT_MS = 8_000L
+        const val POLL_MS = 50L
+    }
+}

--- a/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetUsersBoundaryTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetUsersBoundaryTest.kt
@@ -1,0 +1,165 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.mxt.anitrend.sheet
+
+import android.os.Bundle
+import android.os.Parcel
+import android.widget.ViewFlipper
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.view.widget.FollowStateWidget
+import com.mxt.anitrend.extension.parcelableArrayList
+import com.mxt.anitrend.model.entity.anilist.meta.ImageBase
+import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.view.sheet.BottomSheetUsers
+import com.mxt.anitrend.view.sheet.UserSheetModel
+import com.mxt.anitrend.view.sheet.toUserSheetModel
+import com.mxt.anitrend.widget.ProgressLayoutTestActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feed users sheet boundary tests ([BottomSheetUsers] + [UserSheetModel]).
+ *
+ * A real [android.os.Parcel] is not available in JVM unit tests (the SDK is stubbed),
+ * so the bundle round trip that previously zeroed every `@IgnoredOnParcel` [UserBase]
+ * id is covered here on a real Android runtime.
+ */
+@RunWith(AndroidJUnit4::class)
+class BottomSheetUsersBoundaryTest {
+
+    @Test
+    fun userSheetModelBundleRoundTripPreservesIdAndFollowState() {
+        val original =
+            UserSheetModel(
+                id = 42L,
+                name = "liker",
+                avatar = "https://example.com/avatar.png",
+                isFollowing = true,
+            )
+
+        val restored = original.toBundleRoundTrip()
+
+        assertEquals(42L, restored.id)
+        assertEquals("liker", restored.name)
+        assertEquals("https://example.com/avatar.png", restored.avatar)
+        assertEquals(true, restored.isFollowing)
+    }
+
+    @Test
+    fun builderBundleRoundTripPreservesRealUserIdsAvatarsAndFollowState() {
+        val liker =
+            UserBase(name = "liker", isFollowing = true).apply {
+                id = 42L
+                avatar = ImageBase(extraLarge = null, large = "https://example.com/a.png", medium = null)
+            }
+        val other =
+            UserBase(name = "other-user", isFollowing = false).apply {
+                id = 1337L
+                avatar = ImageBase(extraLarge = "https://example.com/b.png", large = null, medium = null)
+            }
+
+        val bundle =
+            BottomSheetUsers
+                .Builder()
+                .setModel(listOf(liker, other))
+                .build()
+                .arguments
+        val restored = BottomSheetUsers.resolveUsers(requireNotNull(bundle).toParcelRoundTrip())
+
+        assertEquals(2, restored?.size)
+        assertEquals(42L, restored?.get(0)?.id)
+        assertEquals("liker", restored?.get(0)?.name)
+        assertEquals("https://example.com/a.png", restored?.get(0)?.avatar?.large)
+        assertEquals(true, restored?.get(0)?.isFollowing)
+        assertEquals(1337L, restored?.get(1)?.id)
+        assertEquals("other-user", restored?.get(1)?.name)
+        assertEquals("https://example.com/b.png", restored?.get(1)?.avatar?.extraLarge)
+        assertEquals(false, restored?.get(1)?.isFollowing)
+    }
+
+    @Test
+    fun legacyUserBaseDirectParcelRoundTripDropsId() {
+        // Documents why the sheet boundary exists: parceling UserBase directly zeroes
+        // the @IgnoredOnParcel id (and avatar), which is what used to break follow
+        // dispatch and store rebinding for the feed users sheet.
+        val original =
+            UserBase(name = "liker", isFollowing = true).apply {
+                id = 42L
+                avatar = ImageBase(extraLarge = null, large = "https://example.com/a.png", medium = null)
+            }
+
+        val bundle = Bundle().apply {
+            putParcelableArrayList(KeyUtil.arg_list_model, arrayListOf(original))
+        }
+        val restored = bundle.toParcelRoundTrip().parcelableArrayList<UserBase>(KeyUtil.arg_list_model)
+
+        assertEquals(1, restored?.size)
+        assertEquals(0L, restored?.get(0)?.id)
+        assertNull(restored?.get(0)?.avatar)
+        // Constructor-parceled fields survive; only the ignored ones are lost.
+        assertEquals("liker", restored?.get(0)?.name)
+    }
+
+    @Test
+    fun roundTrippedUserClickDispatchesRealUserId() {
+        val liker =
+            UserBase(name = "liker").apply {
+                id = 42L
+            }
+        val bundle =
+            BottomSheetUsers
+                .Builder()
+                .setModel(listOf(liker))
+                .build()
+                .arguments
+        val restored = BottomSheetUsers.resolveUsers(requireNotNull(bundle).toParcelRoundTrip())
+        val roundTrippedUser = restored?.single() ?: error("Expected one round-tripped user")
+
+        val deliveredUserIds = mutableListOf<Long>()
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = FollowStateWidget(activity)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setListener(
+                    FollowStateWidget.Listener { userId ->
+                        deliveredUserIds.add(userId)
+                    },
+                )
+                widget.setUserModel(roundTrippedUser)
+
+                val flipper = widget.findViewById<ViewFlipper>(R.id.widget_flipper)
+                flipper.performClick()
+            }
+        }
+
+        // The id that survived the bundle round trip is the id that gets dispatched.
+        assertEquals(listOf(42L), deliveredUserIds)
+        assertTrue(roundTrippedUser.id == 42L)
+    }
+
+    private fun UserSheetModel.toBundleRoundTrip(): UserSheetModel =
+        Bundle().apply {
+            putParcelableArrayList(KeyUtil.arg_list_model, arrayListOf(this@toBundleRoundTrip))
+        }.toParcelRoundTrip().parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)!!.single()
+
+    private fun Bundle.toParcelRoundTrip(): Bundle {
+        val parcel = Parcel.obtain()
+        return try {
+            writeToParcel(parcel, 0)
+            parcel.setDataPosition(0)
+            Bundle.CREATOR.createFromParcel(parcel)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetUsersBoundaryTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/sheet/BottomSheetUsersBoundaryTest.kt
@@ -15,7 +15,6 @@ import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.view.sheet.BottomSheetUsers
 import com.mxt.anitrend.view.sheet.UserSheetModel
-import com.mxt.anitrend.view.sheet.toUserSheetModel
 import com.mxt.anitrend.widget.ProgressLayoutTestActivity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -147,10 +146,9 @@ class BottomSheetUsersBoundaryTest {
         assertTrue(roundTrippedUser.id == 42L)
     }
 
-    private fun UserSheetModel.toBundleRoundTrip(): UserSheetModel =
-        Bundle().apply {
-            putParcelableArrayList(KeyUtil.arg_list_model, arrayListOf(this@toBundleRoundTrip))
-        }.toParcelRoundTrip().parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)!!.single()
+    private fun UserSheetModel.toBundleRoundTrip(): UserSheetModel = Bundle().apply {
+        putParcelableArrayList(KeyUtil.arg_list_model, arrayListOf(this@toBundleRoundTrip))
+    }.toParcelRoundTrip().parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)!!.single()
 
     private fun Bundle.toParcelRoundTrip(): Bundle {
         val parcel = Parcel.obtain()

--- a/app/src/androidTest/java/com/mxt/anitrend/widget/AboutPanelWidgetInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/widget/AboutPanelWidgetInstrumentationTest.kt
@@ -1,0 +1,128 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.mxt.anitrend.widget
+
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.view.widget.AboutPanelWidget
+import com.mxt.anitrend.base.custom.view.widget.AboutPanelWidget.StatState
+import com.mxt.anitrend.view.sheet.BottomSheetListUsers
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Click wiring for the profile about panel ([AboutPanelWidget]): a loaded stat count
+ * (including zero) opens the normal list sheet, while not-yet-loaded and failed counts
+ * keep the loading toast and must not open anything. The per-state click resolution
+ * itself is unit-tested by AboutPanelWidgetStatStateTest; these tests verify the
+ * container clicks drive the fragment-manager sheet.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class AboutPanelWidgetInstrumentationTest {
+
+    @Test
+    fun loadedZeroFollowers_opensListSheet() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = attachWidget(activity)
+                widget.setStats(StatState.Loaded(0), StatState.NotLoaded, StatState.NotLoaded)
+
+                widget.findViewById<View>(R.id.user_followers_container).performClick()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                assertTrue(
+                    "loaded zero followers must open the empty list sheet",
+                    activity.supportFragmentManager.fragments.any { it is BottomSheetListUsers },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun loadedNonzeroFollowers_opensListSheet() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = attachWidget(activity)
+                widget.setStats(StatState.Loaded(4), StatState.NotLoaded, StatState.NotLoaded)
+
+                widget.findViewById<View>(R.id.user_followers_container).performClick()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                assertTrue(
+                    "loaded nonzero followers must open the list sheet",
+                    activity.supportFragmentManager.fragments.any { it is BottomSheetListUsers },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun loadedZeroFollowing_opensListSheet() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = attachWidget(activity)
+                widget.setStats(StatState.NotLoaded, StatState.Loaded(0), StatState.NotLoaded)
+
+                widget.findViewById<View>(R.id.user_following_container).performClick()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                assertTrue(
+                    "loaded zero following must open the empty list sheet",
+                    activity.supportFragmentManager.fragments.any { it is BottomSheetListUsers },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun notLoadedFollowers_keepsLoadingToastWithoutSheet() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = attachWidget(activity)
+
+                widget.findViewById<View>(R.id.user_followers_container).performClick()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                assertFalse(
+                    "not-yet-loaded followers must not open the list sheet",
+                    activity.supportFragmentManager.fragments.any { it is BottomSheetListUsers },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun failedFollowers_keepsLoadingToastWithoutSheet() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = attachWidget(activity)
+                widget.setStats(StatState.Failed, StatState.NotLoaded, StatState.NotLoaded)
+
+                widget.findViewById<View>(R.id.user_followers_container).performClick()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                assertFalse(
+                    "failed followers must not open the list sheet",
+                    activity.supportFragmentManager.fragments.any { it is BottomSheetListUsers },
+                )
+            }
+        }
+    }
+
+    private fun attachWidget(activity: androidx.appcompat.app.AppCompatActivity): AboutPanelWidget {
+        val container = FrameLayout(activity)
+        activity.setContentView(container)
+        val widget = AboutPanelWidget(activity)
+        container.addView(widget)
+        widget.setFragmentActivity(activity)
+        widget.setUserId(7L, activity.lifecycle)
+        return widget
+    }
+}

--- a/app/src/androidTest/java/com/mxt/anitrend/widget/FollowStateWidgetInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/widget/FollowStateWidgetInstrumentationTest.kt
@@ -2,6 +2,7 @@
 
 package com.mxt.anitrend.widget
 
+import android.view.View
 import android.widget.FrameLayout
 import android.widget.ViewFlipper
 import androidx.test.core.app.ActivityScenario
@@ -121,5 +122,146 @@ class FollowStateWidgetInstrumentationTest {
         }
         database.invalidateBoxStores()
         Settings(androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().targetContext).isAuthenticated = false
+    }
+
+    @Test
+    fun anotherUserControlVisible_whenCurrentUserArrivesAfterModel() {
+        // Regression for the fresh-sheet defect: adapters bind the row model before
+        // the current-user context on the first pass. The visibility decision must be
+        // re-evaluated when the user context arrives, or every row stays hidden.
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = FrameLayout(activity)
+                activity.setContentView(container)
+
+                val widget = FollowStateWidget(activity)
+                container.addView(widget)
+                val targetUser = UserBase(name = "other-user").apply { id = 2L }
+
+                // Adapter order: model first, current user second.
+                widget.setUserModel(targetUser)
+                assertEquals(View.GONE, widget.visibility)
+
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+
+                assertEquals(View.VISIBLE, widget.visibility)
+                val label = widget.findViewById<MaterialButton>(R.id.button_state_text)
+                assertEquals(activity.getString(R.string.follow), label.text.toString())
+            }
+        }
+    }
+
+    @Test
+    fun anotherUserControlVisible_whenCurrentUserBoundBeforeModel() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = FrameLayout(activity)
+                activity.setContentView(container)
+
+                val widget = FollowStateWidget(activity)
+                container.addView(widget)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setUserModel(UserBase(name = "other-user").apply { id = 2L })
+
+                assertEquals(View.VISIBLE, widget.visibility)
+            }
+        }
+    }
+
+    @Test
+    fun selfRowControlStaysHidden() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = FrameLayout(activity)
+                activity.setContentView(container)
+
+                val widget = FollowStateWidget(activity)
+                container.addView(widget)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setUserModel(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+
+                // Self rows intentionally render no follow control: you cannot
+                // follow yourself.
+                assertEquals(View.GONE, widget.visibility)
+            }
+        }
+    }
+
+    @Test
+    fun tapOnInnerButtonStateText_dispatchesRealUserIdExactlyOnce() {
+        // Regression for the follow-control defect: the inner button state text is
+        // the actual tap target Android delivers touches (and accessibility
+        // activations) to. Tapping it must dispatch the bound user's real id, and a
+        // single tap must never dispatch twice (parent and child share the listener,
+        // but the CONTENT_STATE guard switches to loading on the first dispatch).
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = FrameLayout(activity)
+                activity.setContentView(container)
+
+                val widget = FollowStateWidget(activity)
+                container.addView(widget)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setUserModel(UserBase(name = "other-user").apply { id = 2L })
+
+                val deliveredUserIds = mutableListOf<Long>()
+                widget.setListener(
+                    FollowStateWidget.Listener { userId ->
+                        deliveredUserIds.add(userId)
+                    },
+                )
+
+                val button = widget.findViewById<MaterialButton>(R.id.button_state_text)
+                button.performClick()
+
+                // The real bound id is delivered exactly once and the control moves
+                // into the loading state.
+                assertEquals(listOf(2L), deliveredUserIds)
+                val flipper = widget.findViewById<ViewFlipper>(R.id.widget_flipper)
+                assertEquals(WidgetState.LOADING_STATE, flipper.displayedChild)
+
+                // A further tap while the mutation is in flight must not re-dispatch.
+                button.performClick()
+                assertEquals(listOf(2L), deliveredUserIds)
+            }
+        }
+    }
+
+    @Test
+    fun noCurrentUser_hidesControl() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = FrameLayout(activity)
+                activity.setContentView(container)
+
+                val widget = FollowStateWidget(activity)
+                container.addView(widget)
+                widget.setUserModel(UserBase(name = "other-user").apply { id = 2L })
+
+                // Without an authenticated current-user context there is nothing to
+                // follow from, so the control stays hidden.
+                assertEquals(View.GONE, widget.visibility)
+            }
+        }
     }
 }

--- a/app/src/androidTest/java/com/mxt/anitrend/widget/ProgressLayoutInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/widget/ProgressLayoutInstrumentationTest.kt
@@ -42,6 +42,11 @@ class ProgressLayoutInstrumentationTest {
                     "Loading indicator should use Material 3 LoadingIndicator",
                     loadingIndicator is LoadingIndicator,
                 )
+                assertEquals(
+                    "Loading indicator should use the compact visual size",
+                    activity.resources.getDimensionPixelSize(R.dimen.widget_spinner_compact_size),
+                    (loadingIndicator as LoadingIndicator).indicatorSize,
+                )
                 assertTrue(
                     "Error surface should use Material 3 MaterialCardView",
                     errorCard is MaterialCardView,

--- a/app/src/androidTest/java/com/mxt/anitrend/widget/VoteWidgetInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/mxt/anitrend/widget/VoteWidgetInstrumentationTest.kt
@@ -1,0 +1,138 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.mxt.anitrend.widget
+
+import android.widget.ViewFlipper
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.view.widget.VoteWidget
+import com.mxt.anitrend.data.store.mutation.MutationResult
+import com.mxt.anitrend.domain.model.MediaSummaryRecord
+import com.mxt.anitrend.domain.model.ReviewRecord
+import com.mxt.anitrend.domain.model.UserSummaryRecord
+import com.mxt.anitrend.graphql.generated.ReviewRating
+import com.mxt.anitrend.model.entity.base.UserBase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Vote control convergence for review rating mutations ([VoteWidget]): the tapped thumb
+ * stays in the loading state while the mutation is in flight (no optimistic store
+ * mutation), a failure outcome resets the loading state and surfaces the message, and a
+ * success outcome resets the loading state while the canonical store rebinding renders
+ * the committed rating.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class VoteWidgetInstrumentationTest {
+
+    @Test
+    fun clickKeepsLoadingUntilOutcome_failureResetsAndDeliversRating() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = VoteWidget(activity)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setModel(review(), 0)
+
+                val deliveredRatings = mutableListOf<Pair<Long, ReviewRating?>>()
+                widget.setListener(
+                    object : VoteWidget.Listener {
+                        override fun onRateReview(
+                            id: Long,
+                            rating: ReviewRating?,
+                        ) {
+                            deliveredRatings.add(id to rating)
+                        }
+                    },
+                )
+
+                val flipper = widget.findViewById<ViewFlipper>(R.id.widget_thumb_up_flipper)
+                flipper.performClick()
+
+                // No optimistic mutation: the thumb stays in the loading state in flight.
+                assertEquals(listOf(42L to ReviewRating.UP_VOTE), deliveredRatings)
+                assertEquals(VoteWidget.LOADING_STATE, flipper.displayedChild)
+
+                widget.onRateReviewResult(MutationResult.Failure(message = "rate failed"))
+
+                assertEquals(VoteWidget.CONTENT_STATE, flipper.displayedChild)
+            }
+        }
+    }
+
+    @Test
+    fun successOutcomeResetsLoadingState() {
+        ActivityScenario.launch(ProgressLayoutTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val widget = VoteWidget(activity)
+                widget.setCurrentUser(
+                    UserBase(name = "current-user").apply {
+                        id = 1L
+                    },
+                )
+                widget.setModel(review(), 0)
+                widget.setListener(
+                    object : VoteWidget.Listener {
+                        override fun onRateReview(
+                            id: Long,
+                            rating: ReviewRating?,
+                        ) = Unit
+                    },
+                )
+
+                val flipper = widget.findViewById<ViewFlipper>(R.id.widget_thumb_up_flipper)
+                flipper.performClick()
+                assertEquals(VoteWidget.LOADING_STATE, flipper.displayedChild)
+
+                widget.onRateReviewResult(MutationResult.Success)
+
+                assertEquals(VoteWidget.CONTENT_STATE, flipper.displayedChild)
+            }
+        }
+    }
+
+    private fun review(): ReviewRecord = ReviewRecord(
+        id = 42L,
+        summary = "summary",
+        mediaType = "ANIME",
+        body = "body",
+        rating = 10,
+        ratingAmount = 20,
+        userRating = null,
+        score = 80,
+        isPrivate = false,
+        createdAt = 1_600_000_000L,
+        user =
+        UserSummaryRecord(
+            id = 7L,
+            name = "alice",
+            avatar = null,
+            siteUrl = null,
+        ),
+        media =
+        MediaSummaryRecord(
+            id = 44L,
+            titleUserPreferred = "Preferred",
+            titleRomaji = null,
+            titleEnglish = null,
+            titleOriginal = null,
+            coverImage = null,
+            bannerImage = null,
+            type = "ANIME",
+            format = null,
+            episodes = 12,
+            chapters = 0,
+            volumes = 0,
+            status = null,
+            siteUrl = null,
+        ),
+        revision = 1L,
+    )
+}

--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/ReviewAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/ReviewAdapter.kt
@@ -15,6 +15,7 @@ import com.mxt.anitrend.base.custom.view.widget.VoteWidget
 import com.mxt.anitrend.base.interfaces.event.ItemClickListener
 import com.mxt.anitrend.binding.markDown
 import com.mxt.anitrend.binding.setImage
+import com.mxt.anitrend.data.store.mutation.MutationResult
 import com.mxt.anitrend.databinding.AdapterReviewBinding
 import com.mxt.anitrend.databinding.AdapterSeriesReviewBinding
 import com.mxt.anitrend.domain.model.ReviewRecord
@@ -42,11 +43,34 @@ class ReviewAdapter(
 
     var clickListener: ItemClickListener<ReviewRecord>? = null
 
+    /**
+     * Currently bound holders keyed by stable review id, so mutation outcomes arriving
+     * after the list settled can still converge the visible vote controls without
+     * re-submitting the immutable list.
+     */
+    private val holderRegistry = ReviewHolderRegistry<RecyclerView.ViewHolder>()
+
     private val voteListener = object : VoteWidget.Listener {
         override fun onRateReview(
             id: Long,
             rating: ReviewRating?,
         ) = onRateReviewAction(id, rating)
+    }
+
+    /**
+     * Forwards a rate mutation outcome to the bound vote control for the review.
+     * The canonical store rebinding already converges success; this mainly resets the
+     * vote loading state and surfaces failures on the visible holder.
+     */
+    fun onRateReviewResult(
+        reviewId: Long,
+        result: MutationResult,
+    ) {
+        val holder = holderRegistry.holderFor(reviewId) ?: return
+        when (holder) {
+            is ReviewBanner -> holder.binding.reviewVote.onRateReviewResult(result)
+            is ReviewDefault -> holder.binding.reviewVote.onRateReviewResult(result)
+        }
     }
 
     override fun getItemViewType(position: Int): Int = if (!isMediaType) VIEW_TYPE_BANNER else VIEW_TYPE_DEFAULT
@@ -69,6 +93,7 @@ class ReviewAdapter(
         position: Int,
     ) {
         val record = getItem(position)
+        holderRegistry.onBound(record.id, holder)
         when (holder) {
             is ReviewBanner -> holder.bind(record)
             is ReviewDefault -> holder.bind(record)
@@ -77,6 +102,7 @@ class ReviewAdapter(
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
         super.onViewRecycled(holder)
+        holderRegistry.onRecycled(holder)
         when (holder) {
             is ReviewBanner -> holder.recycle()
             is ReviewDefault -> holder.recycle()
@@ -84,7 +110,7 @@ class ReviewAdapter(
     }
 
     inner class ReviewBanner(
-        private val binding: AdapterReviewBinding,
+        val binding: AdapterReviewBinding,
     ) : RecyclerView.ViewHolder(binding.root),
         View.OnClickListener,
         View.OnLongClickListener {
@@ -122,7 +148,7 @@ class ReviewAdapter(
     }
 
     inner class ReviewDefault(
-        private val binding: AdapterSeriesReviewBinding,
+        val binding: AdapterSeriesReviewBinding,
     ) : RecyclerView.ViewHolder(binding.root),
         View.OnClickListener,
         View.OnLongClickListener {
@@ -198,5 +224,47 @@ class ReviewAdapter(
                 newItem: ReviewRecord,
             ): Boolean = oldItem == newItem
         }
+    }
+}
+
+/**
+ * Tracks which holder is currently bound to which review id so mutation outcomes can be
+ * routed to the visible vote control without re-submitting the immutable list.
+ *
+ * A holder may be rebound from one review to another without being recycled first, so
+ * every bind removes the holder's prior mapping and records the review id it is now bound
+ * to. Outcome routing resolves through [holderFor], which only returns a holder that is
+ * still bound to the requested review id; a stale outcome for a previously bound review
+ * can therefore never reach a holder that was rebound to a different review.
+ */
+internal class ReviewHolderRegistry<H : Any> {
+
+    private val holdersByReviewId = mutableMapOf<Long, H>()
+    private val boundReviewIdByHolder = mutableMapOf<H, Long>()
+
+    fun onBound(
+        reviewId: Long,
+        holder: H,
+    ) {
+        boundReviewIdByHolder.remove(holder)?.let { priorReviewId ->
+            if (holdersByReviewId[priorReviewId] === holder) {
+                holdersByReviewId.remove(priorReviewId)
+            }
+        }
+        boundReviewIdByHolder[holder] = reviewId
+        holdersByReviewId[reviewId] = holder
+    }
+
+    fun onRecycled(holder: H) {
+        boundReviewIdByHolder.remove(holder)?.let { reviewId ->
+            if (holdersByReviewId[reviewId] === holder) {
+                holdersByReviewId.remove(reviewId)
+            }
+        }
+    }
+
+    fun holderFor(reviewId: Long): H? {
+        val holder = holdersByReviewId[reviewId] ?: return null
+        return holder.takeIf { boundReviewIdByHolder[it] == reviewId }
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/UserAdapter.kt
+++ b/app/src/main/java/com/mxt/anitrend/adapter/recycler/index/UserAdapter.kt
@@ -84,8 +84,10 @@ class UserAdapter(
         override fun onBindViewHolder(model: UserBase) {
             binding.userAvatar.setImage(model.avatar)
             binding.userName.text = model.name
-            binding.userFollowStateWidget.setUserModel(model)
+            // Current-user context first: the widget evaluates control visibility on
+            // model bind, so a fresh row must never evaluate against a null context.
             binding.userFollowStateWidget.setCurrentUser(currentUser)
+            binding.userFollowStateWidget.setUserModel(model)
             binding.userFollowStateWidget.setListener(followListener)
         }
 

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
@@ -14,7 +14,6 @@ import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.interfaces.view.CustomView
 import com.mxt.anitrend.databinding.WidgetProfileAboutPanelBinding
-import com.mxt.anitrend.model.entity.container.attribute.PageInfo
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.util.WidgetState
@@ -43,15 +42,39 @@ constructor(
 
     private var lastSynced: Long = 0L
 
-    private var followers: PageInfo? = null
-    private var following: PageInfo? = null
-    private var favourites: Int = 0
+    private var followers: StatState = StatState.NotLoaded
+    private var following: StatState = StatState.NotLoaded
+    private var favourites: StatState = StatState.NotLoaded
     private var lastAppliedFollowState: Boolean? = null
 
     private var bottomSheet: BottomSheetBase<*>? = null
     private var fragmentManager: FragmentManager? = null
 
     private val placeHolder = ".."
+
+    /**
+     * Loaded-state contract for a profile stat container (Favourite, Following, Followers).
+     *
+     * The widget must distinguish not-yet-loaded, failed, and loaded counts so a legitimate
+     * zero count never falls back to the loading toast: loaded counts (including zero) open
+     * the normal destination or list sheet, while not-yet-loaded and failed counts keep the
+     * loading toast.
+     */
+    sealed interface StatState {
+        data object NotLoaded : StatState
+        data object Failed : StatState
+        data class Loaded(val total: Int) : StatState
+    }
+
+    /**
+     * Resolves the click behavior of a profile stat container from its loaded state.
+     * Loaded counts (including zero) open the destination or list sheet; not-yet-loaded
+     * and failed counts keep the loading toast.
+     */
+    enum class StatClickAction {
+        Open,
+        ShowLoading,
+    }
 
     init {
         onInit()
@@ -78,27 +101,30 @@ constructor(
             binding.userFavouritesCount.text = placeHolder
             binding.userFollowersCount.text = placeHolder
             binding.userFollowingCount.text = placeHolder
+            followers = StatState.NotLoaded
+            following = StatState.NotLoaded
+            favourites = StatState.NotLoaded
 
             lastSynced = System.currentTimeMillis()
         }
     }
 
     fun setStats(
-        followersTotal: Int?,
-        followingTotal: Int?,
-        favouritesTotal: Int?,
+        followers: StatState,
+        following: StatState,
+        favourites: StatState,
     ) {
-        if (followersTotal != null) {
-            binding.userFollowersCount.text =
-                WidgetState.valueFormatter(followersTotal)
+        this.followers = followers
+        this.following = following
+        this.favourites = favourites
+        (followers as? StatState.Loaded)?.let { state ->
+            binding.userFollowersCount.text = WidgetState.valueFormatter(state.total)
         }
-        if (followingTotal != null) {
-            binding.userFollowingCount.text =
-                WidgetState.valueFormatter(followingTotal)
+        (following as? StatState.Loaded)?.let { state ->
+            binding.userFollowingCount.text = WidgetState.valueFormatter(state.total)
         }
-        if (favouritesTotal != null) {
-            binding.userFavouritesCount.text =
-                WidgetState.valueFormatter(favouritesTotal)
+        (favourites as? StatState.Loaded)?.let { state ->
+            binding.userFavouritesCount.text = WidgetState.valueFormatter(state.total)
         }
     }
 
@@ -113,47 +139,49 @@ constructor(
     override fun onClick(view: View) {
         when (view.id) {
             R.id.user_favourites_container -> {
-                if (favourites < 1) {
-                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
-                } else {
+                if (favourites.resolveStatClick() == StatClickAction.Open) {
                     val intent =
                         Intent(context, FavouriteActivity::class.java).apply {
                             flags = Intent.FLAG_ACTIVITY_NEW_TASK
                             putExtra(KeyUtil.arg_id, userId)
                         }
                     context.startActivity(intent)
+                } else {
+                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
                 }
             }
             R.id.user_followers_container -> {
-                if (followers == null || (followers?.total ?: 0) < 1) {
-                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
-                } else {
+                if (followers.resolveStatClick() == StatClickAction.Open) {
+                    val loaded = followers as StatState.Loaded
                     val manager = fragmentManager ?: return
                     bottomSheet =
                         BottomSheetListUsers
                             .Builder()
                             .setUserId(userId)
-                            .setModelCount(followers?.total ?: 0)
+                            .setModelCount(loaded.total)
                             .setRequestType(KeyUtil.USER_FOLLOWERS_REQ)
                             .setTitle(R.string.title_bottom_sheet_followers)
                             .build()
                     bottomSheet?.show(manager, bottomSheet?.tag)
+                } else {
+                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
                 }
             }
             R.id.user_following_container -> {
-                if (following == null || (following?.total ?: 0) < 1) {
-                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
-                } else {
+                if (following.resolveStatClick() == StatClickAction.Open) {
+                    val loaded = following as StatState.Loaded
                     val manager = fragmentManager ?: return
                     bottomSheet =
                         BottomSheetListUsers
                             .Builder()
                             .setUserId(userId)
-                            .setModelCount(following?.total ?: 0)
+                            .setModelCount(loaded.total)
                             .setRequestType(KeyUtil.USER_FOLLOWING_REQ)
                             .setTitle(R.string.title_bottom_sheet_following)
                             .build()
                     bottomSheet?.show(manager, bottomSheet?.tag)
+                } else {
+                    NotifyUtil.makeText(context, R.string.text_activity_loading, Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -163,3 +191,15 @@ constructor(
         fragmentManager = activity?.supportFragmentManager
     }
 }
+
+/**
+ * Resolves the click behavior of a profile stat container from its loaded state.
+ * Loaded counts (including zero) open the normal destination or list sheet;
+ * not-yet-loaded and failed counts keep the loading toast.
+ */
+internal fun AboutPanelWidget.StatState.resolveStatClick(): AboutPanelWidget.StatClickAction =
+    if (this is AboutPanelWidget.StatState.Loaded) {
+        AboutPanelWidget.StatClickAction.Open
+    } else {
+        AboutPanelWidget.StatClickAction.ShowLoading
+    }

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt
@@ -197,9 +197,8 @@ constructor(
  * Loaded counts (including zero) open the normal destination or list sheet;
  * not-yet-loaded and failed counts keep the loading toast.
  */
-internal fun AboutPanelWidget.StatState.resolveStatClick(): AboutPanelWidget.StatClickAction =
-    if (this is AboutPanelWidget.StatState.Loaded) {
-        AboutPanelWidget.StatClickAction.Open
-    } else {
-        AboutPanelWidget.StatClickAction.ShowLoading
-    }
+internal fun AboutPanelWidget.StatState.resolveStatClick(): AboutPanelWidget.StatClickAction = if (this is AboutPanelWidget.StatState.Loaded) {
+    AboutPanelWidget.StatClickAction.Open
+} else {
+    AboutPanelWidget.StatClickAction.ShowLoading
+}

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FollowStateWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FollowStateWidget.kt
@@ -63,6 +63,13 @@ constructor(
 
     fun setCurrentUser(user: UserBase?) {
         this.currentUser = user
+        // The model may already be bound: adapters commonly bind the row model before
+        // the current-user context on the first pass, and the visibility decision in
+        // setUserModel then runs against a still-null current user. Re-evaluate so a
+        // control is never left hidden because the user context arrived afterwards.
+        if (model != null) {
+            applyVisibilityState()
+        }
     }
 
     init {
@@ -74,7 +81,12 @@ constructor(
      */
     override fun onInit() {
         binding = WidgetButtonStateBinding.inflate(context.getLayoutInflater(), this, true)
+        // The inner button state text is the actual tap target Android delivers
+        // touches (and accessibility activations) to, so it must carry the same
+        // listener as the flipper. The CONTENT_STATE guard in [onClick] makes a
+        // single tap dispatch at most one mutation even if both paths ever fire.
         binding.widgetFlipper.setOnClickListener(this)
+        binding.buttonStateText.setOnClickListener(this)
     }
 
     fun setUserModel(model: UserBase) {
@@ -83,8 +95,19 @@ constructor(
         // A newly bound state always reflects the latest committed render source,
         // so a pending mutation loading state is reset.
         resetLoadingState()
+        applyVisibilityState()
+    }
+
+    /**
+     * Decides whether the follow control is rendered for the bound model:
+     * hidden when there is no authenticated current user context or when the row
+     * is the current user themself, visible otherwise.
+     */
+    private fun applyVisibilityState() {
+        val currentModel = model ?: return
         if (currentUser != null) {
-            if (!isCurrentUser(model)) {
+            if (!isCurrentUser(currentModel)) {
+                visibility = VISIBLE
                 setControlText()
             } else {
                 visibility = GONE
@@ -129,7 +152,9 @@ constructor(
 
     override fun onClick(view: View) {
         when (view.id) {
-            R.id.widget_flipper -> {
+            R.id.widget_flipper,
+            R.id.button_state_text,
+            -> {
                 if (binding.widgetFlipper.displayedChild == CONTENT_STATE) {
                     val currentModel = model ?: run {
                         resetLoadingState()

--- a/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/VoteWidget.kt
+++ b/app/src/main/java/com/mxt/anitrend/base/custom/view/widget/VoteWidget.kt
@@ -1,6 +1,8 @@
 package com.mxt.anitrend.base.custom.view.widget
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -11,6 +13,7 @@ import androidx.annotation.DrawableRes
 import com.mxt.anitrend.R
 import com.mxt.anitrend.base.custom.view.text.SingleLineTextView
 import com.mxt.anitrend.base.interfaces.view.CustomView
+import com.mxt.anitrend.data.store.mutation.MutationResult
 import com.mxt.anitrend.databinding.WidgetVoteBinding
 import com.mxt.anitrend.domain.model.ReviewRecord
 import com.mxt.anitrend.extension.getCompatColor
@@ -49,6 +52,17 @@ constructor(
     private var listener: Listener? = null
     private var recycled = false
     private var currentUser: UserBase? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Bounded fallback so a vote mutation can never leave the widget permanently in the
+     * loading state when no outcome reaches it (for example when the owning screen is not
+     * collecting the ViewModel outcome). The authoritative convergence path is the
+     * canonical store rebinding on success and [onRateReviewResult] on failure.
+     */
+    private val loadingFallback = Runnable {
+        resetFlipperState()
+    }
 
     fun setListener(listener: Listener?) {
         this.listener = listener
@@ -74,10 +88,10 @@ constructor(
             resetFlipperState()
             return
         }
+        // The tapped thumb stays in the loading state until the mutation outcome arrives:
+        // the canonical store rebinding resets it on success, [onRateReviewResult] resets
+        // it on failure, and the bounded fallback guarantees convergence in between.
         listener?.onRateReview(currentModel.id, rating)
-        if (!recycled && isAttachedToWindow) {
-            resetFlipperState()
-        }
     }
 
     override fun onClick(view: View) {
@@ -86,6 +100,7 @@ constructor(
                 R.id.widget_thumb_up_flipper -> {
                     if (binding.widgetThumbUpFlipper.displayedChild == CONTENT_STATE) {
                         binding.widgetThumbUpFlipper.showNext()
+                        showLoadingState()
                         val current = model?.userRating
                         val rating = nextRating(current, KeyUtil.UP_VOTE)
                         performRating(rating)
@@ -101,6 +116,7 @@ constructor(
                 R.id.widget_thumb_down_flipper -> {
                     if (binding.widgetThumbDownFlipper.displayedChild == CONTENT_STATE) {
                         binding.widgetThumbDownFlipper.showNext()
+                        showLoadingState()
                         val current = model?.userRating
                         val rating = nextRating(current, KeyUtil.DOWN_VOTE)
                         performRating(rating)
@@ -126,6 +142,28 @@ constructor(
     }
 
     /**
+     * Converges the widget from the outcome of the pending vote mutation. A failure is
+     * surfaced explicitly and the loading state is always reset; a success is primarily
+     * converged by the canonical store rebinding, so this only resets the loading state.
+     */
+    fun onRateReviewResult(result: MutationResult) {
+        if (result is MutationResult.Failure) {
+            NotifyUtil
+                .makeText(
+                    context,
+                    result.message,
+                    Toast.LENGTH_SHORT,
+                ).show()
+        }
+        resetFlipperState()
+    }
+
+    private fun showLoadingState() {
+        mainHandler.removeCallbacks(loadingFallback)
+        mainHandler.postDelayed(loadingFallback, LOADING_FALLBACK_TIMEOUT_MS)
+    }
+
+    /**
      * Optionally included when constructing custom views
      */
     override fun onInit() {
@@ -145,6 +183,7 @@ constructor(
     }
 
     private fun resetFlipperState() {
+        mainHandler.removeCallbacks(loadingFallback)
         if (binding.widgetThumbUpFlipper.displayedChild == LOADING_STATE) {
             binding.widgetThumbUpFlipper.displayedChild = CONTENT_STATE
         }
@@ -233,6 +272,8 @@ constructor(
     companion object {
         const val CONTENT_STATE = 0
         const val LOADING_STATE = 1
+
+        const val LOADING_FALLBACK_TIMEOUT_MS = 10_000L
 
         fun convertToText(count: Int): String = String.format(Locale.getDefault(), " %d ", count)
 

--- a/app/src/main/java/com/mxt/anitrend/data/mapper/FeedRecordMapper.kt
+++ b/app/src/main/java/com/mxt/anitrend/data/mapper/FeedRecordMapper.kt
@@ -54,6 +54,7 @@ fun UserBase.toUserSummaryRecord(): UserSummaryRecord = UserSummaryRecord(
     name = name,
     avatar = avatar?.large ?: avatar?.medium ?: avatar?.extraLarge,
     siteUrl = null,
+    isFollowing = isFollowing,
 )
 
 fun MediaBase.toMediaSummaryRecord(): MediaSummaryRecord = MediaSummaryRecord(
@@ -122,6 +123,7 @@ fun UserSummaryRecord.toUserBase(): UserBase = UserBase(name = name).apply {
         large = this@toUserBase.avatar,
         medium = this@toUserBase.avatar,
     )
+    isFollowing = this@toUserBase.isFollowing
 }
 
 fun MediaSummaryRecord.toMediaBase(): MediaBase = MediaBase().apply {

--- a/app/src/main/java/com/mxt/anitrend/data/mapper/ReviewRecordMapper.kt
+++ b/app/src/main/java/com/mxt/anitrend/data/mapper/ReviewRecordMapper.kt
@@ -1,7 +1,11 @@
 package com.mxt.anitrend.data.mapper
 
+import com.mxt.anitrend.domain.model.MediaSummaryRecord
 import com.mxt.anitrend.domain.model.ReviewRecord
+import com.mxt.anitrend.domain.model.UserSummaryRecord
 import com.mxt.anitrend.model.entity.anilist.Review
+import com.mxt.anitrend.model.entity.base.MediaBase
+import com.mxt.anitrend.model.entity.base.UserBase
 
 /**
  * Maps the legacy mutable [Review] entity to the immutable [ReviewRecord]
@@ -10,10 +14,14 @@ import com.mxt.anitrend.model.entity.anilist.Review
  * that follows the store contract change.
  *
  * Null/default behavior is explicit:
- * - The legacy entity always materializes non-null `user` and `media` defaults
+ * - The legacy entity normally materializes non-null `user` and `media` defaults
  *   (`UserBase()` / `MediaBase()`). An empty default instance carries no business
  *   identity, so it is mapped to a null nested summary: `user` is null when both
  *   `id == 0L` and `name == null`, and `media` is null when `id == 0L`.
+ * - Gson can also write a runtime null into those declared non-null properties
+ *   when the response contains `"user": null` / `"media": null` (reflection
+ *   bypasses the Kotlin contract, seen on RateReview responses). A runtime null
+ *   carries no business identity either, so it maps to a null nested summary.
  * - Scalar fields are copied verbatim, preserving legacy defaults (e.g. `0` for
  *   `rating`, `ratingAmount`, and `score`).
  */
@@ -28,7 +36,13 @@ fun Review.toReviewRecord(revision: Long = 0L): ReviewRecord = ReviewRecord(
     score = score,
     isPrivate = isPrivate,
     createdAt = createdAt,
-    user = if (user.id == 0L && user.name == null) null else user.toUserSummaryRecord(),
-    media = if (media.id == 0L) null else media.toMediaSummaryRecord(),
+    user = user.toUserSummaryRecordOrNull(),
+    media = media.toMediaSummaryRecordOrNull(),
     revision = revision,
 )
+
+private fun UserBase?.toUserSummaryRecordOrNull(): UserSummaryRecord? =
+    if (this == null || (id == 0L && name == null)) null else toUserSummaryRecord()
+
+private fun MediaBase?.toMediaSummaryRecordOrNull(): MediaSummaryRecord? =
+    if (this == null || id == 0L) null else toMediaSummaryRecord()

--- a/app/src/main/java/com/mxt/anitrend/data/mapper/ReviewRecordMapper.kt
+++ b/app/src/main/java/com/mxt/anitrend/data/mapper/ReviewRecordMapper.kt
@@ -41,8 +41,6 @@ fun Review.toReviewRecord(revision: Long = 0L): ReviewRecord = ReviewRecord(
     revision = revision,
 )
 
-private fun UserBase?.toUserSummaryRecordOrNull(): UserSummaryRecord? =
-    if (this == null || (id == 0L && name == null)) null else toUserSummaryRecord()
+private fun UserBase?.toUserSummaryRecordOrNull(): UserSummaryRecord? = if (this == null || (id == 0L && name == null)) null else toUserSummaryRecord()
 
-private fun MediaBase?.toMediaSummaryRecordOrNull(): MediaSummaryRecord? =
-    if (this == null || id == 0L) null else toMediaSummaryRecord()
+private fun MediaBase?.toMediaSummaryRecordOrNull(): MediaSummaryRecord? = if (this == null || id == 0L) null else toMediaSummaryRecord()

--- a/app/src/main/java/com/mxt/anitrend/domain/model/FeedItemUiModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/domain/model/FeedItemUiModel.kt
@@ -167,4 +167,5 @@ private fun UserBase.toUserSummaryRecord(): UserSummaryRecord = UserSummaryRecor
     name = name,
     avatar = avatarUrl(),
     siteUrl = null,
+    isFollowing = isFollowing,
 )

--- a/app/src/main/java/com/mxt/anitrend/domain/model/UserSummaryRecord.kt
+++ b/app/src/main/java/com/mxt/anitrend/domain/model/UserSummaryRecord.kt
@@ -5,4 +5,11 @@ data class UserSummaryRecord(
     val name: String?,
     val avatar: String?,
     val siteUrl: String?,
+    /**
+     * Server-reported follow state of the summarized user for the current viewer.
+     * Defaults to false so existing construction sites stay source-compatible; the
+     * canonical committed follow state remains owned exclusively by
+     * [com.mxt.anitrend.data.store.user.UserStore].
+     */
+    val isFollowing: Boolean = false,
 )

--- a/app/src/main/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractor.kt
+++ b/app/src/main/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractor.kt
@@ -9,6 +9,7 @@ import com.mxt.anitrend.data.store.mutation.ResourceKey
 import com.mxt.anitrend.data.store.review.ReviewStore
 import com.mxt.anitrend.data.store.review.ReviewStoreChange
 import com.mxt.anitrend.domain.interactor.executeMutation
+import com.mxt.anitrend.domain.model.ReviewRecord
 import com.mxt.anitrend.graphql.generated.ReviewRating
 import com.mxt.anitrend.repository.BrowseRepository
 
@@ -33,9 +34,15 @@ class RateReviewInteractor(
         ).fold(
             onSuccess = { review ->
                 context.ensureSessionActive()
+                val mapped = review.toReviewRecord(revision = revision)
+                val existing = reviewStore.state.value.reviewsById[reviewId]?.review
                 reviewStore.apply(
                     ReviewStoreChange.ReviewRated(
-                        review = review.toReviewRecord(revision = revision),
+                        review = convergeRatingState(
+                            existing = existing,
+                            response = mapped,
+                            revision = revision,
+                        ),
                         revision = revision,
                     ),
                 )
@@ -49,4 +56,47 @@ class RateReviewInteractor(
             },
         )
     }
+}
+
+/**
+ * Rating-only convergence for successful RateReview responses.
+ *
+ * AniList RateReview responses are partial: the live response can carry
+ * `user: null` and `media: null` (and no body/summary/mediaType), which Gson
+ * writes into the legacy [com.mxt.anitrend.model.entity.anilist.Review]
+ * regardless of declared nullability. Wholesale-committing that partial record
+ * would erase the cached author/media/body/summary display metadata of the
+ * review already committed in the store. Response fields such as mediaType,
+ * summary, or body must never be used to decide whether the response is full:
+ * the live response can carry a non-null mediaType while user/media stay null.
+ *
+ * For every existing committed record, only the mutation-authoritative rating
+ * state ([ReviewRecord.rating], [ReviewRecord.ratingAmount],
+ * [ReviewRecord.userRating]) is patched in. All display metadata - nested user
+ * and media summaries, body, summary, mediaType, and the non-rating scalars
+ * (score, isPrivate, createdAt), which a rate mutation cannot change - is
+ * unconditionally retained from the existing record.
+ * [ReviewRecord.revision] is refreshed to the current store revision so the
+ * committed record stays self-contained, matching the store wrapper revision.
+ *
+ * Only when no existing record exists is the mapped response committed as-is.
+ *
+ * The store remains the sole state owner: this only reads the committed state
+ * to derive the next change, which is applied through [ReviewStore.apply].
+ */
+private fun convergeRatingState(
+    existing: ReviewRecord?,
+    response: ReviewRecord,
+    revision: Long,
+): ReviewRecord {
+    if (existing == null) {
+        return response
+    }
+
+    return existing.copy(
+        rating = response.rating,
+        ratingAmount = response.ratingAmount,
+        userRating = response.userRating,
+        revision = revision,
+    )
 }

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/BrowseReviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/BrowseReviewFragment.kt
@@ -162,6 +162,14 @@ class BrowseReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<Review
                 }
             }
         }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                browseReviewViewModel.rateReviewEvents.collect { outcome ->
+                    reviewAdapter?.onRateReviewResult(outcome.reviewId, outcome.result)
+                }
+            }
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/ReviewFragment.kt
@@ -120,6 +120,14 @@ class ReviewFragment : FragmentBaseList<ReviewRecord, PageContainer<ReviewRecord
                 }
             }
         }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                reviewViewModel.rateReviewEvents.collect { outcome ->
+                    reviewAdapter?.onRateReviewResult(outcome.reviewId, outcome.result)
+                }
+            }
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/fragment/detail/UserOverviewFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mxt.anitrend.R
+import com.mxt.anitrend.base.custom.view.widget.AboutPanelWidget.StatState
 import com.mxt.anitrend.binding.richMarkDown
 import com.mxt.anitrend.binding.setImage
 import com.mxt.anitrend.databinding.FragmentUserAboutBinding
@@ -176,22 +177,30 @@ class UserOverviewFragment : Fragment() {
             val followingDef = async { userRepository.getFollowing(id = userId, perPage = 1) }
             val favsDef = async { userRepository.getFavouritesCount(id = userId, perPage = 1) }
 
-            val followersTotal = followersDef.await().getOrNull()?.pageInfo?.total
-            val followingTotal = followingDef.await().getOrNull()?.pageInfo?.total
-            val favConnection = favsDef.await().getOrNull()?.connection
-            val favouritesTotal = if (favConnection != null) {
-                listOfNotNull(
-                    favConnection.anime?.pageInfo?.total,
-                    favConnection.manga?.pageInfo?.total,
-                    favConnection.characters?.pageInfo?.total,
-                    favConnection.staff?.pageInfo?.total,
-                    favConnection.studios?.pageInfo?.total,
-                ).sum()
-            } else {
-                null
-            }
+            val followersState = followersDef.await().fold(
+                onSuccess = { result -> StatState.Loaded(result.pageInfo?.total ?: 0) },
+                onFailure = { StatState.Failed },
+            )
+            val followingState = followingDef.await().fold(
+                onSuccess = { result -> StatState.Loaded(result.pageInfo?.total ?: 0) },
+                onFailure = { StatState.Failed },
+            )
+            val favouritesState = favsDef.await().fold(
+                onSuccess = { container ->
+                    StatState.Loaded(
+                        listOfNotNull(
+                            container.connection.anime?.pageInfo?.total,
+                            container.connection.manga?.pageInfo?.total,
+                            container.connection.characters?.pageInfo?.total,
+                            container.connection.staff?.pageInfo?.total,
+                            container.connection.studios?.pageInfo?.total,
+                        ).sum(),
+                    )
+                },
+                onFailure = { StatState.Failed },
+            )
 
-            binding.userAboutPanelWidget.setStats(followersTotal, followingTotal, favouritesTotal)
+            binding.userAboutPanelWidget.setStats(followersState, followingState, favouritesState)
         }
     }
 

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetListUsers.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetListUsers.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
+import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -21,6 +22,7 @@ import com.mxt.anitrend.base.interfaces.event.ISearchDelegate
 import com.mxt.anitrend.base.interfaces.event.ItemClickListener
 import com.mxt.anitrend.base.interfaces.event.RecyclerLoadListener
 import com.mxt.anitrend.data.DatabaseHelper
+import com.mxt.anitrend.data.store.mutation.MutationResult
 import com.mxt.anitrend.data.store.user.UserStore
 import com.mxt.anitrend.databinding.BottomSheetListBinding
 import com.mxt.anitrend.domain.model.ToggleUserFollowCommand
@@ -34,6 +36,7 @@ import com.mxt.anitrend.navigation.extension.screenParamKey
 import com.mxt.anitrend.navigation.model.UserListScreenParam
 import com.mxt.anitrend.util.CompatUtil
 import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.view.activity.detail.ProfileActivity
 import com.mxt.anitrend.viewmodel.UserListViewModel
 import com.mxt.anitrend.widget.ProgressLayout
@@ -123,19 +126,32 @@ class BottomSheetListUsers :
         isPager = true
         mColumnSize = resources.getInteger(R.integer.single_list_x1)
         observeUserStore()
+        observeViewModelState()
     }
 
     /**
      * Fire-and-forget delivery from the render-only [FollowStateWidget]. The legacy adapter
-     * still passes a result callback slot, which is intentionally ignored: the mutation result
-     * is applied by observing [UserStore] below.
+     * still passes a result callback slot, which is intentionally ignored: the committed
+     * result is applied by observing [UserStore] below. Request failures are reported
+     * explicitly because a failed mutation commits nothing and would otherwise stay silent
+     * until the widget's bounded loading fallback expires.
      */
     private fun toggleFollow(
         userId: Long,
         @Suppress("UNUSED_PARAMETER") onResult: (Result<UserBase>) -> Unit,
     ) {
         lifecycleScope.launch {
-            toggleUserFollowInteractor(ToggleUserFollowCommand(userId = userId))
+            val result = toggleUserFollowInteractor(ToggleUserFollowCommand(userId = userId))
+            reportFollowFailure(result) { message ->
+                context?.let {
+                    NotifyUtil
+                        .makeText(
+                            it,
+                            message,
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
         }
     }
 
@@ -162,11 +178,20 @@ class BottomSheetListUsers :
         }
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+    /**
+     * Renders the ViewModel's terminal states into the dialog's content.
+     *
+     * This dialog attaches its content in [onCreateDialog] via `dialog.setContentView`
+     * and never creates a fragment view, so [onViewCreated] (and with it
+     * `viewLifecycleOwner`) never runs. Collection therefore starts on the fragment
+     * lifecycle from [onCreate]: [repeatOnLifecycle] begins collecting exactly when the
+     * dialog is started and cancels when it is dismissed, so a terminal state is
+     * rendered while the dialog is visible, a dismissed dialog never renders a late
+     * response, and no collector outlives the fragment.
+     */
+    private fun observeViewModelState() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 userListViewModel.state.collect { state ->
                     when (state) {
                         is UserListViewModel.UiState.Loading -> {
@@ -429,4 +454,23 @@ internal fun UserBase.rebindFollowState(record: UserRecord?): Boolean {
     if (record == null || record.id != id || isFollowing == record.isFollowing) return false
     isFollowing = record.isFollowing
     return true
+}
+
+/**
+ * Surfaces a failed follow mutation through the sheet's notification convention.
+ *
+ * A successful mutation commits to [com.mxt.anitrend.data.store.user.UserStore] and
+ * converges the displayed rows via [BottomSheetListUsers.observeUserStore], so only
+ * failures need explicit reporting here: a failed mutation commits nothing and would
+ * otherwise stay silent until the widget's bounded loading fallback expires. Success
+ * results are intentionally not surfaced.
+ */
+@VisibleForTesting
+internal fun reportFollowFailure(
+    result: MutationResult,
+    notify: (String) -> Unit,
+) {
+    if (result is MutationResult.Failure) {
+        notify(result.message)
+    }
 }

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetUsers.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetUsers.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
+import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
@@ -17,6 +19,7 @@ import com.mxt.anitrend.base.custom.sheet.BottomSheetBase
 import com.mxt.anitrend.base.interfaces.event.ISearchDelegate
 import com.mxt.anitrend.base.interfaces.event.ItemClickListener
 import com.mxt.anitrend.data.DatabaseHelper
+import com.mxt.anitrend.data.store.mutation.MutationResult
 import com.mxt.anitrend.data.store.user.UserStore
 import com.mxt.anitrend.databinding.BottomSheetListBinding
 import com.mxt.anitrend.domain.model.ToggleUserFollowCommand
@@ -26,6 +29,7 @@ import com.mxt.anitrend.extension.getCompatDrawable
 import com.mxt.anitrend.extension.parcelableArrayList
 import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.util.KeyUtil
+import com.mxt.anitrend.util.NotifyUtil
 import com.mxt.anitrend.view.activity.detail.ProfileActivity
 import com.mxt.anitrend.widget.ProgressLayout
 import kotlinx.coroutines.launch
@@ -54,6 +58,20 @@ class BottomSheetUsers :
         fun newInstance(bundle: Bundle): BottomSheetUsers = BottomSheetUsers().apply {
             arguments = bundle
         }
+
+        /**
+         * Identity-preserving read of the users sheet payload.
+         *
+         * The bundle carries [UserSheetModel] entries (parcel-safe by construction,
+         * see [UserBase.toUserSheetModel]) and is converted back to in-memory
+         * [UserBase] items with their real ids, avatars, and initial follow state
+         * restored. Reading [UserBase] directly from the bundle would zero every
+         * `@IgnoredOnParcel` id and break follow dispatch and store rebinding.
+         */
+        @VisibleForTesting
+        internal fun resolveUsers(bundle: Bundle?): List<UserBase>? =
+            bundle?.parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)
+                ?.map(UserSheetModel::toUserBase)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,7 +83,7 @@ class BottomSheetUsers :
             currentUser = databaseHelper.currentUser,
             onToggleFollowAction = ::toggleFollow,
         )
-        val baseList = arguments?.parcelableArrayList<UserBase>(KeyUtil.arg_list_model)
+        val baseList = resolveUsers(arguments)
         if (!baseList.isNullOrEmpty()) {
             mAdapter.onItemsInserted(baseList)
         }
@@ -74,15 +92,26 @@ class BottomSheetUsers :
 
     /**
      * Fire-and-forget delivery from the render-only [FollowStateWidget]. The legacy adapter
-     * still passes a result callback slot, which is intentionally ignored: the mutation result
-     * is applied by observing [UserStore] below.
+     * still passes a result callback slot, which is intentionally ignored: the committed
+     * result is applied by observing [UserStore] below. Request failures are reported
+     * explicitly because a failed mutation commits nothing and would otherwise stay silent.
      */
     private fun toggleFollow(
         userId: Long,
         @Suppress("UNUSED_PARAMETER") onResult: (Result<UserBase>) -> Unit,
     ) {
         lifecycleScope.launch {
-            toggleUserFollowInteractor(ToggleUserFollowCommand(userId = userId))
+            val result = toggleUserFollowInteractor(ToggleUserFollowCommand(userId = userId))
+            if (result is MutationResult.Failure) {
+                context?.let {
+                    NotifyUtil
+                        .makeText(
+                            it,
+                            result.message,
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
         }
     }
 
@@ -103,9 +132,9 @@ class BottomSheetUsers :
         val position = mAdapter.data.indexOfFirst { it.id == record.id }
         if (position < 0) return
         val current = mAdapter.data[position]
-        if (current.isFollowing == record.isFollowing) return
-        current.isFollowing = record.isFollowing
-        mAdapter.onItemChanged(current, position)
+        if (current.rebindFollowState(record)) {
+            mAdapter.onItemChanged(current, position)
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -198,8 +227,17 @@ class BottomSheetUsers :
     class Builder : BottomSheetBuilder() {
         override fun build(): BottomSheetBase<*> = newInstance(bundle)
 
+        /**
+         * Writes the user list through the parcel-safe [UserSheetModel] boundary.
+         * [UserBase] itself cannot be parceled without losing its `@IgnoredOnParcel`
+         * id (and avatar), so the identity is captured here while the entities are
+         * still alive in memory and restored on read by [resolveUsers].
+         */
         fun setModel(model: List<UserBase>): Builder {
-            bundle.putParcelableArrayList(KeyUtil.arg_list_model, ArrayList(model))
+            bundle.putParcelableArrayList(
+                KeyUtil.arg_list_model,
+                ArrayList(model.map(UserBase::toUserSheetModel)),
+            )
             return this
         }
     }

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetUsers.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetUsers.kt
@@ -69,9 +69,8 @@ class BottomSheetUsers :
          * `@IgnoredOnParcel` id and break follow dispatch and store rebinding.
          */
         @VisibleForTesting
-        internal fun resolveUsers(bundle: Bundle?): List<UserBase>? =
-            bundle?.parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)
-                ?.map(UserSheetModel::toUserBase)
+        internal fun resolveUsers(bundle: Bundle?): List<UserBase>? = bundle?.parcelableArrayList<UserSheetModel>(KeyUtil.arg_list_model)
+            ?.map(UserSheetModel::toUserBase)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mxt/anitrend/view/sheet/UserSheetModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/sheet/UserSheetModel.kt
@@ -1,0 +1,50 @@
+package com.mxt.anitrend.view.sheet
+
+import android.os.Parcelable
+import com.mxt.anitrend.model.entity.anilist.meta.ImageBase
+import com.mxt.anitrend.model.entity.base.UserBase
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Parcel-safe immutable boundary model for the users bottom sheet ([BottomSheetUsers]).
+ *
+ * The legacy [UserBase] entity marks its `id` and `avatar` as `@IgnoredOnParcel`, so a
+ * bundle round trip silently zeroes the id (and drops the avatar). That breaks follow
+ * dispatch (userId 0 is sent) and [com.mxt.anitrend.data.store.user.UserStore] rebinding
+ * (a record id never matches a zeroed row id). [BottomSheetUsers.Builder] therefore
+ * converts every item through this model before parceling, and the sheet converts back
+ * with [toUserBase], keeping the real AniList user id and avatar alive across the boundary.
+ *
+ * [isFollowing] is carried through the round trip so the server-reported follow state
+ * added to [com.mxt.anitrend.domain.model.UserSummaryRecord] is preserved until the
+ * canonical [com.mxt.anitrend.data.store.user.UserStore] commits authoritative state.
+ */
+@Parcelize
+data class UserSheetModel(
+    val id: Long,
+    val name: String?,
+    val avatar: String?,
+    val isFollowing: Boolean = false,
+) : Parcelable
+
+fun UserBase.toUserSheetModel(): UserSheetModel = UserSheetModel(
+    id = id,
+    name = name,
+    avatar = avatar?.large ?: avatar?.medium ?: avatar?.extraLarge,
+    isFollowing = isFollowing,
+)
+
+fun UserSheetModel.toUserBase(): UserBase {
+    val avatarUrl = avatar
+    return UserBase(name = name).apply {
+        id = this@toUserBase.id
+        avatar = avatarUrl?.let {
+            ImageBase(
+                extraLarge = it,
+                large = it,
+                medium = it,
+            )
+        }
+        isFollowing = this@toUserBase.isFollowing
+    }
+}

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/BrowseReviewViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/BrowseReviewViewModel.kt
@@ -14,12 +14,15 @@ import com.mxt.anitrend.graphql.generated.ReviewSort
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.util.KeyUtil
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -50,6 +53,19 @@ class BrowseReviewViewModel(
     )
 
     private val screenState = MutableStateFlow(ScreenState())
+
+    private val _rateReviewEvents = Channel<ReviewRateOutcome>(Channel.BUFFERED)
+
+    /**
+     * One-shot outcomes of [rateReview] calls. The canonical committed state is delivered
+     * through the [state] flow (store rebinding); these events only drive widget
+     * convergence (reset the vote loading state, surface a failure message).
+     *
+     * A buffered single-consumer channel is used so an outcome emitted while the fragment
+     * collector is inactive (for example when the view left STARTED mid-mutation) is
+     * retained and delivered when the next collector subscribes, instead of being dropped.
+     */
+    val rateReviewEvents: Flow<ReviewRateOutcome> = _rateReviewEvents.receiveAsFlow()
 
     val state: StateFlow<UiState> =
         screenState
@@ -144,7 +160,16 @@ class BrowseReviewViewModel(
 
     fun rateReview(reviewId: Long, rating: ReviewRating?) {
         viewModelScope.launch {
-            rateReviewInteractor(reviewId, rating)
+            val outcome = ReviewRateOutcome(
+                reviewId = reviewId,
+                result = rateReviewInteractor(reviewId, rating),
+            )
+            _rateReviewEvents.send(outcome)
         }
+    }
+
+    override fun onCleared() {
+        _rateReviewEvents.close()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/ReviewRateOutcome.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/ReviewRateOutcome.kt
@@ -1,0 +1,16 @@
+package com.mxt.anitrend.viewmodel
+
+import com.mxt.anitrend.data.store.mutation.MutationResult
+
+/**
+ * UI-effect result of a review rating mutation.
+ *
+ * The canonical committed state stays exclusively in
+ * [com.mxt.anitrend.data.store.review.ReviewStore]; this outcome only lets the
+ * screen converge widget loading/error/success behavior (reset the vote control,
+ * surface a failure message) without optimistic store mutation.
+ */
+data class ReviewRateOutcome(
+    val reviewId: Long,
+    val result: MutationResult,
+)

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/ReviewViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/ReviewViewModel.kt
@@ -13,12 +13,15 @@ import com.mxt.anitrend.graphql.generated.ReviewRating
 import com.mxt.anitrend.model.entity.container.body.PageContainer
 import com.mxt.anitrend.repository.BrowseRepository
 import com.mxt.anitrend.util.KeyUtil
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -49,6 +52,19 @@ class ReviewViewModel(
     )
 
     private val screenState = MutableStateFlow(ScreenState())
+
+    private val _rateReviewEvents = Channel<ReviewRateOutcome>(Channel.BUFFERED)
+
+    /**
+     * One-shot outcomes of [rateReview] calls. The canonical committed state is delivered
+     * through the [state] flow (store rebinding); these events only drive widget
+     * convergence (reset the vote loading state, surface a failure message).
+     *
+     * A buffered single-consumer channel is used so an outcome emitted while the fragment
+     * collector is inactive (for example when the view left STARTED mid-mutation) is
+     * retained and delivered when the next collector subscribes, instead of being dropped.
+     */
+    val rateReviewEvents: Flow<ReviewRateOutcome> = _rateReviewEvents.receiveAsFlow()
 
     val state: StateFlow<UiState> =
         screenState
@@ -138,7 +154,16 @@ class ReviewViewModel(
 
     fun rateReview(reviewId: Long, rating: ReviewRating?) {
         viewModelScope.launch {
-            rateReviewInteractor(reviewId, rating)
+            val outcome = ReviewRateOutcome(
+                reviewId = reviewId,
+                result = rateReviewInteractor(reviewId, rating),
+            )
+            _rateReviewEvents.send(outcome)
         }
+    }
+
+    override fun onCleared() {
+        _rateReviewEvents.close()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/widget/ProgressLayout.kt
+++ b/app/src/main/java/com/mxt/anitrend/widget/ProgressLayout.kt
@@ -61,6 +61,20 @@ constructor(
         applyState()
     }
 
+    /**
+     * Capture the content baseline as soon as a non-overlay child is attached, before any
+     * state transition can overwrite its visibility. Children are added programmatically
+     * after construction (e.g. via [addView]), which means [onFinishInflate] never sees
+     * them; without this, a child hidden before [showLoading] would have that hidden state
+     * recorded as its baseline and never be restored.
+     */
+    override fun onViewAdded(child: View) {
+        super.onViewAdded(child)
+        if (child.id !in overlayIds) {
+            initialContentVisibility.putIfAbsent(child, child.visibility)
+        }
+    }
+
     @MainThread
     fun showLoading() {
         if (!isMainThread()) {

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -319,6 +319,7 @@
     <style name="Widget.AniTrend.ProgressLayout.LoadingIndicator" parent="Widget.Material3.LoadingIndicator.Contained">
         <item name="indicatorColor">?attr/colorAccent</item>
         <item name="containerColor">?attr/cardColor</item>
+        <item name="indicatorSize">@dimen/widget_spinner_compact_size</item>
     </style>
 
     <style name="ThemeOverlay.AniTrend.ProgressLayout.Material3" parent="Theme.Material3.Light.NoActionBar">

--- a/app/src/test/java/com/mxt/anitrend/adapter/recycler/index/ReviewHolderRegistryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/adapter/recycler/index/ReviewHolderRegistryTest.kt
@@ -1,0 +1,69 @@
+package com.mxt.anitrend.adapter.recycler.index
+
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Focused tests for [ReviewHolderRegistry], the holder-to-review binding used by
+ * [ReviewAdapter.onRateReviewResult] to route mutation outcomes to the visible vote
+ * control. A holder rebound from review A to review B must drop the stale A mapping so
+ * a late outcome for A can never reach (and mutate the vote control of) B.
+ */
+class ReviewHolderRegistryTest {
+
+    @Test
+    fun `holder rebound from review A to B drops stale A outcome and leaves B untouched`() {
+        val registry = ReviewHolderRegistry<Any>()
+        val holder = Any()
+        val reviewA = 1L
+        val reviewB = 2L
+
+        registry.onBound(reviewA, holder)
+        assertSame(holder, registry.holderFor(reviewA))
+
+        // The same holder is rebound to review B without being recycled first.
+        registry.onBound(reviewB, holder)
+
+        // Delivering an outcome for A resolves no holder, so B's vote control is untouched.
+        assertNull(registry.holderFor(reviewA))
+        // B remains bound and routable.
+        assertSame(holder, registry.holderFor(reviewB))
+    }
+
+    @Test
+    fun `recycled holder is no longer routable`() {
+        val registry = ReviewHolderRegistry<Any>()
+        val holder = Any()
+
+        registry.onBound(1L, holder)
+        registry.onRecycled(holder)
+
+        assertNull(registry.holderFor(1L))
+    }
+
+    @Test
+    fun `rebinding a different holder for the same review replaces the mapping`() {
+        val registry = ReviewHolderRegistry<Any>()
+        val first = Any()
+        val second = Any()
+
+        registry.onBound(1L, first)
+        registry.onBound(1L, second)
+
+        assertSame(second, registry.holderFor(1L))
+    }
+
+    @Test
+    fun `recycling the replaced holder does not remove the active mapping`() {
+        val registry = ReviewHolderRegistry<Any>()
+        val first = Any()
+        val second = Any()
+
+        registry.onBound(1L, first)
+        registry.onBound(1L, second)
+        registry.onRecycled(first)
+
+        assertSame(second, registry.holderFor(1L))
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidgetStatStateTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidgetStatStateTest.kt
@@ -1,0 +1,36 @@
+package com.mxt.anitrend.base.custom.view.widget
+
+import com.mxt.anitrend.base.custom.view.widget.AboutPanelWidget.StatClickAction
+import com.mxt.anitrend.base.custom.view.widget.AboutPanelWidget.StatState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Consumer-level click contract for the profile about panel
+ * ([AboutPanelWidget]). A stat container must distinguish not-yet-loaded, failed,
+ * loaded nonzero, and loaded-zero: loaded counts (including zero) open the normal
+ * destination or list sheet, while not-yet-loaded and failed counts keep the
+ * loading toast. A loaded zero must never fall back to the loading toast.
+ */
+class AboutPanelWidgetStatStateTest {
+
+    @Test
+    fun `loaded zero resolves to open and never emits the loading toast`() {
+        assertEquals(StatClickAction.Open, StatState.Loaded(0).resolveStatClick())
+    }
+
+    @Test
+    fun `loaded nonzero resolves to open`() {
+        assertEquals(StatClickAction.Open, StatState.Loaded(5).resolveStatClick())
+    }
+
+    @Test
+    fun `not yet loaded resolves to the loading toast`() {
+        assertEquals(StatClickAction.ShowLoading, StatState.NotLoaded.resolveStatClick())
+    }
+
+    @Test
+    fun `failed resolves to the loading toast`() {
+        assertEquals(StatClickAction.ShowLoading, StatState.Failed.resolveStatClick())
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/data/mapper/ReviewRecordMapperTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/data/mapper/ReviewRecordMapperTest.kt
@@ -1,17 +1,34 @@
 package com.mxt.anitrend.data.mapper
 
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
 import com.mxt.anitrend.model.entity.anilist.Review
 import com.mxt.anitrend.model.entity.anilist.meta.ImageBase
 import com.mxt.anitrend.model.entity.anilist.meta.MediaTitle
 import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.base.UserBase
+import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.lang.reflect.Type
 
 class ReviewRecordMapperTest {
+
+    /**
+     * Mirrors the production Gson configuration used by the retrofit pipeline
+     * (`ServiceFactory.gson` and the Koin `AniGraphConverter`): plain Gson with no
+     * null-skipping or custom adapters. This is what deserializes `AniListContainer<Review>`
+     * responses, so regression tests for the mapper must go through the same machinery.
+     */
+    private val productionGson: Gson =
+        GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .setLenient()
+            .create()
 
     @Test
     fun `map legacy Review to ReviewRecord preserving all values`() {
@@ -106,6 +123,110 @@ class ReviewRecordMapperTest {
         assertEquals("alice", record.user?.name)
         assertEquals(44L, record.media?.id)
         assertEquals(3L, record.revision)
+    }
+
+    @Test
+    fun `production Gson response with null user and media maps to null nested summaries`() {
+        // Confirmed live defect: an authenticated RateReview response can contain
+        // "user": null and "media": null. Plain Gson writes those nulls into the
+        // declared non-null Review.user / Review.media fields via reflection, so the
+        // mapper must treat a runtime null the same as the empty default instance.
+        val review = productionGson.fromJson(
+            """
+            {"id":42,"summary":"A solid series","mediaType":"ANIME","body":"Full body text",
+             "rating":55,"ratingAmount":3,"userRating":"UP_VOTE","score":90,"private":false,
+             "createdAt":1600000000,"user":null,"media":null}
+            """.trimIndent(),
+            Review::class.java,
+        )
+
+        assertNull(review.user)
+        assertNull(review.media)
+
+        val record = review.toReviewRecord(revision = 7L)
+
+        assertEquals(42L, record.id)
+        assertEquals("A solid series", record.summary)
+        assertEquals("ANIME", record.mediaType)
+        assertEquals("Full body text", record.body)
+        assertEquals(55, record.rating)
+        assertEquals(3, record.ratingAmount)
+        assertEquals("UP_VOTE", record.userRating)
+        assertEquals(90, record.score)
+        assertEquals(1_600_000_000L, record.createdAt)
+        assertNull(record.user)
+        assertNull(record.media)
+        assertEquals(7L, record.revision)
+    }
+
+    @Test
+    fun `production Gson RateReview container with null user and media unwraps and maps`() {
+        val containerType: Type = object : TypeToken<AniListContainer<Review>>() {}.type
+        val container = productionGson.fromJson<AniListContainer<Review>>(
+            """
+            {"data":{"RateReview":{"id":42,"rating":55,"ratingAmount":3,"userRating":"UP_VOTE",
+             "user":null,"media":null}},"errors":null}
+            """.trimIndent(),
+            containerType,
+        )
+
+        val review = container.data?.result
+        assertNull(review?.user)
+        assertNull(review?.media)
+
+        val record = review?.toReviewRecord(revision = 1L)
+
+        assertEquals(42L, record?.id)
+        assertEquals(55, record?.rating)
+        assertEquals("UP_VOTE", record?.userRating)
+        assertNull(record?.user)
+        assertNull(record?.media)
+        assertEquals(1L, record?.revision)
+    }
+
+    @Test
+    fun `production Gson response with null media only preserves user summary`() {
+        val review = productionGson.fromJson(
+            """
+            {"id":42,"rating":55,"user":{"id":7,"name":"alice","avatar":{"large":"https://avatar-large"}},"media":null}
+            """.trimIndent(),
+            Review::class.java,
+        )
+
+        assertNull(review.media)
+
+        val record = review.toReviewRecord()
+
+        assertEquals(42L, record.id)
+        assertEquals(7L, record.user?.id)
+        assertEquals("alice", record.user?.name)
+        assertEquals("https://avatar-large", record.user?.avatar)
+        assertNull(record.media)
+    }
+
+    @Test
+    fun `production Gson response with user and media present maps full summaries`() {
+        val review = productionGson.fromJson(
+            """
+            {"id":42,"rating":55,"user":{"id":7,"name":"alice","avatar":{"large":"https://avatar-large"}},
+             "media":{"id":44,"title":{"romaji":"Romaji","english":"English","native":"Original","userPreferred":"Preferred"},
+             "coverImage":{"extraLarge":"https://cover-extra-large"},"type":"ANIME"}}
+            """.trimIndent(),
+            Review::class.java,
+        )
+
+        val record = review.toReviewRecord(revision = 4L)
+
+        assertEquals(7L, record.user?.id)
+        assertEquals("alice", record.user?.name)
+        assertEquals(44L, record.media?.id)
+        assertEquals("Romaji", record.media?.titleRomaji)
+        assertEquals("English", record.media?.titleEnglish)
+        assertEquals("Original", record.media?.titleOriginal)
+        assertEquals("Preferred", record.media?.titleUserPreferred)
+        assertEquals("https://cover-extra-large", record.media?.coverImage)
+        assertEquals("ANIME", record.media?.type)
+        assertEquals(4L, record.revision)
     }
 
     private fun createReview(

--- a/app/src/test/java/com/mxt/anitrend/data/store/FeedRecordMapperTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/data/store/FeedRecordMapperTest.kt
@@ -1,7 +1,9 @@
 package com.mxt.anitrend.data.store
 
+import com.mxt.anitrend.data.mapper.toFeedList
 import com.mxt.anitrend.data.mapper.toFeedRecord
 import com.mxt.anitrend.data.mapper.toFeedReplyRecord
+import com.mxt.anitrend.data.mapper.toUserBase
 import com.mxt.anitrend.data.mapper.toUserSummaryRecord
 import com.mxt.anitrend.model.entity.anilist.FeedList
 import com.mxt.anitrend.model.entity.anilist.FeedReply
@@ -10,7 +12,9 @@ import com.mxt.anitrend.model.entity.anilist.meta.MediaTitle
 import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.base.UserBase
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FeedRecordMapperTest {
@@ -97,6 +101,42 @@ class FeedRecordMapperTest {
         assertEquals("summary-user", record.name)
         assertEquals("https://avatar-large", record.avatar)
         assertNull(record.siteUrl)
+        assertFalse(record.isFollowing)
+    }
+
+    @Test
+    fun `map UserBase isFollowing into UserSummaryRecord`() {
+        val user = createUser(8L, "summary-user", isFollowing = true)
+
+        val record = user.toUserSummaryRecord()
+
+        assertTrue(record.isFollowing)
+    }
+
+    @Test
+    fun `map UserSummaryRecord back to UserBase preserves isFollowing`() {
+        val record =
+            createUser(8L, "summary-user", isFollowing = true)
+                .toUserSummaryRecord()
+
+        val user = record.toUserBase()
+
+        assertEquals(8L, user.id)
+        assertEquals("summary-user", user.name)
+        assertEquals("https://avatar-large", user.avatar?.large)
+        assertTrue(user.isFollowing)
+    }
+
+    @Test
+    fun `feed likes carry isFollowing into FeedRecord and back`() {
+        val liker = createUser(8L, "liker", isFollowing = true)
+        val feed = createFeed(likes = mutableListOf(liker))
+
+        val record = feed.toFeedRecord(revision = 1L)
+        assertTrue(record.likes.single().isFollowing)
+
+        val restored = record.toFeedList()
+        assertTrue(restored.likes.orEmpty().single().isFollowing)
     }
 
     private fun createFeed(likes: MutableList<UserBase> = mutableListOf(createUser(7L, "bob"), createUser(8L, "eve"))): FeedList = FeedList(
@@ -114,7 +154,11 @@ class FeedRecordMapperTest {
         siteUrl = "https://feed",
     )
 
-    private fun createUser(id: Long, name: String): UserBase = UserBase(name = name).also {
+    private fun createUser(
+        id: Long,
+        name: String,
+        isFollowing: Boolean = false,
+    ): UserBase = UserBase(name = name, isFollowing = isFollowing).also {
         it.id = id
         it.avatar = ImageBase(
             extraLarge = "https://avatar-extra-large",

--- a/app/src/test/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractorTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractorTest.kt
@@ -1,5 +1,7 @@
 package com.mxt.anitrend.domain.review.interactor
 
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.mxt.anitrend.data.store.mutation.DefaultMutationExecutor
 import com.mxt.anitrend.data.store.mutation.DefaultMutationRegistry
 import com.mxt.anitrend.data.store.mutation.DefaultOperationIdGenerator
@@ -9,6 +11,9 @@ import com.mxt.anitrend.data.store.mutation.RequestSequence
 import com.mxt.anitrend.data.store.mutation.SessionEpoch
 import com.mxt.anitrend.data.store.review.InMemoryReviewStore
 import com.mxt.anitrend.data.store.review.ReviewStoreChange
+import com.mxt.anitrend.domain.model.MediaSummaryRecord
+import com.mxt.anitrend.domain.model.ReviewRecord
+import com.mxt.anitrend.domain.model.UserSummaryRecord
 import com.mxt.anitrend.graphql.generated.MediaType
 import com.mxt.anitrend.graphql.generated.ReviewRating
 import com.mxt.anitrend.model.entity.anilist.Review
@@ -17,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doReturn
@@ -120,6 +126,228 @@ class RateReviewInteractorTest {
         assertEquals(1L, store.state.value.reviewsById.getValue(42L).revision)
     }
 
+    @Test
+    fun `null-nested rate response preserves existing display metadata while updating rating state`() = runTest {
+        val repository = mock(BrowseRepository::class.java)
+        val store = InMemoryReviewStore()
+        val existing = ReviewRecord(
+            id = 42L,
+            summary = "A solid series",
+            mediaType = "ANIME",
+            body = "Full body text",
+            rating = 10,
+            ratingAmount = 1,
+            userRating = "DOWN_VOTE",
+            score = 90,
+            isPrivate = true,
+            createdAt = 1_600_000_000L,
+            user = UserSummaryRecord(
+                id = 7L,
+                name = "alice",
+                avatar = "https://avatar-large",
+                siteUrl = "https://anilist.co/user/alice",
+            ),
+            media = MediaSummaryRecord(
+                id = 44L,
+                titleUserPreferred = "Preferred",
+                titleRomaji = "Romaji",
+                titleEnglish = "English",
+                titleOriginal = "Original",
+                coverImage = "https://cover-extra-large",
+                type = "ANIME",
+                episodes = 12,
+                chapters = 0,
+                volumes = 0,
+                status = "FINISHED",
+                siteUrl = "https://media",
+            ),
+            revision = 0L,
+        )
+        store.apply(ReviewStoreChange.ReviewSaved(review = existing, revision = 0L))
+        // Mirrors the live defect: RateReview returns "user": null and "media": null
+        // (and no body/summary/mediaType), which plain Gson writes via reflection.
+        doReturn(Result.success(nullNestedRateResponse(id = 42L, rating = 55, ratingAmount = 3, userRating = "UP_VOTE")))
+            .`when`(repository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        val interactor = RateReviewInteractor(
+            browseRepository = repository,
+            mutationExecutor = mutationExecutor(backgroundScope),
+            reviewStore = store,
+            requestSequence = RequestSequence(),
+        )
+
+        val result = interactor(42L, ReviewRating.UP_VOTE)
+
+        assertEquals(MutationResult.Success, result)
+        val record = store.state.value.reviewsById.getValue(42L).review
+        assertEquals(42L, record.id)
+        assertEquals(55, record.rating)
+        assertEquals(3, record.ratingAmount)
+        assertEquals("UP_VOTE", record.userRating)
+        assertEquals(1L, record.revision)
+        assertEquals(1L, store.state.value.reviewsById.getValue(42L).revision)
+        // Display metadata retained from the existing committed record.
+        assertEquals("A solid series", record.summary)
+        assertEquals("ANIME", record.mediaType)
+        assertEquals("Full body text", record.body)
+        assertEquals(90, record.score)
+        assertTrue(record.isPrivate)
+        assertEquals(1_600_000_000L, record.createdAt)
+        assertEquals(7L, record.user?.id)
+        assertEquals("alice", record.user?.name)
+        assertEquals("https://avatar-large", record.user?.avatar)
+        assertEquals(44L, record.media?.id)
+        assertEquals("Preferred", record.media?.titleUserPreferred)
+        assertEquals("Romaji", record.media?.titleRomaji)
+        assertEquals("English", record.media?.titleEnglish)
+        assertEquals("Original", record.media?.titleOriginal)
+        assertEquals("https://cover-extra-large", record.media?.coverImage)
+        assertEquals("ANIME", record.media?.type)
+    }
+
+    @Test
+    fun `rate response with non-null mediaType and null user media still preserves existing display metadata`() = runTest {
+        val repository = mock(BrowseRepository::class.java)
+        val store = InMemoryReviewStore()
+        val existing = ReviewRecord(
+            id = 42L,
+            summary = "A solid series",
+            mediaType = "MANGA",
+            body = "Full body text",
+            rating = 10,
+            ratingAmount = 1,
+            userRating = "DOWN_VOTE",
+            score = 90,
+            isPrivate = true,
+            createdAt = 1_600_000_000L,
+            user = UserSummaryRecord(
+                id = 7L,
+                name = "alice",
+                avatar = "https://avatar-large",
+                siteUrl = "https://anilist.co/user/alice",
+            ),
+            media = MediaSummaryRecord(
+                id = 44L,
+                titleUserPreferred = "Preferred",
+                titleRomaji = "Romaji",
+                titleEnglish = "English",
+                titleOriginal = "Original",
+                coverImage = "https://cover-extra-large",
+                type = "MANGA",
+                episodes = 12,
+                chapters = 0,
+                volumes = 0,
+                status = "FINISHED",
+                siteUrl = "https://media",
+            ),
+            revision = 0L,
+        )
+        store.apply(ReviewStoreChange.ReviewSaved(review = existing, revision = 0L))
+        // Regression: the response carries a non-null mediaType ("ANIME") while
+        // user/media are null. mediaType must not be used to treat the response
+        // as full: the existing author/media/body/summary metadata must survive
+        // and the response mediaType must not leak into the committed record.
+        doReturn(
+            Result.success(
+                nullNestedRateResponse(
+                    id = 42L,
+                    rating = 55,
+                    ratingAmount = 3,
+                    userRating = "UP_VOTE",
+                    mediaType = "ANIME",
+                ),
+            ),
+        )
+            .`when`(repository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        val interactor = RateReviewInteractor(
+            browseRepository = repository,
+            mutationExecutor = mutationExecutor(backgroundScope),
+            reviewStore = store,
+            requestSequence = RequestSequence(),
+        )
+
+        val result = interactor(42L, ReviewRating.UP_VOTE)
+
+        assertEquals(MutationResult.Success, result)
+        val record = store.state.value.reviewsById.getValue(42L).review
+        assertEquals(42L, record.id)
+        assertEquals(55, record.rating)
+        assertEquals(3, record.ratingAmount)
+        assertEquals("UP_VOTE", record.userRating)
+        assertEquals(1L, record.revision)
+        assertEquals(1L, store.state.value.reviewsById.getValue(42L).revision)
+        // Display metadata retained from the existing committed record,
+        // including the existing mediaType instead of the response's "ANIME".
+        assertEquals("A solid series", record.summary)
+        assertEquals("MANGA", record.mediaType)
+        assertEquals("Full body text", record.body)
+        assertEquals(90, record.score)
+        assertTrue(record.isPrivate)
+        assertEquals(1_600_000_000L, record.createdAt)
+        assertEquals(7L, record.user?.id)
+        assertEquals("alice", record.user?.name)
+        assertEquals("https://avatar-large", record.user?.avatar)
+        assertEquals(44L, record.media?.id)
+        assertEquals("Preferred", record.media?.titleUserPreferred)
+        assertEquals("Romaji", record.media?.titleRomaji)
+        assertEquals("English", record.media?.titleEnglish)
+        assertEquals("Original", record.media?.titleOriginal)
+        assertEquals("https://cover-extra-large", record.media?.coverImage)
+        assertEquals("MANGA", record.media?.type)
+    }
+
+    @Test
+    fun `null-nested rate response with no existing record commits mapped response as-is`() = runTest {
+        val repository = mock(BrowseRepository::class.java)
+        val store = InMemoryReviewStore()
+        doReturn(Result.success(nullNestedRateResponse(id = 42L, rating = 55, ratingAmount = 3, userRating = "UP_VOTE")))
+            .`when`(repository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        val interactor = RateReviewInteractor(
+            browseRepository = repository,
+            mutationExecutor = mutationExecutor(backgroundScope),
+            reviewStore = store,
+            requestSequence = RequestSequence(),
+        )
+
+        val result = interactor(42L, ReviewRating.UP_VOTE)
+
+        assertEquals(MutationResult.Success, result)
+        val record = store.state.value.reviewsById.getValue(42L).review
+        assertEquals(42L, record.id)
+        assertEquals(55, record.rating)
+        assertEquals(3, record.ratingAmount)
+        assertEquals("UP_VOTE", record.userRating)
+        assertEquals(1L, record.revision)
+        assertNull(record.user)
+        assertNull(record.media)
+        assertNull(record.summary)
+        assertNull(record.body)
+        assertNull(record.mediaType)
+    }
+
     private fun mutationExecutor(scope: CoroutineScope) = DefaultMutationExecutor(
         applicationScope = scope,
         keyedMutex = KeyedMutex(scope),
@@ -141,4 +369,31 @@ class RateReviewInteractorTest {
         media.id = 100L
         media.type = MediaType.ANIME.name
     }
+
+    /**
+     * Builds a Review with runtime-null `user` and `media` (and optional
+     * body/summary/mediaType), mirroring how plain Gson deserializes a partial
+     * RateReview response: reflection writes the nulls into the declared
+     * non-null legacy properties, which Kotlin cannot express directly.
+     */
+    private fun nullNestedRateResponse(
+        id: Long,
+        rating: Int,
+        ratingAmount: Int,
+        userRating: String?,
+        mediaType: String? = null,
+    ): Review {
+        val userRatingJson = userRating?.let { "\"$it\"" } ?: "null"
+        val mediaTypeJson = mediaType?.let { "\"$it\"" } ?: "null"
+        return productionGson.fromJson(
+            """{"id":$id,"rating":$rating,"ratingAmount":$ratingAmount,"userRating":$userRatingJson,"mediaType":$mediaTypeJson,"user":null,"media":null}""",
+            Review::class.java,
+        )
+    }
+
+    private val productionGson: Gson =
+        GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .setLenient()
+            .create()
 }

--- a/app/src/test/java/com/mxt/anitrend/view/sheet/BottomSheetListUsersFollowFailureTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/sheet/BottomSheetListUsersFollowFailureTest.kt
@@ -1,0 +1,42 @@
+package com.mxt.anitrend.view.sheet
+
+import com.mxt.anitrend.data.store.mutation.MutationResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Failure reporting for [BottomSheetListUsers] follow toggles.
+ *
+ * A failed mutation commits nothing to the canonical
+ * [com.mxt.anitrend.data.store.user.UserStore], so it must be surfaced immediately
+ * through the sheet's notification convention instead of leaving the follow control
+ * in its loading state until the widget's bounded fallback expires. Successful
+ * mutations converge via the store observation and are not surfaced.
+ */
+class BottomSheetListUsersFollowFailureTest {
+
+    @Test
+    fun `failure result is surfaced with its message`() {
+        val messages = mutableListOf<String>()
+
+        reportFollowFailure(
+            result = MutationResult.Failure(message = "Unable to toggle follow"),
+            notify = messages::add,
+        )
+
+        assertEquals(listOf("Unable to toggle follow"), messages)
+    }
+
+    @Test
+    fun `success result is not surfaced`() {
+        val messages = mutableListOf<String>()
+
+        reportFollowFailure(
+            result = MutationResult.Success,
+            notify = messages::add,
+        )
+
+        assertTrue(messages.isEmpty())
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/view/sheet/UserSheetModelMapperTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/view/sheet/UserSheetModelMapperTest.kt
@@ -1,0 +1,76 @@
+package com.mxt.anitrend.view.sheet
+
+import com.mxt.anitrend.model.entity.anilist.meta.ImageBase
+import com.mxt.anitrend.model.entity.base.UserBase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Identity-preservation of the users sheet boundary model ([UserSheetModel]).
+ *
+ * [UserBase] marks its id (and avatar) as `@IgnoredOnParcel`, so the sheet must never
+ * parcel entities directly. The to/from conversions here must round trip the real
+ * AniList user id, the avatar, and the server-reported follow state so follow dispatch
+ * and [com.mxt.anitrend.data.store.user.UserStore] rebinding keep working.
+ */
+class UserSheetModelMapperTest {
+
+    @Test
+    fun `UserBase to UserSheetModel captures identity avatar and follow state`() {
+        val user =
+            UserBase(name = "liker", isFollowing = true).apply {
+                id = 987L
+                avatar = ImageBase(extraLarge = null, large = "https://example.com/avatar.png", medium = null)
+            }
+
+        val sheetModel = user.toUserSheetModel()
+
+        assertEquals(987L, sheetModel.id)
+        assertEquals("liker", sheetModel.name)
+        assertEquals("https://example.com/avatar.png", sheetModel.avatar)
+        assertEquals(true, sheetModel.isFollowing)
+    }
+
+    @Test
+    fun `UserSheetModel round trip preserves the real user id`() {
+        val original =
+            UserBase(name = "other-user", isFollowing = false).apply {
+                id = 42L
+                avatar = ImageBase(extraLarge = null, large = "avatar-url", medium = null)
+            }
+
+        val restored = original.toUserSheetModel().toUserBase()
+
+        assertEquals(42L, restored.id)
+        assertEquals("other-user", restored.name)
+        assertEquals("avatar-url", restored.avatar?.large)
+        assertEquals(false, restored.isFollowing)
+    }
+
+    @Test
+    fun `UserSheetModel round trip preserves initial following state`() {
+        val original =
+            UserBase(name = "already-following", isFollowing = true).apply {
+                id = 7L
+            }
+
+        val restored = original.toUserSheetModel().toUserBase()
+
+        assertEquals(7L, restored.id)
+        assertEquals(true, restored.isFollowing)
+    }
+
+    @Test
+    fun `null avatar survives the round trip`() {
+        val original =
+            UserBase(name = "no-avatar").apply {
+                id = 3L
+            }
+
+        val restored = original.toUserSheetModel().toUserBase()
+
+        assertEquals(3L, restored.id)
+        assertNull(restored.avatar)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/BrowseReviewViewModelRateTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/BrowseReviewViewModelRateTest.kt
@@ -1,0 +1,231 @@
+package com.mxt.anitrend.viewmodel
+
+import com.mxt.anitrend.data.mapper.toReviewRecord
+import com.mxt.anitrend.data.store.mutation.DefaultMutationExecutor
+import com.mxt.anitrend.data.store.mutation.DefaultMutationRegistry
+import com.mxt.anitrend.data.store.mutation.DefaultOperationIdGenerator
+import com.mxt.anitrend.data.store.mutation.KeyedMutex
+import com.mxt.anitrend.data.store.mutation.MutationResult
+import com.mxt.anitrend.data.store.mutation.RequestSequence
+import com.mxt.anitrend.data.store.mutation.SessionEpoch
+import com.mxt.anitrend.data.store.review.InMemoryReviewStore
+import com.mxt.anitrend.data.store.review.ReviewQueryKey
+import com.mxt.anitrend.data.store.review.ReviewStoreChange
+import com.mxt.anitrend.domain.review.interactor.RateReviewInteractor
+import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.graphql.generated.ReviewRating
+import com.mxt.anitrend.graphql.generated.ReviewSort
+import com.mxt.anitrend.model.entity.anilist.Review
+import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.repository.BrowseRepository
+import com.mxt.anitrend.util.KeyUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+
+/**
+ * Verifies BrowseReviewViewModel rate-mutation behavior: the outcome is observable as
+ * a UI effect through [BrowseReviewViewModel.rateReviewEvents] while the canonical
+ * ReviewStore remains the sole committed-state owner, the existing store StateFlow
+ * rebinding stays intact, and failures never commit.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BrowseReviewViewModelRateTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var browseRepository: BrowseRepository
+    private lateinit var reviewStore: InMemoryReviewStore
+
+    private val queryKey = ReviewQueryKey(
+        mediaId = null,
+        mediaType = null,
+        sort = ReviewSort.ID_DESC,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        browseRepository = mock(BrowseRepository::class.java)
+        reviewStore = InMemoryReviewStore()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `successful rate commits to store, emits Success outcome and rebinds state`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.state.collect {} }
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+
+        stubPage()
+        viewModel.load(type = null, page = 1, sort = "ID_DESC")
+        advanceUntilIdle()
+        assertEquals(0, (viewModel.state.value as BrowseReviewViewModel.UiState.Success).content.pageData.single().rating)
+
+        doReturn(Result.success(review(id = 42L, rating = 55, ratingAmount = 3, userRating = "UP_VOTE")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(42L, outcomes.single().reviewId)
+        assertEquals(MutationResult.Success, outcomes.single().result)
+        val committed = reviewStore.state.value.reviewsById.getValue(42L).review
+        assertEquals(55, committed.rating)
+        assertEquals("UP_VOTE", committed.userRating)
+        assertEquals(55, (viewModel.state.value as BrowseReviewViewModel.UiState.Success).content.pageData.single().rating)
+    }
+
+    @Test
+    fun `failed rate emits Failure outcome and does not commit`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.state.collect {} }
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+
+        stubPage()
+        viewModel.load(type = null, page = 1, sort = "ID_DESC")
+        advanceUntilIdle()
+
+        doReturn(Result.failure<Review>(IllegalStateException("rate failed")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertTrue(outcomes.single().result is MutationResult.Failure)
+        assertEquals("rate failed", (outcomes.single().result as MutationResult.Failure).message)
+        assertEquals(0, reviewStore.state.value.reviewsById.getValue(42L).review.rating)
+        assertEquals(0, (viewModel.state.value as BrowseReviewViewModel.UiState.Success).content.pageData.single().rating)
+    }
+
+    @Test
+    fun `failed rate emitted with no active collector is delivered to a later collector`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        backgroundScope.launch { viewModel.state.collect {} }
+
+        stubPage()
+        viewModel.load(type = null, page = 1, sort = "ID_DESC")
+        advanceUntilIdle()
+
+        doReturn(Result.failure<Review>(IllegalStateException("rate failed")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        // No outcome collector is active while the mutation runs (the fragment view is
+        // not in STARTED): the buffered channel must retain the outcome.
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertTrue(outcomes.single().result is MutationResult.Failure)
+        assertEquals("rate failed", (outcomes.single().result as MutationResult.Failure).message)
+        assertEquals(0, reviewStore.state.value.reviewsById.getValue(42L).review.rating)
+    }
+
+    private fun TestScope.viewModel(): BrowseReviewViewModel = BrowseReviewViewModel(
+        browseRepository = browseRepository,
+        reviewStore = reviewStore,
+        requestSequence = RequestSequence(),
+        rateReviewInteractor = RateReviewInteractor(
+            browseRepository = browseRepository,
+            mutationExecutor = DefaultMutationExecutor(
+                applicationScope = backgroundScope,
+                keyedMutex = KeyedMutex(backgroundScope),
+                mutationRegistry = DefaultMutationRegistry(),
+                operationIdGenerator = DefaultOperationIdGenerator(),
+                sessionEpoch = SessionEpoch(),
+            ),
+            reviewStore = reviewStore,
+            requestSequence = RequestSequence(),
+        ),
+    )
+
+    private fun stubPage() {
+        val content = PageContainer<Review>().apply {
+            pageData = listOf(review(id = 42L))
+        }
+        runBlocking {
+            reviewStore.apply(
+                ReviewStoreChange.PageLoaded(
+                    queryKey = queryKey,
+                    page = 1,
+                    token = 1L,
+                    reviews = listOf(review(id = 42L).toReviewRecord(revision = 1L)),
+                    pageInfo = null,
+                ),
+            )
+        }
+        runBlocking {
+            doReturn(Result.success(content))
+                .`when`(browseRepository)
+                .getReviewBrowse(
+                    page = 1,
+                    perPage = KeyUtil.PAGING_LIMIT,
+                    type = null,
+                    sort = listOf(ReviewSort.ID_DESC),
+                    asHtml = false,
+                    queryKey = queryKey,
+                    readToken = 1L,
+                )
+        }
+    }
+
+    private fun review(
+        id: Long,
+        rating: Int = 0,
+        ratingAmount: Int = 0,
+        userRating: String? = null,
+    ): Review = Review().apply {
+        this.id = id
+        this.rating = rating
+        this.ratingAmount = ratingAmount
+        this.userRating = userRating
+        media.id = 100L
+        media.type = MediaType.ANIME.name
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/ReviewViewModelRateTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/ReviewViewModelRateTest.kt
@@ -1,0 +1,302 @@
+package com.mxt.anitrend.viewmodel
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import com.mxt.anitrend.data.mapper.toReviewRecord
+import com.mxt.anitrend.data.store.mutation.DefaultMutationExecutor
+import com.mxt.anitrend.data.store.mutation.DefaultMutationRegistry
+import com.mxt.anitrend.data.store.mutation.DefaultOperationIdGenerator
+import com.mxt.anitrend.data.store.mutation.KeyedMutex
+import com.mxt.anitrend.data.store.mutation.MutationResult
+import com.mxt.anitrend.data.store.mutation.RequestSequence
+import com.mxt.anitrend.data.store.mutation.SessionEpoch
+import com.mxt.anitrend.data.store.review.InMemoryReviewStore
+import com.mxt.anitrend.data.store.review.ReviewQueryKey
+import com.mxt.anitrend.data.store.review.ReviewStoreChange
+import com.mxt.anitrend.domain.review.interactor.RateReviewInteractor
+import com.mxt.anitrend.graphql.generated.MediaType
+import com.mxt.anitrend.graphql.generated.ReviewRating
+import com.mxt.anitrend.model.entity.anilist.Review
+import com.mxt.anitrend.model.entity.container.body.AniListContainer
+import com.mxt.anitrend.model.entity.container.body.PageContainer
+import com.mxt.anitrend.repository.BrowseRepository
+import com.mxt.anitrend.util.KeyUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+
+/**
+ * Verifies ReviewViewModel rate-mutation behavior: the outcome is observable as a
+ * UI effect through [ReviewViewModel.rateReviewEvents] while the canonical
+ * ReviewStore remains the sole committed-state owner, the existing store StateFlow
+ * rebinding stays intact, and failures never commit.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReviewViewModelRateTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var browseRepository: BrowseRepository
+    private lateinit var reviewStore: InMemoryReviewStore
+
+    private val queryKey = ReviewQueryKey(
+        mediaId = 42L,
+        mediaType = null,
+        sort = null,
+    )
+
+    /**
+     * Mirrors the production Gson configuration used by the retrofit pipeline
+     * (`ServiceFactory.gson` and the Koin `AniGraphConverter`): plain Gson with no
+     * null-skipping or custom adapters. Regression tests for the rate path must
+     * deserialize responses through the same machinery that produced the runtime
+     * nulls on [Review.user] / [Review.media].
+     */
+    private val productionGson: Gson =
+        GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .setLenient()
+            .create()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        browseRepository = mock(BrowseRepository::class.java)
+        reviewStore = InMemoryReviewStore()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `successful rate commits to store, emits Success outcome and rebinds state`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.state.collect {} }
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+
+        stubPage()
+        viewModel.load(mediaId = 42L, type = null, page = 1)
+        advanceUntilIdle()
+        assertEquals(0, (viewModel.state.value as ReviewViewModel.UiState.Success).content.pageData.single().rating)
+
+        doReturn(Result.success(review(id = 42L, rating = 55, ratingAmount = 3, userRating = "UP_VOTE")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(42L, outcomes.single().reviewId)
+        assertEquals(MutationResult.Success, outcomes.single().result)
+        val committed = reviewStore.state.value.reviewsById.getValue(42L).review
+        assertEquals(55, committed.rating)
+        assertEquals("UP_VOTE", committed.userRating)
+        assertEquals(55, (viewModel.state.value as ReviewViewModel.UiState.Success).content.pageData.single().rating)
+    }
+
+    @Test
+    fun `successful rate response with null user and media summaries still commits and emits Success`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.state.collect {} }
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+
+        stubPage()
+        viewModel.load(mediaId = 42L, type = null, page = 1)
+        advanceUntilIdle()
+        assertEquals(0, (viewModel.state.value as ReviewViewModel.UiState.Success).content.pageData.single().rating)
+
+        // Confirmed live defect: the RateReview POST succeeds but the response contains
+        // "user": null and "media": null. Production Gson writes those nulls into the
+        // declared non-null Review fields; the mapper/interactor must still commit a
+        // ReviewRecord instead of failing with a toast. The response's non-null
+        // mediaType must not be treated as authoritative: the rating-only patch keeps
+        // the existing committed display metadata, so the response mediaType must not
+        // leak into the committed record and the committed media summary must survive.
+        val response = productionGson.fromJson<AniListContainer<Review>>(
+            """
+            {"data":{"RateReview":{"id":42,"summary":null,"mediaType":"ANIME","body":null,
+             "rating":55,"ratingAmount":3,"userRating":"UP_VOTE","score":90,"private":false,
+             "createdAt":1600000000,"user":null,"media":null}},"errors":null}
+            """.trimIndent(),
+            object : TypeToken<AniListContainer<Review>>() {}.type,
+        )
+        doReturn(Result.success(response.data?.result))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(42L, outcomes.single().reviewId)
+        assertEquals(MutationResult.Success, outcomes.single().result)
+        val committed = reviewStore.state.value.reviewsById.getValue(42L).review
+        assertEquals(55, committed.rating)
+        assertEquals("UP_VOTE", committed.userRating)
+        // Rating-only patch: response mediaType stays out, existing display metadata survives.
+        assertNull(committed.mediaType)
+        assertNull(committed.user)
+        assertEquals(100L, committed.media?.id)
+        assertEquals("ANIME", committed.media?.type)
+        assertEquals(55, (viewModel.state.value as ReviewViewModel.UiState.Success).content.pageData.single().rating)
+    }
+
+    @Test
+    fun `failed rate emits Failure outcome and does not commit`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.state.collect {} }
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+
+        stubPage()
+        viewModel.load(mediaId = 42L, type = null, page = 1)
+        advanceUntilIdle()
+
+        doReturn(Result.failure<Review>(IllegalStateException("rate failed")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertTrue(outcomes.single().result is MutationResult.Failure)
+        assertEquals("rate failed", (outcomes.single().result as MutationResult.Failure).message)
+        assertEquals(0, reviewStore.state.value.reviewsById.getValue(42L).review.rating)
+        assertEquals(0, (viewModel.state.value as ReviewViewModel.UiState.Success).content.pageData.single().rating)
+    }
+
+    @Test
+    fun `failed rate emitted with no active collector is delivered to a later collector`() = runTest(testDispatcher) {
+        val viewModel = viewModel()
+        backgroundScope.launch { viewModel.state.collect {} }
+
+        stubPage()
+        viewModel.load(mediaId = 42L, type = null, page = 1)
+        advanceUntilIdle()
+
+        doReturn(Result.failure<Review>(IllegalStateException("rate failed")))
+            .`when`(browseRepository)
+            .rateReview(
+                id = 42L,
+                rating = ReviewRating.UP_VOTE,
+                asHtml = false,
+                commitToStore = false,
+                revision = 1L,
+            )
+
+        // No outcome collector is active while the mutation runs (the fragment view is
+        // not in STARTED): the buffered channel must retain the outcome.
+        viewModel.rateReview(42L, ReviewRating.UP_VOTE)
+        advanceUntilIdle()
+
+        val outcomes = mutableListOf<ReviewRateOutcome>()
+        backgroundScope.launch { viewModel.rateReviewEvents.collect { outcomes += it } }
+        advanceUntilIdle()
+
+        assertEquals(1, outcomes.size)
+        assertTrue(outcomes.single().result is MutationResult.Failure)
+        assertEquals("rate failed", (outcomes.single().result as MutationResult.Failure).message)
+        assertEquals(0, reviewStore.state.value.reviewsById.getValue(42L).review.rating)
+    }
+
+    private fun TestScope.viewModel(): ReviewViewModel = ReviewViewModel(
+        browseRepository = browseRepository,
+        reviewStore = reviewStore,
+        requestSequence = RequestSequence(),
+        rateReviewInteractor = RateReviewInteractor(
+            browseRepository = browseRepository,
+            mutationExecutor = DefaultMutationExecutor(
+                applicationScope = backgroundScope,
+                keyedMutex = KeyedMutex(backgroundScope),
+                mutationRegistry = DefaultMutationRegistry(),
+                operationIdGenerator = DefaultOperationIdGenerator(),
+                sessionEpoch = SessionEpoch(),
+            ),
+            reviewStore = reviewStore,
+            requestSequence = RequestSequence(),
+        ),
+    )
+
+    private fun stubPage() {
+        val content = PageContainer<Review>().apply {
+            pageData = listOf(review(id = 42L))
+        }
+        runBlocking {
+            reviewStore.apply(
+                ReviewStoreChange.PageLoaded(
+                    queryKey = queryKey,
+                    page = 1,
+                    token = 1L,
+                    reviews = listOf(review(id = 42L).toReviewRecord(revision = 1L)),
+                    pageInfo = null,
+                ),
+            )
+        }
+        runBlocking {
+            doReturn(Result.success(content))
+                .`when`(browseRepository)
+                .getReviewBrowse(
+                    mediaId = 42L,
+                    page = 1,
+                    perPage = KeyUtil.PAGING_LIMIT,
+                    type = null,
+                    asHtml = false,
+                    queryKey = queryKey,
+                    readToken = 1L,
+                )
+        }
+    }
+
+    private fun review(
+        id: Long,
+        rating: Int = 0,
+        ratingAmount: Int = 0,
+        userRating: String? = null,
+    ): Review = Review().apply {
+        this.id = id
+        this.rating = rating
+        this.ratingAmount = ratingAmount
+        this.userRating = userRating
+        media.id = 100L
+        media.type = MediaType.ANIME.name
+    }
+}

--- a/docs/bugs/social-interaction-regression-evidence.md
+++ b/docs/bugs/social-interaction-regression-evidence.md
@@ -1,0 +1,253 @@
+# Social Interaction Regression Evidence and Remediation Plan
+
+**Date:** 2026-08-06  
+**Branch under test:** `fix/social-mutation-ui-state`  
+**Device:** Android Emulator `Custom_API_36`, API 36, serial `emulator-5554`  
+**Build:** `appDebug`, rebuilt and installed with Android CLI and Gradle
+
+## Executive finding
+
+The earlier unit and instrumentation checks passed, but the authenticated Argent run exposed three live failures. The evidence below distinguishes confirmed causes from hypotheses that still require runtime request evidence.
+
+| Area | Authenticated result | Current confidence |
+|---|---|---|
+| Review vote response | `RateReview` POST succeeded, then the UI showed `Attempt to invoke virtual method 'long ...'`; no committed UI state was observed. | Root cause confirmed in response mapping. |
+| Profile Followers/Following | Both destinations opened with the correct title, but each remained on the loading spinner for more than 10 seconds. | Symptom confirmed; precise request failure is not yet proven. |
+| Feed users follow control | Users sheet opened and remained without follow/unfollow controls after expansion. | Visibility conditions and ID-loss defect confirmed in code; exact live visibility branch still needs runtime state capture. |
+| Profile Favourites | `Users Favourites` opened successfully from the loaded profile overview. | Passing path. |
+
+## Evidence collection
+
+### Build and runtime setup
+
+The following setup completed successfully:
+
+```text
+android emulator start Custom_API_36
+bash .github/scripts/setup-config.sh
+./gradlew :app:assembleAppDebug :app:installAppDebug --no-daemon --console=plain
+```
+
+The app launched as `com.mxt.anitrend`. Argent discovery was used before every interaction. The authenticated session was already present on the emulator; no credentials are recorded here.
+
+Prior automated evidence also exists:
+
+- `:app:testAppDebugUnitTest`: 1071 tests passed.
+- Focused mapper, ViewModel, holder registry, profile state, and follow convergence tests passed.
+- Direct Android instrumentation: 9/9 passed across `AboutPanelWidgetInstrumentationTest`, `VoteWidgetInstrumentationTest`, and `FollowStateWidgetInstrumentationTest`.
+
+Those checks are necessary but insufficient. The authenticated live run is the decisive evidence for the failures documented below.
+
+## Issue 1: Review vote response does not converge the UI
+
+### Observed behavior
+
+On `Series Reviews`, the authenticated user tapped the first review's up-vote control.
+
+- The UI emitted: `Attempt to invoke virtual method 'long ...'`.
+- No reliable vote-state convergence was observed.
+- The request log showed a successful `POST https://graphql.anilist.co/` for `RateReview`.
+- The response contained a valid review payload with `id: 32611`, but `user: null` and `media: null`.
+
+### Confirmed code path
+
+```text
+VoteWidget
+  -> ReviewViewModel/BrowseReviewViewModel.rateReview
+  -> RateReviewInteractor
+  -> BrowseRepository.rateReview
+  -> RateReview GraphQL POST
+  -> ReviewRecordMapper.toReviewRecord
+  -> ReviewStore
+  -> review StateFlow
+  -> adapter rebind
+```
+
+Relevant source:
+
+- GraphQL schema declares `Review.user` nullable at `app/src/main/graphql/schema.graphql:3261` and `Review.media` nullable at `:3241`.
+- The response requests both fields in `app/src/main/graphql/mutations/review/RateReview.graphql:1-5` and `app/src/main/graphql/fragments/review/ReviewFragment.graphql:12-17`.
+- Legacy DTO fields are declared non-null with defaults in `app/src/main/java/com/mxt/anitrend/model/entity/anilist/Review.kt:28-29`.
+- Plain Gson deserialization can write JSON null into those Kotlin fields through `app/src/main/java/com/mxt/anitrend/model/api/converter/AniGraphConverter.kt:36-47` and `AniGraphResponseConverter.kt:12-14`.
+- `ReviewRecordMapper.toReviewRecord` dereferences `user.id` and `media.id` without a null guard at `app/src/main/java/com/mxt/anitrend/data/mapper/ReviewRecordMapper.kt:20-34`.
+- `BrowseRepository.rateReview` wraps the mapping path at `app/src/main/java/com/mxt/anitrend/repository/BrowseRepository.kt:363-388`.
+- `RateReviewInteractor` maps the successful response before committing at `app/src/main/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractor.kt:34-42`.
+- `MutationInteractorSupport` converts thrown failures to `MutationResult.Failure` at `app/src/main/java/com/mxt/anitrend/domain/interactor/MutationInteractorSupport.kt:18-31`.
+- `VoteWidget` then surfaces the failure and resets the flipper at `app/src/main/java/com/mxt/anitrend/base/custom/view/widget/VoteWidget.kt:149-159`.
+
+### Why existing tests missed it
+
+- `RateReviewInteractorTest` constructs reviews with non-null user and media defaults at `app/src/test/java/com/mxt/anitrend/domain/review/interactor/RateReviewInteractorTest.kt:131-143`.
+- `ReviewRecordMapperTest` covers empty defaults and null user names, but cannot construct the Gson-hidden-null state with normal Kotlin assignment at `app/src/test/java/com/mxt/anitrend/data/mapper/ReviewRecordMapperTest.kt:58-86`.
+
+### Resolution
+
+1. Make `ReviewRecordMapper.toReviewRecord` safe for Gson-injected nulls, treating null user/media the same as absent summaries, or migrate this response to the generated nullable GraphQL type and map explicitly.
+2. Keep `ReviewStore` as the only committed state owner.
+3. Add a production-Gson deserialization regression test with JSON `"user": null` and `"media": null`.
+4. Add an interactor test proving a successful HTTP response with null nested objects does not crash and either commits a null-summary record or returns a controlled failure.
+5. Re-run the authenticated vote journey and verify both the request and visible vote control state after the response.
+
+### Acceptance criteria
+
+- A successful `RateReview` response with null `user` and `media` never produces an NPE or generic virtual-method toast.
+- The vote control exits loading through store convergence or a controlled failure effect.
+- The review count/state is correct without manual refresh.
+
+## Issue 2: Followers and Following sheets remain loading
+
+### Observed behavior
+
+On the authenticated profile overview:
+
+- Profile counters loaded: `Following 122`, `Followers 131`, `Favourites 1.2 K`.
+- Tapping Followers opened a sheet titled `Followers: 131`, but `Busy, please wait!` remained visible for more than 10 seconds.
+- Tapping Following opened a sheet titled `Following: 122`, with the same persistent loading state.
+- Favourites opened `Users Favourites` successfully.
+
+### Confirmed code path
+
+```text
+AboutPanelWidget click
+  -> BottomSheetListUsers
+  -> onStart
+  -> onRefresh
+  -> requestType switch
+  -> UserListViewModel.loadFollowers/loadFollowing
+  -> UserRepository.getFollowers/getFollowing
+  -> UserFollowers GraphQL query
+  -> UserListViewModel.UiState
+  -> BottomSheetListUsers render
+```
+
+Relevant source:
+
+- Entry and request type assignment: `app/src/main/java/com/mxt/anitrend/base/custom/view/widget/AboutPanelWidget.kt:153-186`.
+- Argument resolution and fallback behavior: `app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetListUsers.kt:94-116`.
+- Load trigger and refresh path: `BottomSheetListUsers.kt:200-228` and `:287-311`.
+- State rendering and error handling: `BottomSheetListUsers.kt:313-358`.
+- Request state conversion: `app/src/main/java/com/mxt/anitrend/viewmodel/UserListViewModel.kt:27-73`.
+- Repository calls: `app/src/main/java/com/mxt/anitrend/repository/UserRepository.kt:128-152`.
+- Null GraphQL data failure: `app/src/main/java/com/mxt/anitrend/repository/AbstractRepository.kt:21-27`.
+
+### What is confirmed versus unknown
+
+Confirmed:
+
+- The sheet receives the expected title and opens.
+- The sheet enters loading state.
+- The spinner does not disappear within the 10-second verification window.
+- The request and render path converts failures into `UiState.Error`, but the live run did not capture which failure branch occurred.
+
+Not yet proven:
+
+- Whether the API response was unsuccessful, had null page data, failed DTO conversion, used an invalid request type, or was otherwise interrupted.
+- Whether the spinner is a request failure that failed to reach the error renderer or a separate lifecycle/render issue.
+
+### Resolution
+
+1. Reproduce with logcat and Chucker request/response capture around one Followers request and one Following request.
+2. Add `UserListViewModel` tests for success, HTTP/API failure, null page data, and cancellation. Do not convert `CancellationException` into a user-visible error.
+3. Add a deterministic test for `BottomSheetListUsers.resolve()` covering typed request arguments, legacy arguments, invalid values, and absent values.
+4. Ensure every terminal state hides the spinner, including error and empty states.
+5. Fix refresh-after-error behavior so the adapter is cleared before replacing page-one data; current append logic at `BottomSheetListUsers.kt:313-334` can duplicate entries after retry.
+6. Re-run both authenticated sheet journeys and require the spinner to disappear into content, empty, or explicit error UI.
+
+### Acceptance criteria
+
+- Followers and Following each leave loading within a bounded timeout.
+- Successful requests render rows.
+- API or conversion failures render retry/error UI, never an indefinite spinner.
+- Retry does not duplicate the first page.
+
+## Issue 3: Feed users sheet has no follow/unfollow control
+
+### Observed behavior
+
+On authenticated Status Feeds:
+
+- The feed loaded and the first likes control opened `Total Likes: 3`.
+- The sheet displayed rows for `MeitanteiKates`, `nsen`, and `THEKiimphaa`.
+- After expanding the sheet, rows still had no visible follow/unfollow control.
+- Because no control was rendered, no follow/unfollow request could be initiated from this journey.
+
+### Confirmed code path and visibility rules
+
+- Feed sheet construction: `app/src/main/java/com/mxt/anitrend/view/sheet/BottomSheetUsers.kt:62-76` and `:212-219`.
+- Adapter bind: `app/src/main/java/com/mxt/anitrend/adapter/recycler/index/UserAdapter.kt:84-90`.
+- Layout includes the widget at `app/src/main/res/layout/adapter_user.xml:40-44`.
+- Visibility is controlled by `FollowStateWidget.setUserModel` at `app/src/main/java/com/mxt/anitrend/base/custom/view/widget/FollowStateWidget.kt:80-97`.
+
+The widget is hidden when:
+
+- `currentUser == null`.
+- The row is the current user's own row.
+
+The sheet supplies `databaseHelper.currentUser` at `BottomSheetUsers.kt:66-70`, which is read from ObjectBox by `app/src/main/java/com/mxt/anitrend/data/DatabaseHelper.kt:49-59`.
+
+### Confirmed separate defect: user IDs are lost
+
+- `UserBase.id` is marked `@IgnoredOnParcel` at `app/src/main/java/com/mxt/anitrend/model/entity/base/UserBase.kt:26-28`.
+- `BottomSheetUsers.Builder.setModel` parcels the full `UserBase` list at `BottomSheetUsers.kt:212-219`.
+- On sheet recreation, IDs can therefore return as `0`.
+- `FollowStateWidget` can dispatch `userId = 0` at `FollowStateWidget.kt:130-141`.
+- `BottomSheetUsers.rebindUserIfPresent` cannot match store records when the item ID is zero at `BottomSheetUsers.kt:116-123`.
+
+This explains non-functional toggles even when a control is visible. The live reason all controls were absent still needs runtime capture of `databaseHelper.currentUser` and each row's self/current-user comparison. The strongest candidate is a null current-user object at bind time, but that is not asserted as fact from the live run alone.
+
+### Resolution
+
+1. Preserve stable user IDs across the feed likes sheet boundary. Prefer an ID-safe parcel model or pass immutable identity-plus-display data instead of parceling `UserBase` with an ignored ID.
+2. Add a direct test that a feed likes list survives bundle round trip with each user ID intact.
+3. Add visibility tests for current user present, current user absent, self row, and another user row.
+4. Add a dispatch test proving the clicked row sends its real user ID to `ToggleUserFollowInteractor`.
+5. Add a store convergence test proving a successful toggle updates the visible row without reopening the sheet.
+6. Capture runtime `currentUser` availability and row IDs in a debuggable test or inspectable test fixture before finalizing the visibility branch.
+
+### Acceptance criteria
+
+- Another user's row visibly shows Follow or Following on first render.
+- The current user's own row remains correctly hidden or otherwise intentionally non-actionable.
+- Tapping the control sends the actual user ID, never `0`.
+- Success changes the control state without manual refresh.
+- Failure exits loading and shows explicit retry/error feedback.
+
+## Delivery plan
+
+### Phase A: close the confirmed vote and ID defects
+
+- Null-safe review response mapping and production-Gson regression tests.
+- ID-safe feed users-sheet model boundary and round-trip tests.
+- Follow control visibility and real-ID dispatch tests.
+
+### Phase B: diagnose and harden user-list loading
+
+- Capture one Followers and one Following request with response/error evidence.
+- Add ViewModel and sheet state tests for success, empty, failure, cancellation, and retry.
+- Ensure terminal states always hide loading and retry replaces page-one data.
+
+### Phase C: authenticated acceptance run
+
+- Rebuild and install with Android CLI.
+- Use Argent discovery before each interaction.
+- Verify vote request and post-response UI state.
+- Verify Followers, Following, and Favourites destinations.
+- Verify feed users initial control, actual toggle request, successful convergence, and failure handling.
+
+## Current status
+
+The remediation is implemented on `fix/social-mutation-ui-state` but has not yet received a post-fix authenticated Argent acceptance run.
+
+Implemented resolutions:
+
+- Review responses now tolerate Gson-hidden null `user`/`media` values, and existing reviews receive a rating-only patch so cached display metadata cannot be erased by a partial mutation response.
+- Feed users now cross the sheet boundary through parcel-safe `UserSheetModel` identity data. Adapter binding supplies the current-user context before the model, and the follow widget re-evaluates visibility when that context arrives.
+- Followers/Following state collection now runs on the dialog's Fragment lifecycle from `onCreate`, rather than the nonexistent view lifecycle. Success, error, and retry behavior are covered by a real dialog regression test.
+- Followers/Following follow failures now surface immediately through the sheet's existing notification convention instead of relying on the widget's 10-second fallback.
+
+Deterministic verification after remediation:
+
+- Full app unit suite: 169 suites, 1089 tests, 0 failures/errors.
+- `compileAppDebugKotlin`, `compileAppDebugAndroidTestKotlin`, and `assembleAppDebug`: BUILD SUCCESSFUL.
+- Phase 3 device acceptance is pending. The API 36 AVD reached boot completion in its log but became ADB-inaccessible; Argent and Android CLI retries failed, and a stale orphaned QEMU process remains. No post-fix authenticated UI result is being claimed until the emulator is recoverable.
+- The follow-failure unit seam is covered by `BottomSheetListUsersFollowFailureTest`. Full coroutine/interactor/Toast integration remains a device acceptance obligation once the emulator is available.


### PR DESCRIPTION
## Description
Fix social interaction state regressions across reviews, profiles, user sheets, and feed follow controls.

- Preserve review metadata when rating responses omit nested user/media data.
- Route review mutation outcomes safely through ViewModels and bound holders.
- Restore profile stats navigation for loaded zero counts.
- Preserve feed follow state and real user identity across sheets.
- Repair Followers/Following dialog state collection, retry/error rendering, and follow failure feedback.
- Reduce the shared loading indicator to 18dp and preserve dynamic child visibility baselines.

## Verification
- Full app unit suite: 169 suites, 1089 tests passed.
- Connected Android instrumentation: 20/20 passed on Custom_API_36.
- App compile/assembly and Android test compilation passed.
- git diff --check passed.
- Authenticated manual verification confirmed the follow widget behavior.

## Remaining uncertainty
Post-fix live AniList end-to-end verification for RateReview and Followers/Following API journeys was not rerun.