### PR TITLE
chore: align release drafter branch labels

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -12,24 +12,56 @@ categories:
   - title: '🧰 Maintenance'
     labels:
       - 'refactor'
+      - 'chore'
+      - 'ci'
+      - 'platform'
       - 'dependencies'
+      - 'architecture'
 autolabeler:
   - label: 'docs'
     files:
       - '*.md'
     branch:
       - '/docs{0,1}\/.+/'
+    title:
+      - '/^docs(\(.+\))?!?: /'
   - label: 'bugfix'
     branch:
       - '/fix\/.+/'
       - '/hotfix\/.+/'
+    title:
+      - '/^(fix|hotfix)(\(.+\))?!?: /'
   - label: 'enhancement'
     branch:
       - '/feature\/.+/'
+      - '/feat\/.+/'
+    title:
+      - '/^(feat|feature)(\(.+\))?!?: /'
+  - label: 'refactor'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/^refactor(\(.+\))?!?: /'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/^chore(\(.+\))?!?: /'
+  - label: 'ci'
+    branch:
+      - '/ci\/.+/'
+    title:
+      - '/^ci(\(.+\))?!?: /'
+  - label: 'platform'
+    branch:
+      - '/platform\/.+/'
   - label: 'dependencies'
     branch:
       - '/dependencies\/.+/'
       - '/renovate\/.+/'
+    title:
+      - '/^build\(deps\)!?: /'
+      - '/^chore\(deps\)!?: /'
 change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -48,6 +80,10 @@ version-resolver:
       - 'hotfix'
       - 'dependencies'
       - 'refactor'
+      - 'chore'
+      - 'ci'
+      - 'platform'
+      - 'architecture'
   default: patch
   exclude-labels:
     - 'skip-changelog'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,22 @@ Please ensure your pull request adheres to the following guidelines:
 - Be sure not to stage any files in excluded in .gitignore
 - Check your spelling and grammar.
 
+## Pull Request Branch Naming
+
+Pull request branches should follow the `<type>/<short-description>` convention (for example `fix/login-crash` or `feat/manga-timeline`). Supported types are:
+
+- `feat/` (legacy alias `feature/`): new features
+- `fix/` and `hotfix/`: bug fixes
+- `refactor/`: code restructuring that does not change behaviour
+- `chore/`: routine maintenance
+- `ci/`: CI/CD pipeline changes
+- `platform/`: platform and build configuration changes
+- `docs/`: documentation
+- `dependencies/`: dependency updates
+- `renovate/`: dependency updates managed by Renovate automation
+
+Branch names and pull request titles should use one of these types so Release Drafter can classify each pull request into the correct changelog category.
+
 ## Code of Conduct
 
 ### Our Pledge


### PR DESCRIPTION
## Description

- Document supported pull request branch prefixes in CONTRIBUTING.md.
- Configure Release Drafter to classify supported branches and Conventional Commit titles.
- Apply missing type labels to the referenced historical pull requests.

## Verification

- YAML parsing passed.
- All supported branch-prefix checks passed.
- GitNexus staged change detection reported low risk.