### PR TITLE
feat(skill): add fastlane release changelog management

### DIFF
--- a/.agents/skills/fastlane-release-changelog-management/SKILL.md
+++ b/.agents/skills/fastlane-release-changelog-management/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: fastlane-release-changelog-management
+description: "Use when creating or updating Google Play release notes for AniTrend. Manages Fastlane version-code changelogs in fastlane/metadata/android/en-GB/changelogs/<code>.txt, sourced from Release Drafter draft releases, within Google Play's 500-character limit. Does not publish releases, push tags, run Fastlane deployment, or edit version metadata."
+---
+
+# Skill: Fastlane Release Changelog Management
+
+Use this skill when the task is to produce or refresh the Google Play release notes for a specific
+AniTrend version code. The deliverable is always the exact file
+`fastlane/metadata/android/en-GB/changelogs/<versionCode>.txt`.
+
+## Scope
+
+This skill covers release changelog management only.
+
+May do:
+
+- Create or update the exact `fastlane/metadata/android/en-GB/changelogs/<code>.txt` file for the
+  current version defined in `gradle/version.properties`.
+- Derive notes from the Release Drafter draft release for the current version. There is no
+  fallback source: when the draft is unusable, the skill stops (see Draft Completeness).
+
+Must NOT do:
+
+- Publish releases or promote drafts.
+- Push tags.
+- Run Fastlane deployment lanes (`deploy`, `submit_beta`, `submit_prod`) or any
+  `upload_to_play_store` call.
+- Edit version metadata: `gradle/version.properties`, `app/.meta/version.json`, or the
+  `version-updater.yml` pipeline files. Version bumps are automation-owned.
+
+## Mandatory Preflight
+
+Run all of the following before reading any draft or writing any file. Any failure stops the
+skill.
+
+1. Verify repository identity and authentication:
+
+   ```bash
+   gh auth status
+   gh repo view AniTrend/anitrend-app --json nameWithOwner
+   ```
+
+   Require `AniTrend/anitrend-app` and an authenticated session that can read its releases.
+
+2. Parse `gradle/version.properties` strictly. Require exactly one usable value each for
+   `version`, `code`, and `name`. Duplicates, missing keys, malformed lines, and unexpected keys
+   are hard failures. The supporting validator performs this parse; prefer it over ad-hoc greps.
+
+3. Validate the values:
+
+   - `version` must be strict numeric three-part SemVer: three dot-separated non-negative
+     integers with no leading zeros, no `v` prefix, no pre-release or build suffixes.
+     `1.13.0` is valid; `v1.13.0`, `1.13`, `1.13.0.1`, `1.13.0-rc1` are not.
+   - `name` must equal `v$version`, e.g. `v1.13.0` for version `1.13.0`.
+   - `code` must equal `major*1000000000 + minor*1000000 + patch*1000`, e.g.
+     `1*1000000000 + 13*1000000 + 0*1000 = 1013000000`.
+   - `code` must fit the signed Android int range: `0 <= code <= 2147483647`.
+
+4. When `app/.meta/version.json` exists, require its `version` and `code` to match
+   `gradle/version.properties`. A mismatch is a hard stop.
+
+5. When local configuration permits (JDK 21 and a Gradle setup that does not require secrets),
+   run:
+
+   ```bash
+   ./gradlew :app:assembleAppRelease --dry-run --no-daemon
+   ```
+
+   A failed dry-run means the configured version cannot build; stop instead of writing notes for
+   an unbuildable version. Skip the dry-run only when local keystore/secrets configuration makes
+   it impossible, and say so explicitly.
+
+## Draft Selection
+
+Never use an unqualified `gh release view`; it resolves to the latest release, which may be a
+published tag or the wrong draft. Selection is JSON-based and exact-match only. Fetch the release
+list through the GitHub REST API, paginated and flattened into one array:
+
+```bash
+gh api repos/AniTrend/anitrend-app/releases --paginate --slurp > /tmp/anitrend-release-pages.json
+
+jq 'add' /tmp/anitrend-release-pages.json > /tmp/anitrend-releases.json
+
+jq -r --arg tag "1.13.0" --arg name "v1.13.0" '
+  [.[] | select(.draft == true and .tag_name == $tag and .name == $name
+               and .target_commitish == "develop")] | length' /tmp/anitrend-releases.json
+```
+
+The flattened array uses GitHub REST release fields: `tag_name`, `name`, `draft`,
+`target_commitish`, `body`, `created_at`, `published_at`.
+
+Require exactly one match. The draft must satisfy all three conditions:
+
+- `tag_name == <version>` (Release Drafter emits a numeric tag, e.g. `1.13.0`, no `v`).
+- `name == <name>` (the draft title carries the `v` prefix, e.g. `v1.13.0`).
+- `target_commitish == "develop"`.
+
+Extract the body only from that single match:
+
+```bash
+jq -r --arg tag "1.13.0" --arg name "v1.13.0" '
+  [.[] | select(.draft == true and .tag_name == $tag and .name == $name
+               and .target_commitish == "develop")][0].body' /tmp/anitrend-releases.json
+```
+
+Stop immediately when the match count is zero or greater than one, or when any of the three
+fields differs. Never widen the filter to make a draft fit.
+
+## Draft Completeness
+
+Treat the draft as incomplete only when its body is absent, empty, or has no usable entries
+under the `# What's Changed` heading. Release Drafter always emits that heading; a draft with no
+merged changes has no `- ` entries under it. A body that has entries under the heading is
+complete, even if the entries are noisy.
+
+Save the selected body to a temporary file and run the deterministic completeness check:
+
+```bash
+jq -r --arg tag "1.13.0" --arg name "v1.13.0" '
+  [.[] | select(.draft == true and .tag_name == $tag and .name == $name
+               and .target_commitish == "develop")][0].body' /tmp/anitrend-releases.json \
+  > /tmp/anitrend-draft-body.txt
+
+python3 - <<'PYEOF'
+import re
+body = open("/tmp/anitrend-draft-body.txt", encoding="utf-8").read()
+heading = re.search(r"^# What's Changed[ \t]*$", body, re.M)
+if not heading:
+    raise SystemExit("draft incomplete: no '# What's Changed' heading; hard stop, no fallback")
+section = body[heading.end():]
+boundary = re.search(r"^(?:# |\*\*Full Changelog\*\*)", section, re.M)
+if boundary:
+    section = section[:boundary.start()]
+if not re.search(r"^-\s+\S", section, re.M):
+    raise SystemExit("draft incomplete: no bullet under '# What's Changed'; hard stop, no fallback")
+PYEOF
+```
+
+The check extracts the exact section starting at the `# What's Changed` heading and ending at
+the next top-level heading, a `**Full Changelog**` line, or the end of the body, then requires
+at least one non-empty markdown bullet (`^-\s+\S`) inside that section. Bullets in other
+sections do not count. An incomplete body is a hard stop; there is no merged-PR fallback:
+commit-message issue-number extraction cannot reliably prove PR membership, base branch, or
+range boundaries, so the skill must not invent scope from broad or guessed PR queries. The draft
+must instead be refreshed or resolved by release automation (the Release Drafter workflow
+regenerates the draft on the next push to `develop`), or reviewed manually, before this skill
+continues. Stop and report which of the two is required.
+
+## Generation Guidance
+
+1. Read the draft body's categories (`🚀 Features`, `🐛 Bug Fixes`, `🧰 Maintenance`) and PR
+   titles.
+2. Map to the house style seen in recent changelogs:
+
+   - Features to a `🚀 What's New:` section.
+   - Bug fixes to a `🐛 Bug Fixes:` section.
+   - Maintenance, refactor, and dependency entries to an `📈 Improvements:` section, usually
+     collapsed into a single "Various stability improvements." style bullet, matching existing
+     files.
+
+3. Rewrite PR titles into concise user-facing en-GB prose. Strip conventional-commit prefixes
+   such as `fix(ui):`, keep each bullet short, and skip noise such as the version-bump
+   automation commit and Renovate dependency churn.
+4. Use a safety budget of at most 480 characters for the whole file, every newline included,
+   final newline included. Count with a UTF-8-aware tool, never bytes:
+
+   ```bash
+   python3 -c "import sys; print(len(open(sys.argv[1], encoding='utf-8').read()))" TARGET
+   ```
+
+   The current house footer (`⚠️ A Quick Note:` plus FAQ plus thanks lines) costs 353 characters
+   including the final newline, leaving about 127 characters of bullets under the 480 budget.
+   Trim or drop the quick note when the content does not fit.
+5. Write UTF-8 without BOM. The filename must be exactly `<code>.txt` (e.g. `1013000000.txt`).
+   Fastlane expects the exact `<versionCode>.txt`; `default.txt` is only a fallback and must
+   never be altered. Historical changelogs must not be edited.
+6. If the target file already exists, inspect it first and update it intentionally: preserve
+   stable copy, change only entries that changed. Never overwrite blindly.
+7. If the generated notes are identical to the existing target, write nothing and report the
+   no-op.
+
+## Required Before/After Scope Check
+
+The worktree may already contain unrelated pre-existing changes. Protect scope precisely with
+the scope helper (stdlib only, no network, writes only the snapshot file you name, never
+repository files).
+
+Before writing, capture the snapshot from the repository root:
+
+```bash
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  snapshot /tmp/anitrend-scope-before.json
+```
+
+The snapshot records every `git status --porcelain=v1 -z --untracked-files=all` path with
+spaces handled safely, its two-character status, and the SHA-256 of its current bytes when the
+file is present. Rename and copy statuses are rejected rather than silently misrepresented.
+
+After writing, verify against the snapshot, naming the exact target path:
+
+```bash
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  verify /tmp/anitrend-scope-before.json \
+  "fastlane/metadata/android/en-GB/changelogs/$CODE.txt"
+```
+
+The verify command ignores only the exact target path. Every other path must have identical
+status and hash; the target must be the only allowed difference. Unrelated pre-existing changes
+are allowed only if unchanged. A target absent from both the snapshot and the worktree manifest
+passes only when it exists on disk as a regular, tracked, unchanged file (clean no-op, e.g. an
+already committed changelog that needs no write); otherwise it fails as a typo or a write that
+never happened. Stop on any unexpected path, status, or content change, on a deleted or
+disappeared target, and on malformed snapshots (entries must carry a two-character status and a
+null or 64-hex-character sha256).
+
+Then run the validators, including the scope helper:
+
+```bash
+LC_ALL=en_US.UTF-8 bash .github/scripts/validate-changelogs.sh
+python3 .agents/skills/fastlane-release-changelog-management/scripts/validate-release-changelog.py
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  verify /tmp/anitrend-scope-before.json \
+  "fastlane/metadata/android/en-GB/changelogs/$CODE.txt"
+```
+
+## Current Pipeline Caveats
+
+- `.github/scripts/validate-changelogs.sh` is warn-only for missing files: it fails CI only when
+  a file exceeds 500 characters. The supporting validator is the strict local check for the
+  target file's existence and content; the shell validator remains authoritative for CI and is
+  run separately by this skill.
+- In `.github/workflows/android-build.yaml`, the artifact upload and `gh release upload` steps
+  run with `if: always()`, so APKs are published to the tag release even when earlier steps
+  fail. A bad changelog therefore ships; the file must be right locally.
+- `fastlane/Fastfile` sets `skip_metadata_upload = true`, so both `submit_beta` and
+  `submit_prod` call `upload_to_play_store` with `skip_upload_metadata: true`. Fastlane
+  currently does not upload changelog metadata to Google Play.
+- Google Play enforces a 500 Unicode-character limit per locale; this project's en-GB changelog
+  must stay within it. Fastlane reads changelog files as UTF-8, so a BOM or invalid UTF-8
+  corrupts uploads.
+
+## Quick Reference
+
+```bash
+# Preflight identity
+gh auth status
+gh repo view AniTrend/anitrend-app --json nameWithOwner
+
+# Fetch release pages via REST API and flatten into one array
+gh api repos/AniTrend/anitrend-app/releases --paginate --slurp > /tmp/anitrend-release-pages.json
+jq 'add' /tmp/anitrend-release-pages.json > /tmp/anitrend-releases.json
+
+# Draft body for exactly one match, saved for the completeness check
+jq -r --arg tag "1.13.0" --arg name "v1.13.0" '
+  [.[] | select(.draft == true and .tag_name == $tag and .name == $name
+               and .target_commitish == "develop")][0].body' /tmp/anitrend-releases.json \
+  > /tmp/anitrend-draft-body.txt
+
+# Deterministic completeness check: bullet must be inside the "# What's Changed" section
+python3 - <<'PYEOF'
+import re
+body = open("/tmp/anitrend-draft-body.txt", encoding="utf-8").read()
+heading = re.search(r"^# What's Changed[ \t]*$", body, re.M)
+if not heading:
+    raise SystemExit("draft incomplete: no '# What's Changed' heading; hard stop, no fallback")
+section = body[heading.end():]
+boundary = re.search(r"^(?:# |\*\*Full Changelog\*\*)", section, re.M)
+if boundary:
+    section = section[:boundary.start()]
+if not re.search(r"^-\s+\S", section, re.M):
+    raise SystemExit("draft incomplete: no bullet under '# What's Changed'; hard stop, no fallback")
+PYEOF
+
+# Scope snapshot before writing (from the repository root)
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  snapshot /tmp/anitrend-scope-before.json
+
+# Write notes (UTF-8, no BOM)
+printf '%s' "$NOTES" > "fastlane/metadata/android/en-GB/changelogs/$CODE.txt"
+
+# Scope verify after writing: only the target path may differ (clean no-op targets pass)
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  verify /tmp/anitrend-scope-before.json \
+  "fastlane/metadata/android/en-GB/changelogs/$CODE.txt"
+
+# Count characters, newlines included
+python3 -c "import sys; print(len(open(sys.argv[1], encoding='utf-8').read()))" TARGET
+
+# Validate
+LC_ALL=en_US.UTF-8 bash .github/scripts/validate-changelogs.sh
+python3 .agents/skills/fastlane-release-changelog-management/scripts/validate-release-changelog.py
+python3 .agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py \
+  verify /tmp/anitrend-scope-before.json \
+  "fastlane/metadata/android/en-GB/changelogs/$CODE.txt"
+```
+
+## Common Failure Modes and Rationalizations
+
+- "The draft name has an extra word, close enough." Stop. Only exact triple matches count.
+- "There are two drafts, take the newer one." Stop. Resolve the duplicate upstream.
+- "The draft is empty, just query recent PRs to fill it in." Stop. Commit-message issue numbers
+  cannot prove PR membership, base, or range; refresh the draft via release automation or review
+  it manually.
+- "The draft body exists but has no bullets under the heading, close enough." Stop. The
+  deterministic completeness check extracts the section under `# What's Changed` (up to the next
+  top-level heading, `**Full Changelog**`, or EOF) and requires at least one non-empty bullet
+  (`^-\s+\S`) inside it; a bullet in another section does not count.
+- "The status diff looks clean, so nothing else changed." Stop. Status alone misses content
+  edits; the scope helper hashes every path and rejects rename/copy statuses instead of
+  approximating them.
+- "The changelog is already committed and clean, so I skipped the scope verify." Stop. Run
+  verify anyway; a clean tracked target present in neither manifest passes as a no-op, and the
+  rest of the worktree is still checked.
+- "I changed a bullet in an old changelog to keep the style consistent." Stop. Historical files
+  are frozen.
+- "default.txt is the same thing." No. It is only a fallback and stays untouched.
+- "wc -c says 480 so we are fine." Bytes are not characters. Count Unicode characters.
+- "The file was already there, so I overwrote it." Inspect first, then update intentionally.
+
+## Explicit Stop Conditions
+
+- Preflight: auth or repo identity mismatch; `version.properties` unparsable, duplicate, or with
+  unexpected keys; `version` not strict numeric three-part SemVer; `name != v$version`; code
+  formula mismatch; code outside `0..2147483647`; `version.json` mismatch; gradle dry-run
+  failure (when run).
+- Draft: zero, multiple, or ambiguous drafts; missing fields; incomplete draft body (absent,
+  empty, or failing the deterministic check: no `# What's Changed` heading, or no non-empty
+  bullet inside the extracted section). No fallback exists; refresh via release automation or
+  review manually.
+- Generation: character budget exceeded (480); any uncertainty about the draft's intended
+  audience.
+- Scope: the scope helper rejects rename/copy statuses; any path other than the target changelog
+  changed relative to the pre-write snapshot (path, status, or content), including unrelated
+  pre-existing changes that are no longer byte-for-byte or status-identical; the target is
+  deleted (status D) or disappeared from the worktree; the target is absent from both the
+  snapshot and the worktree without being a clean tracked file on disk; the snapshot file is
+  missing, invalid, or has malformed entries (status not a two-character string, sha256 not null
+  or a 64-hex-character string).
+- Validation: any of the three commands exits nonzero (shell validator, changelog validator,
+  scope helper verify).

--- a/.agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py
+++ b/.agents/skills/fastlane-release-changelog-management/scripts/check-changelog-scope.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Capture and verify repository scope for changelog edits.
+
+Commands:
+  snapshot SNAPSHOT_PATH
+      Run from the repository root. Captures every path reported by
+      `git status --porcelain=v1 -z --untracked-files=all`, its two-character
+      status, and the SHA-256 of its current bytes when the file is present on
+      disk. Paths with spaces are handled safely (records are NUL-separated and
+      paths are not re-quoted). Rename and copy statuses are rejected because
+      porcelain v1 -z cannot represent the origin/destination pair in a single
+      record; refusing is safer than misrepresenting scope. Writes
+      deterministic JSON to SNAPSHOT_PATH and refuses to write the snapshot
+      inside the repository.
+
+  verify SNAPSHOT_PATH TARGET_RELATIVE_PATH
+      Run from the repository root. Captures the same manifest and compares it
+      with the snapshot, ignoring only the exact target path. Every non-target
+      path must have identical status and hash; the target must be the only
+      allowed difference. A target present in the worktree (newly created,
+      staged, or modified) passes. A deleted target (status D) or one that was
+      in the snapshot but disappeared fails. If the target is absent from both
+      manifests, verification passes only when the target exists on disk as a
+      regular tracked file that is unchanged (clean no-op); a target missing on
+      disk fails. Snapshot entries are validated before comparison: each entry
+      must be an object with a two-character string status and a sha256 that is
+      null or a 64-hex-character string; malformed snapshots are rejected with
+      clear errors, never tracebacks.
+
+No network access, no writes to repository files (the snapshot file must live
+outside the repository), Python standard library only.
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import NoReturn
+
+GIT_STATUS_ARGS = ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"]
+FORMAT_VERSION = 1
+REJECTED_STATUS_CHARS = "RC"
+
+USAGE = """\
+usage:
+  check-changelog-scope.py snapshot SNAPSHOT_PATH
+  check-changelog-scope.py verify SNAPSHOT_PATH TARGET_RELATIVE_PATH
+  check-changelog-scope.py --help
+
+snapshot SNAPSHOT_PATH
+    Run from the repository root. Capture every git status path with its
+    two-character status and a SHA-256 of its current bytes (when present),
+    written as deterministic JSON to SNAPSHOT_PATH (must be outside the repo).
+
+verify SNAPSHOT_PATH TARGET_RELATIVE_PATH
+    Run from the repository root. Capture the same manifest and compare it with
+    the snapshot, ignoring only the exact target path. Non-target paths must
+    keep identical status and hashes; the target must be the only allowed
+    difference. A clean unchanged target present in neither manifest is a valid
+    no-op. Deleted, disappeared, or missing targets fail. Rename/copy statuses
+    are rejected, not approximated. Snapshot entries are shape-validated.
+"""
+
+
+def fail(message: str, code: int = 1) -> NoReturn:
+    print("ERROR: " + message, file=sys.stderr)
+    sys.exit(code)
+
+
+def repo_root_or_fail():
+    proc = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        fail("not inside a git repository")
+    # realpath normalizes symlinked prefixes (e.g. /var -> /private/var on macOS)
+    root = os.path.realpath(proc.stdout.strip())
+    if root != os.path.realpath(os.getcwd()):
+        fail("must run from the repository root: %s" % root)
+    return root
+
+
+def file_sha256(path):
+    if not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def capture_manifest():
+    proc = subprocess.run(GIT_STATUS_ARGS, capture_output=True, text=True)
+    if proc.returncode != 0:
+        fail("git status failed: %s" % proc.stderr.strip())
+    manifest = {}
+    for record in proc.stdout.split("\0"):
+        if not record:
+            continue
+        if len(record) < 4:
+            fail("unexpected short git status record: %r" % record)
+        status = record[0:2]
+        path = record[3:]
+        if status[0] in REJECTED_STATUS_CHARS or status[1] in REJECTED_STATUS_CHARS:
+            fail("unsupported rename/copy status %r for %r; porcelain v1 -z cannot represent "
+                 "the origin/destination pair, refusing to misrepresent scope"
+                 % (status, path))
+        manifest[path] = {"status": status, "sha256": file_sha256(path)}
+    return manifest
+
+
+def normalize_target(target):
+    if not target:
+        fail("target path must not be empty")
+    target = target.replace(os.sep, "/")
+    while target.startswith("./"):
+        target = target[2:]
+    if target.startswith("/") or os.path.isabs(target):
+        fail("target path must be relative: %r" % target)
+    if any(part in ("", "..") for part in target.split("/")):
+        fail("target path must not contain empty or '..' components: %r" % target)
+    return target
+
+
+def cmd_snapshot(snapshot_path):
+    root = repo_root_or_fail()
+    abs_snapshot = os.path.realpath(snapshot_path)
+    if abs_snapshot != root and os.path.commonpath([root, abs_snapshot]) == root:
+        fail("refusing to write snapshot inside the repository: %s "
+             "(use a path outside the repo, e.g. /tmp)" % snapshot_path)
+    manifest = capture_manifest()
+    payload = {"format": FORMAT_VERSION, "entries": manifest}
+    with open(snapshot_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+    print("snapshot written: %s (%d entries)" % (snapshot_path, len(manifest)))
+
+
+def validate_snapshot_entries(entries, snapshot_path):
+    for path, entry in sorted(entries.items()):
+        if not isinstance(entry, dict):
+            fail("snapshot %s entry %r must be an object; got %s"
+                 % (snapshot_path, path, type(entry).__name__))
+        if "status" not in entry or "sha256" not in entry:
+            fail("snapshot %s entry %r is missing status or sha256"
+                 % (snapshot_path, path))
+        status = entry["status"]
+        if not isinstance(status, str) or len(status) != 2:
+            fail("snapshot %s entry %r has invalid status %r; expected a two-character "
+                 "string" % (snapshot_path, path, status))
+        sha256 = entry["sha256"]
+        if sha256 is not None and (not isinstance(sha256, str)
+                                   or not re.fullmatch(r"[0-9a-f]{64}", sha256)):
+            fail("snapshot %s entry %r has invalid sha256 %r; expected null or a "
+                 "64-hex-character string" % (snapshot_path, path, sha256))
+
+
+def load_snapshot(snapshot_path):
+    if not os.path.isfile(snapshot_path):
+        fail("snapshot file not found: %s" % snapshot_path)
+    try:
+        with open(snapshot_path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError) as exc:
+        fail("cannot load snapshot %s: %s" % (snapshot_path, exc))
+    if not isinstance(payload, dict):
+        fail("snapshot %s is not a JSON object (format %d expected)"
+             % (snapshot_path, FORMAT_VERSION))
+    if payload.get("format") != FORMAT_VERSION:
+        fail("snapshot %s has unsupported format %r (expected %d)"
+             % (snapshot_path, payload.get("format"), FORMAT_VERSION))
+    entries = payload.get("entries")
+    if not isinstance(entries, dict):
+        fail("snapshot %s is missing a valid entries object" % snapshot_path)
+    validate_snapshot_entries(entries, snapshot_path)
+    return entries
+
+
+def target_is_clean_noop(target):
+    """True when the target is a regular file, tracked, and unchanged vs HEAD."""
+    if not os.path.isfile(target):
+        return False
+    tracked = subprocess.run(["git", "ls-files", "--error-unmatch", "--", target],
+                             capture_output=True, text=True)
+    if tracked.returncode != 0:
+        return False
+    unstaged = subprocess.run(["git", "diff", "--quiet", "--", target],
+                              capture_output=True, text=True)
+    staged = subprocess.run(["git", "diff", "--cached", "--quiet", "--", target],
+                            capture_output=True, text=True)
+    return unstaged.returncode == 0 and staged.returncode == 0
+
+
+def cmd_verify(snapshot_path, target_raw):
+    repo_root_or_fail()
+    target = normalize_target(target_raw)
+    snapshot_entries = load_snapshot(snapshot_path)
+    current = capture_manifest()
+
+    noop_target = False
+    if target not in current and target not in snapshot_entries:
+        if target_is_clean_noop(target):
+            noop_target = True
+        else:
+            fail("target path %r is absent from both the snapshot and the worktree status "
+                 "manifest and is not a clean tracked file on disk; nothing was written on the "
+                 "target path or the target path is wrong" % target)
+    elif target not in current:
+        fail("target path %r is in the snapshot but is no longer present in the worktree" % target)
+    else:
+        target_status = current[target]["status"]
+        if "D" in target_status:
+            fail("target path %r is deleted in the worktree (status %r); the skill never "
+                 "deletes the target" % (target, target_status))
+
+    problems = []
+    for path, entry in sorted(snapshot_entries.items()):
+        if path == target:
+            continue
+        if path not in current:
+            problems.append("path disappeared from the worktree: %r" % path)
+            continue
+        cur = current[path]
+        if cur["status"] != entry["status"]:
+            problems.append("status changed for %r: was %r, now %r"
+                            % (path, entry["status"], cur["status"]))
+        if cur["sha256"] != entry["sha256"]:
+            problems.append("content changed for %r: sha256 %r -> %r"
+                            % (path, entry["sha256"], cur["sha256"]))
+    for path in sorted(current):
+        if path != target and path not in snapshot_entries:
+            problems.append("unexpected new path in the worktree: %r" % path)
+    if problems:
+        fail("scope check failed:\n  - " + "\n  - ".join(problems))
+    if noop_target:
+        print("scope OK: no unexpected changes; target %r is a clean unchanged no-op" % target)
+    else:
+        print("scope OK: no unexpected changes outside %r" % target)
+
+
+def main(argv):
+    if len(argv) == 1:
+        print(USAGE, file=sys.stderr)
+        return 2
+    if argv[1] in ("-h", "--help", "help"):
+        print(USAGE)
+        return 0
+    command = argv[1]
+    if command == "snapshot":
+        if len(argv) != 3:
+            print(USAGE, file=sys.stderr)
+            return 2
+        cmd_snapshot(argv[2])
+        return 0
+    if command == "verify":
+        if len(argv) != 4:
+            print(USAGE, file=sys.stderr)
+            return 2
+        cmd_verify(argv[2], argv[3])
+        return 0
+    print("unknown command: %s" % command, file=sys.stderr)
+    print(USAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.agents/skills/fastlane-release-changelog-management/scripts/validate-release-changelog.py
+++ b/.agents/skills/fastlane-release-changelog-management/scripts/validate-release-changelog.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Validate the release changelog state of the AniTrend repository.
+
+Read-only validator: no network access, no release publishing, no file writes.
+It validates the current repository state only.
+
+Checks:
+- gradle/version.properties parses strictly (exactly one version, code, name;
+  duplicates, missing keys, malformed lines and unexpected keys are failures).
+- version is strict numeric three-part SemVer (no v prefix, no leading zeros,
+  no pre-release/build suffixes).
+- name equals "v" + version.
+- code equals major*1000000000 + minor*1000000 + patch*1000.
+- code fits the signed Android int range 0..2147483647.
+- app/.meta/version.json (when present) parses strictly (non-standard constants such as NaN
+  and Infinity and duplicate object keys are rejected) and is a JSON object whose version is a
+  string and code is a non-boolean integer matching version and code.
+- the target fastlane/metadata/android/en-GB/changelogs/<code>.txt exists, is a
+  regular non-empty file, decodes as UTF-8, has no BOM, and contains 1..500
+  characters (Unicode code points, newlines included; bytes are not counted).
+
+The repository shell validator (.github/scripts/validate-changelogs.sh) remains
+authoritative for CI and is run separately by the skill.
+
+Usage:
+    python3 validate-release-changelog.py [REPO_ROOT]
+
+REPO_ROOT defaults to the current directory. Exits 0 on success, nonzero on
+validation failure.
+"""
+
+import json
+import os
+import re
+import sys
+from typing import NoReturn
+
+INT32_MAX = 2_147_483_647
+
+VERSION_PROPERTIES_REL = os.path.join("gradle", "version.properties")
+VERSION_JSON_REL = os.path.join("app", ".meta", "version.json")
+CHANGELOG_DIR_REL = os.path.join("fastlane", "metadata", "android", "en-GB", "changelogs")
+
+STRICT_SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+# Non-negative decimal digits, no leading zeros: only "0" or a digit 1-9 followed by digits.
+CODE_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+
+REQUIRED_KEYS = ("version", "code", "name")
+
+
+def fail(message: str) -> NoReturn:
+    print("ERROR: " + message, file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_version_properties(path):
+    """Return {key: value} parsed strictly from gradle/version.properties."""
+    if not os.path.isfile(path):
+        fail("missing %s; is the given path a repository root?" % VERSION_PROPERTIES_REL)
+
+    values = {}
+    line_numbers = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for lineno, raw in enumerate(handle, 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                fail("%s:%d malformed line, expected key=value: %r"
+                     % (VERSION_PROPERTIES_REL, lineno, line))
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if not key or not value:
+                fail("%s:%d malformed key/value pair: %r"
+                     % (VERSION_PROPERTIES_REL, lineno, line))
+            if key in values:
+                fail("%s:%d duplicate key %r (first defined at line %d)"
+                     % (VERSION_PROPERTIES_REL, lineno, key, line_numbers[key]))
+            values[key] = value
+            line_numbers[key] = lineno
+
+    missing = [key for key in REQUIRED_KEYS if key not in values]
+    if missing:
+        fail("missing key(s) in %s: %s" % (VERSION_PROPERTIES_REL, ", ".join(missing)))
+    unexpected = [key for key in values if key not in REQUIRED_KEYS]
+    if unexpected:
+        fail("unexpected key(s) in %s: %s"
+             % (VERSION_PROPERTIES_REL, ", ".join(sorted(unexpected))))
+    return values
+
+
+def parse_code(code_str):
+    if CODE_RE.match(code_str):
+        return int(code_str, 10)
+    if code_str.startswith(("+", "-")):
+        fail("code %r in %s must not have a sign; use plain decimal digits"
+             % (code_str, VERSION_PROPERTIES_REL))
+    if code_str.isdigit():
+        fail("code %r in %s has leading zeros; use 0 or decimal digits starting with 1-9"
+             % (code_str, VERSION_PROPERTIES_REL))
+    fail("code %r in %s is not a non-negative decimal integer"
+         % (code_str, VERSION_PROPERTIES_REL))
+
+
+def check_version_meta(repo_root, version, code):
+    path = os.path.join(repo_root, VERSION_JSON_REL)
+    if not os.path.isfile(path):
+        print("note: %s not found; comparison skipped" % VERSION_JSON_REL)
+        return
+
+    def reject_constant(constant):
+        fail("%s contains non-standard JSON constant %r" % (VERSION_JSON_REL, constant))
+
+    def reject_duplicate_keys(pairs):
+        seen = {}
+        for key, value in pairs:
+            if key in seen:
+                fail("%s contains duplicate key %r" % (VERSION_JSON_REL, key))
+            seen[key] = value
+        return seen
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            meta = json.load(handle,
+                             parse_constant=reject_constant,
+                             object_pairs_hook=reject_duplicate_keys)
+    except (OSError, ValueError) as exc:
+        fail("cannot parse %s: %s" % (VERSION_JSON_REL, exc))
+    if not isinstance(meta, dict):
+        fail("%s must be a JSON object with version and code; got %s"
+             % (VERSION_JSON_REL, type(meta).__name__))
+    if "version" not in meta:
+        fail("%s is missing the version key" % VERSION_JSON_REL)
+    if "code" not in meta:
+        fail("%s is missing the code key" % VERSION_JSON_REL)
+    meta_version = meta["version"]
+    meta_code = meta["code"]
+    if not isinstance(meta_version, str):
+        fail("%s version must be a string; got %s"
+             % (VERSION_JSON_REL, type(meta_version).__name__))
+    if isinstance(meta_code, bool) or not isinstance(meta_code, int):
+        fail("%s code must be a JSON integer, not a boolean or other type; got %s"
+             % (VERSION_JSON_REL, type(meta_code).__name__))
+    mismatches = []
+    if meta_version != version:
+        mismatches.append("version %r does not match %r" % (meta_version, version))
+    if meta_code != code:
+        mismatches.append("code %r does not match %d" % (meta_code, code))
+    if mismatches:
+        fail("%s does not match %s: %s"
+             % (VERSION_JSON_REL, VERSION_PROPERTIES_REL, "; ".join(mismatches)))
+
+
+def check_changelog(repo_root, code):
+    target_rel = os.path.join(CHANGELOG_DIR_REL, "%d.txt" % code)
+    target_path = os.path.join(repo_root, target_rel)
+    if not os.path.exists(target_path):
+        fail("target changelog missing: %s (note: .github/scripts/validate-changelogs.sh is "
+             "warn-only for missing files; this validator treats it as a hard error)" % target_rel)
+    if not os.path.isfile(target_path):
+        fail("target changelog is not a regular file: %s" % target_rel)
+    if os.path.getsize(target_path) == 0:
+        fail("target changelog is empty: %s" % target_rel)
+    with open(target_path, "rb") as handle:
+        raw = handle.read()
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("target changelog has a UTF-8 BOM: %s" % target_rel)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail("target changelog is not valid UTF-8: %s (%s)" % (target_rel, exc))
+    char_count = len(text)
+    if not 1 <= char_count <= 500:
+        fail("target changelog has %d characters; Google Play allows 1..500 Unicode characters "
+             "per locale (newlines included)" % char_count)
+    return target_rel, char_count
+
+
+def main(argv):
+    if len(argv) > 2:
+        print("usage: validate-release-changelog.py [REPO_ROOT]", file=sys.stderr)
+        return 2
+    repo_root = os.path.abspath(argv[1] if len(argv) == 2 else os.getcwd())
+    if not os.path.isdir(repo_root):
+        fail("repo root is not a directory: %s" % repo_root)
+
+    props_path = os.path.join(repo_root, VERSION_PROPERTIES_REL)
+    values = parse_version_properties(props_path)
+
+    version = values["version"]
+    match = STRICT_SEMVER_RE.match(version)
+    if not match:
+        fail("version %r is not strict numeric three-part SemVer (three dot-separated integers, "
+             "no v prefix, no leading zeros, no pre-release/build suffixes)" % version)
+    major, minor, patch = (int(part) for part in match.groups())
+
+    name = values["name"]
+    expected_name = "v" + version
+    if name != expected_name:
+        fail("name %r does not equal v$version (%r)" % (name, expected_name))
+
+    code = parse_code(values["code"])
+    expected_code = major * 1_000_000_000 + minor * 1_000_000 + patch * 1_000
+    if code != expected_code:
+        fail("code %d does not match formula major*1000000000 + minor*1000000 + patch*1000 "
+             "(%d for version %s)" % (code, expected_code, version))
+    if not 0 <= code <= INT32_MAX:
+        fail("code %d is outside the signed Android int range 0..%d" % (code, INT32_MAX))
+
+    check_version_meta(repo_root, version, code)
+    target_rel, char_count = check_changelog(repo_root, code)
+
+    print("OK: version %s (%s), code %d, changelog %s (%d characters)"
+         % (version, name, code, target_rel, char_count))
+    print("note: .github/scripts/validate-changelogs.sh remains authoritative for CI and is run "
+         "separately by the skill")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ playstore-service-account.json
 
 # Deepwork session state
 .slim/deepwork/
+
+# Python cache files
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Description

- Add a repo-local Fastlane and Google Play changelog management skill.
- Validate version metadata, Release Drafter draft identity, UTF-8 content, Unicode limits, and exact version-code filenames.
- Add strict release validation and dirty-worktree scope helpers.
- Ignore Python cache files.

## Verification

- Existing changelog validator passes.
- Strict validator correctly rejects the currently missing release-specific changelog.
- Draft completeness and scope helper checks pass.
- GitNexus staged change detection reports low risk.