### PR TITLE
feat(ui): modernize onboarding experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,53 +1,47 @@
 # AniTrend Agent Notes
 
 ## Architecture and module boundaries
-- Real Gradle project is single-module `:app` (`settings.gradle.kts`); `app-compose/` exists in repo but is a stale, excluded build-output directory, not a module. Do not include it in the build.
+- Real Gradle project is single-module `:app` (`settings.gradle.kts`); `app-compose/` exists in repo but is not included in the build.
 - App build logic is centralized in `buildSrc` via plugin `com.mxt.anitrend.plugin` (`app/build.gradle.kts`); prefer changing `buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/*` over adding ad-hoc module config.
-- Product flavors are `app` and `github` (`app/src/app/`, `app/src/github/`); the `github` flavor adds a `-github` version suffix and has its own manifest/service surface. Preserve flavor behavior when editing build logic.
-- Current toolchain: Gradle wrapper 9.6.1, AGP 9.3.1, Kotlin 2.4.10 (do not conflate these versions), compileSdk/targetSdk 37, minSdk 23, Java 21 (`.java-version` = `21.0.11`), Kotlin JVM 21.
-- View Binding is enabled and Data Binding is disabled. Legacy KAPT remains in use alongside ObjectBox, GraphQL code generation, Kotlinx serialization, parcelize, and Spotless; do not opportunistically migrate to KSP.
-- `app/.config/configuration.properties` is committed configuration. Secrets and signing properties are local or CI-provisioned and must never be committed.
+- Product flavors are `app` and `github` (`app/src/app/`, `app/src/github/`); preserve flavor behavior when editing build logic.
 
 ## GraphQL migration state
-- GraphQL is codegen-first: schema + operations live in `app/src/main/graphql/**`.
-- Generated operation API package is `com.mxt.anitrend.graphql.generated` (configured in `GraphQLComponents.kt`), using Kotlinx serialization.
-- Use typed generated requests (`SomeOperation.request(...)` / `GraphQLRequest<...>`); do not reintroduce removed legacy patterns `@GraphQuery`, `QueryContainerBuilder`, or `RequestHandler` in new work.
-- `KeyUtil.*_REQ` request routing still exists (for example in `StaffPageAdapter`, `CharacterPageAdapter`, and `MediaFormatViewModel`); do not add new `KeyUtil.*_REQ` routing and migrate existing routing when touched.
+- GraphQL is codegen-first now: schema + operations live in `app/src/main/graphql/**`.
+- Generated operation API package is `com.mxt.anitrend.graphql.generated` (configured in `GraphQLComponents.kt`).
+- Use typed generated requests (`SomeOperation.request(...)` / `GraphQLRequest<...>`); do not reintroduce legacy `@GraphQuery` / `QueryContainerBuilder` patterns.
 - GraphQL list input variables that are semantically absent must be passed as `null`, not an empty list. Empty lists are treated by the AniList backend as real filter/search input and can produce no results, as seen around `MediaBrowseFragment` and its ViewModel.
 - Avoid nullable list item types for GraphQL filters unless the schema or business rule explicitly requires nullable elements. Prefer `List<T>?` over `List<T?>?` for values such as genres or tags, because lists like `["value", null, null]` are not meaningful backend input.
-- The unit-test workflow checks out retrofit-graphql branch `0.12.1`, while the catalog pins the runtime/API at `0.13.0`. Current Gradle files do not prove that checkout is consumed, so treat this as an unverified or unused CI checkout/version mismatch, not as proof that CI builds against `0.12.1`.
 
 ## Build and verification commands
+- Java target is 21 (`.java-version` = `21.0.11`); CI also uses JDK 21.
 - Fast local verification after code changes:
   - `./gradlew :app:compileAppDebugKotlin :app:assembleAppDebug --no-daemon`
-  - Run `bash .github/scripts/setup-config.sh` first when `app/.config/secrets.properties` is absent.
 - Flavor APK builds:
   - `./gradlew :app:assembleAppDebug`
   - `./gradlew :app:assembleGithubDebug`
+- Unit tests used in CI:
+  - `bash .github/scripts/setup-config.sh` (creates placeholder `app/.config/secrets.properties`)
+  - `./gradlew test --stacktrace`
 
-## CI scope and release gotchas
-- PR/develop unit CI (`android-unit-test.yaml`) runs on JDK 21 Temurin and executes `./gradlew :app:spotlessCheck --stacktrace` and `./gradlew test --stacktrace`. It does not separately assemble APKs.
-- Tag release CI (`android-build.yaml`) builds release APKs through Fastlane via `bash .github/scripts/fastlane.sh` and uploads them to the GitHub release. Do not claim CI globally never assembles; scope any claim to the workflow in question.
+## CI and release-specific gotchas
 - CI always runs `bash .github/scripts/validate-changelogs.sh`; any file in `fastlane/metadata/android/en-GB/changelogs/*.txt` must be `<= 500` chars.
-- Fastlane lanes live in `fastlane/Fastfile`: `verify`, `build`, `submit_beta`, `submit_prod`, and `deploy`.
-- Version metadata is automated by workflow `version-updater.yml` on branch `platform/update-version-meta-data`, targeting `develop`; check that branch/PR before manual version-file edits. Version data lives in `gradle/version.properties`.
-- Generated `app/.meta/version.json` currently reports minSdk 21 while the Android build uses minSdk 23. Treat this as a known automation mismatch; do not alter build values without a dedicated change.
+- Version metadata is automated by workflow `version-updater.yml` on branch `platform/update-version-meta-data`; check that branch/PR before manual version-file edits.
 
 ## Dependency and build-edit conventions
 - Use version catalog aliases from `gradle/libs.versions.toml`; do not hardcode dependency coordinates in module build files.
 - Keep current toolchain choices unless asked explicitly: AGP/Kotlin/JVM levels, KAPT (do not opportunistically migrate to KSP), ObjectBox/DataBinding compatibility settings.
+- Do not hardcode secrets; keep environment-specific values in `app/.config/*.properties` / local files and avoid committing them.
 
 ## ViewModel-first architecture (new and refactored UI)
 
 ### Default direction
-- `ViewModel` owns loading, parsing, filtering, and state. Activities, Fragments, and Custom Views observe and render.
-- New ViewModels extend `androidx.lifecycle.ViewModel` directly. Do not
-  reintroduce the deleted legacy base-class wiring.
-- Compose and Navigation 3 are future direction only. Current production UI is the XML/View system with AndroidX Navigation 2.9.8. Do not claim Compose or Navigation 3 is active.
+- `ViewModel` owns loading, parsing, filtering, and state. Activities, Fragments, and Custom Views observe and render during the migration to a single-activity architecture.
+- New ViewModels extend `androidx.lifecycle.ViewModel` directly. Do not extend `ViewModelBase<T>` for new work.
+- New screens do not call `ActivityBase.setViewModel()`.
+- Activities are a legacy shell only. The long-term direction is Nav3 + Compose with a single activity.
 
 ### Coexistence with legacy
-- `CommonActivity` is the current Koin `activityScope` shell for activities. Existing presenter dependencies are compatibility debt that must not be expanded.
-- Direct-ViewModel activities on `CommonActivity` are already proven: `LoggingActivity`, `StudioActivity`, `ProfileActivity`, `MediaActivity`, `CharacterActivity`, and `StaffActivity`. `CommonActivity` remains a legacy shell to thin out.
+- Activities may still extend `ActivityBase<Void, BasePresenter>` for shared shell behavior while the migration is in progress.
 - Do not add new presenter usage. Presenters are legacy-only and should be removed during refactors instead of being carried forward.
 - When presenter dependencies still exist during legacy cleanup, inject the required presenter explicitly at the usage site with `by inject<T>()` rather than relying on removed base-class presenter wiring.
 
@@ -56,7 +50,7 @@
 - **Domain feature** (API-backed, needs business logic): `UI -> ViewModel -> interactor/use case -> repository/data source`. Only required when a real domain boundary exists; do not force this for every screen.
 
 ### State and testing
-- New ViewModel state surfaces use `StateFlow` by default. `SharedFlow` has no current main-source usage; adopt it only for explicit one-shot events. `LiveData` is acceptable for screens already using it.
+- New ViewModel state surfaces use `StateFlow` or `SharedFlow` by default. `LiveData` is acceptable for screens already using it.
 - Inject dispatchers into new ViewModels for testability. Keep `lifecycleScope` usage in activities limited to UI-bound launches and observation glue.
 - Parsing, filtering, state reduction, and metadata assembly must be unit-testable outside the activity.
 
@@ -64,26 +58,26 @@
 - Custom views remain view-only. They must not own a ViewModel or initiate data loading. Activities/Fragments observe the ViewModel and push data into custom views.
 
 ### Reference
-- See `docs/superpowers/specs/2026-07-19-viewmodel-first-architecture-modernization-design.md` for the full design spec and migration strategy; `LoggingActivity` is the existing local-feature ViewModel-first precedent, not a future refactor target.
+- See `docs/superpowers/specs/2026-07-19-viewmodel-first-architecture-modernization-design.md` for the full design spec, migration strategy, and `LoggingActivity` refactor target.
 
 ## State synchronisation and mutation architecture
 
-The full specification lives at `docs/architecture/state-synchronization-and-mutation-refactor.md`. It is a proposed specification: the rules below are mandatory for new and refactored code in migrated domains (feed, comments, likes, replies, media-list entries) only. Do not assume the entire repository is migrated or that the specification is complete.
+The full specification lives at `docs/architecture/state-synchronization-and-mutation-refactor.md`. The rules below are mandatory for all new and refactored code in migrated domains (feed, comments, likes, replies, media-list entries).
 
 ### Canonical stores
 - Each migrated domain has one canonical store as the exclusive mutable owner of committed entity state. Repositories commit successful mutation responses into stores; ViewModels observe store state.
-- Do not introduce repository `SharedFlow` mutation events (`mutationEvents`); the pattern appears only in the proposed specification and has no current main-source symbol. Business state must live in observable store or ViewModel state, not transient event streams.
+- Do not use repository `SharedFlow` mutation events (`mutationEvents`) as a business-state propagation mechanism. Business state must live in observable store or ViewModel state, not transient event streams.
 - Do not create one generic global store. Stores are domain-specific (`FeedStore`, `MediaListStore`).
 
 ### No repository or coordinator access from adapters or widgets
-- Adapters and custom views must not resolve repositories or any Koin business dependency.
+- Adapters and custom views must not resolve repositories, `WidgetMutationCoordinator`, or any Koin business dependency.
 - Adapters render immutable item models and forward actions via callbacks. Widgets render immutable state and emit user actions only.
 - Do not launch business coroutines from adapters, ViewHolders, or widgets.
 
 ### Immutable RecyclerView items
 - Migrated adapters use `ListAdapter` or `AsyncListDiffer` with immutable item UI models. No submitted list or item may be mutated after submission.
 - Adapters must not maintain a canonical list independent of the ViewModel. Fragments call `submitList(state.items)`.
-- Stable IDs must use actual stable domain IDs, not `hashCode()` or object identity. For heterogeneous lists, namespace the ID by entity type (for example, `"media:123"` vs `"character:123"`) so different item types that share an ID do not collide.
+- Stable IDs must use actual stable domain IDs, not `hashCode()` or object identity.
 - The generic `RecyclerViewAdapter` base class is legacy infrastructure that uses `MutableList`, `notifyDataSetChanged()`, and `hashCode()`-based stable IDs. It remains for non-migrated screens. Do not use it for new or migrated screens. Use `ListAdapter` with `DiffUtil` instead. Track its removal as follow-up infrastructure debt.
 
 ### Identity-only navigation
@@ -96,27 +90,10 @@ The full specification lives at `docs/architecture/state-synchronization-and-mut
 - Stale responses must be rejected using revision ordering; an older response must not overwrite newer committed state.
 
 ### Reference
-- See `docs/architecture/state-synchronization-and-mutation-refactor.md` for phase gates, prohibited patterns, and completion criteria.
-
-## Kotlin-first domain model migration
-- The migration is proposed, not complete. See `docs/adr/2026-08-01-kotlin-first-domain-model-and-navigation.md` and its companion inventory `docs/adr/2026-08-01-kotlin-first-domain-model-inventory.md`.
-- The legacy `com.mxt.anitrend.model.entity` tree is a compatibility boundary. The checked-in inventory is a 95-class snapshot from its generation time; the current legacy tree has 87 Kotlin files after deletions, and migration work must reconcile the inventory.
-- Do not treat every entity as a domain model. Update the checked-in inventory with every model migration PR; the assigned target roles are proposed, not completed work.
-- New domain values should be pure Kotlin and immutable. Persistence, remote, UI, framework/container, and navigation roles remain distinct; domain models must not import Android, ObjectBox, serialization frameworks, or presentation inheritance, and domain APIs must not expose generated GraphQL types.
+- See `docs/architecture/state-synchronization-and-mutation-refactor.md` for the full specification, phase gates, prohibited patterns, and completion criteria.
 
 ## Material 3 design system
 - `@DESIGN.md` is the app-wide M3 design system. It defines color tokens, typography hierarchy, spacing scale, component specs (bottom sheets, dialogs, cards, buttons, text fields, switches, sliders, chips, lists, navigation, custom views, loading), motion and feedback rules, and do's and don'ts.
 - Consult `@DESIGN.md` before any UI/UX work: new screens, layout changes, component selection, styling, spacing, color usage, typography choices, dialog or sheet design, custom view creation, or any visual refactor.
 - The manage list editor (`BottomSheetSeriesManage`) is the reference implementation of this design language. Future design passes must carry the same philosophy across the whole app.
 - When a design decision changes (new component pattern, revised token usage, updated spacing convention), update `@DESIGN.md` in the same PR so it stays the source of truth.
-
-## Branch, commit, and PR conventions
-- Primary integration branch is `develop`. Branch prefixes in use: `feat/`, `fix/`, `chore/`, `refactor/`, `platform/`, `renovate/`, `translation/`.
-- Commits follow conventional commits; common scopes include `ui`, `deps`, `architecture`, `navigation`, `skill`, `startup`, `config`, `media-browse`. Automation/platform version bot commits are the exception.
-- Architecture PRs must document the fields required by `docs/architecture/pr-checklist.md`, including invariants, compatibility paths, tests, commands, limitations, follow-ups, and rollback.
-
-## Test stack
-- Unit tests: JUnit 4, coroutines test, Mockito.
-- MockK and Koin test are instrumentation-scoped.
-- Turbine is declared for androidTest but currently unused.
-- Instrumentation uses AndroidX test core/runner/rules/ActivityScenario as applicable; Espresso and fragment-testing dependencies are declared but currently unused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,53 @@
 # AniTrend Agent Notes
 
 ## Architecture and module boundaries
-- Real Gradle project is single-module `:app` (`settings.gradle.kts`); `app-compose/` exists in repo but is not included in the build.
+- Real Gradle project is single-module `:app` (`settings.gradle.kts`); `app-compose/` exists in repo but is a stale, excluded build-output directory, not a module. Do not include it in the build.
 - App build logic is centralized in `buildSrc` via plugin `com.mxt.anitrend.plugin` (`app/build.gradle.kts`); prefer changing `buildSrc/src/main/java/com/mxt/anitrend/buildsrc/components/*` over adding ad-hoc module config.
-- Product flavors are `app` and `github` (`app/src/app/`, `app/src/github/`); preserve flavor behavior when editing build logic.
+- Product flavors are `app` and `github` (`app/src/app/`, `app/src/github/`); the `github` flavor adds a `-github` version suffix and has its own manifest/service surface. Preserve flavor behavior when editing build logic.
+- Current toolchain: Gradle wrapper 9.6.1, AGP 9.3.1, Kotlin 2.4.10 (do not conflate these versions), compileSdk/targetSdk 37, minSdk 23, Java 21 (`.java-version` = `21.0.11`), Kotlin JVM 21.
+- View Binding is enabled and Data Binding is disabled. Legacy KAPT remains in use alongside ObjectBox, GraphQL code generation, Kotlinx serialization, parcelize, and Spotless; do not opportunistically migrate to KSP.
+- `app/.config/configuration.properties` is committed configuration. Secrets and signing properties are local or CI-provisioned and must never be committed.
 
 ## GraphQL migration state
-- GraphQL is codegen-first now: schema + operations live in `app/src/main/graphql/**`.
-- Generated operation API package is `com.mxt.anitrend.graphql.generated` (configured in `GraphQLComponents.kt`).
-- Use typed generated requests (`SomeOperation.request(...)` / `GraphQLRequest<...>`); do not reintroduce legacy `@GraphQuery` / `QueryContainerBuilder` patterns.
+- GraphQL is codegen-first: schema + operations live in `app/src/main/graphql/**`.
+- Generated operation API package is `com.mxt.anitrend.graphql.generated` (configured in `GraphQLComponents.kt`), using Kotlinx serialization.
+- Use typed generated requests (`SomeOperation.request(...)` / `GraphQLRequest<...>`); do not reintroduce removed legacy patterns `@GraphQuery`, `QueryContainerBuilder`, or `RequestHandler` in new work.
+- `KeyUtil.*_REQ` request routing still exists (for example in `StaffPageAdapter`, `CharacterPageAdapter`, and `MediaFormatViewModel`); do not add new `KeyUtil.*_REQ` routing and migrate existing routing when touched.
 - GraphQL list input variables that are semantically absent must be passed as `null`, not an empty list. Empty lists are treated by the AniList backend as real filter/search input and can produce no results, as seen around `MediaBrowseFragment` and its ViewModel.
 - Avoid nullable list item types for GraphQL filters unless the schema or business rule explicitly requires nullable elements. Prefer `List<T>?` over `List<T?>?` for values such as genres or tags, because lists like `["value", null, null]` are not meaningful backend input.
+- The unit-test workflow checks out retrofit-graphql branch `0.12.1`, while the catalog pins the runtime/API at `0.13.0`. Current Gradle files do not prove that checkout is consumed, so treat this as an unverified or unused CI checkout/version mismatch, not as proof that CI builds against `0.12.1`.
 
 ## Build and verification commands
-- Java target is 21 (`.java-version` = `21.0.11`); CI also uses JDK 21.
 - Fast local verification after code changes:
   - `./gradlew :app:compileAppDebugKotlin :app:assembleAppDebug --no-daemon`
+  - Run `bash .github/scripts/setup-config.sh` first when `app/.config/secrets.properties` is absent.
 - Flavor APK builds:
   - `./gradlew :app:assembleAppDebug`
   - `./gradlew :app:assembleGithubDebug`
-- Unit tests used in CI:
-  - `bash .github/scripts/setup-config.sh` (creates placeholder `app/.config/secrets.properties`)
-  - `./gradlew test --stacktrace`
 
-## CI and release-specific gotchas
+## CI scope and release gotchas
+- PR/develop unit CI (`android-unit-test.yaml`) runs on JDK 21 Temurin and executes `./gradlew :app:spotlessCheck --stacktrace` and `./gradlew test --stacktrace`. It does not separately assemble APKs.
+- Tag release CI (`android-build.yaml`) builds release APKs through Fastlane via `bash .github/scripts/fastlane.sh` and uploads them to the GitHub release. Do not claim CI globally never assembles; scope any claim to the workflow in question.
 - CI always runs `bash .github/scripts/validate-changelogs.sh`; any file in `fastlane/metadata/android/en-GB/changelogs/*.txt` must be `<= 500` chars.
-- Version metadata is automated by workflow `version-updater.yml` on branch `platform/update-version-meta-data`; check that branch/PR before manual version-file edits.
+- Fastlane lanes live in `fastlane/Fastfile`: `verify`, `build`, `submit_beta`, `submit_prod`, and `deploy`.
+- Version metadata is automated by workflow `version-updater.yml` on branch `platform/update-version-meta-data`, targeting `develop`; check that branch/PR before manual version-file edits. Version data lives in `gradle/version.properties`.
+- Generated `app/.meta/version.json` currently reports minSdk 21 while the Android build uses minSdk 23. Treat this as a known automation mismatch; do not alter build values without a dedicated change.
 
 ## Dependency and build-edit conventions
 - Use version catalog aliases from `gradle/libs.versions.toml`; do not hardcode dependency coordinates in module build files.
 - Keep current toolchain choices unless asked explicitly: AGP/Kotlin/JVM levels, KAPT (do not opportunistically migrate to KSP), ObjectBox/DataBinding compatibility settings.
-- Do not hardcode secrets; keep environment-specific values in `app/.config/*.properties` / local files and avoid committing them.
 
 ## ViewModel-first architecture (new and refactored UI)
 
 ### Default direction
-- `ViewModel` owns loading, parsing, filtering, and state. Activities, Fragments, and Custom Views observe and render during the migration to a single-activity architecture.
-- New ViewModels extend `androidx.lifecycle.ViewModel` directly. Do not extend `ViewModelBase<T>` for new work.
-- New screens do not call `ActivityBase.setViewModel()`.
-- Activities are a legacy shell only. The long-term direction is Nav3 + Compose with a single activity.
+- `ViewModel` owns loading, parsing, filtering, and state. Activities, Fragments, and Custom Views observe and render.
+- New ViewModels extend `androidx.lifecycle.ViewModel` directly. Do not
+  reintroduce the deleted legacy base-class wiring.
+- Compose and Navigation 3 are future direction only. Current production UI is the XML/View system with AndroidX Navigation 2.9.8. Do not claim Compose or Navigation 3 is active.
 
 ### Coexistence with legacy
-- Activities may still extend `ActivityBase<Void, BasePresenter>` for shared shell behavior while the migration is in progress.
+- `CommonActivity` is the current Koin `activityScope` shell for activities. Existing presenter dependencies are compatibility debt that must not be expanded.
+- Direct-ViewModel activities on `CommonActivity` are already proven: `LoggingActivity`, `StudioActivity`, `ProfileActivity`, `MediaActivity`, `CharacterActivity`, and `StaffActivity`. `CommonActivity` remains a legacy shell to thin out.
 - Do not add new presenter usage. Presenters are legacy-only and should be removed during refactors instead of being carried forward.
 - When presenter dependencies still exist during legacy cleanup, inject the required presenter explicitly at the usage site with `by inject<T>()` rather than relying on removed base-class presenter wiring.
 
@@ -50,7 +56,7 @@
 - **Domain feature** (API-backed, needs business logic): `UI -> ViewModel -> interactor/use case -> repository/data source`. Only required when a real domain boundary exists; do not force this for every screen.
 
 ### State and testing
-- New ViewModel state surfaces use `StateFlow` or `SharedFlow` by default. `LiveData` is acceptable for screens already using it.
+- New ViewModel state surfaces use `StateFlow` by default. `SharedFlow` has no current main-source usage; adopt it only for explicit one-shot events. `LiveData` is acceptable for screens already using it.
 - Inject dispatchers into new ViewModels for testability. Keep `lifecycleScope` usage in activities limited to UI-bound launches and observation glue.
 - Parsing, filtering, state reduction, and metadata assembly must be unit-testable outside the activity.
 
@@ -58,26 +64,26 @@
 - Custom views remain view-only. They must not own a ViewModel or initiate data loading. Activities/Fragments observe the ViewModel and push data into custom views.
 
 ### Reference
-- See `docs/superpowers/specs/2026-07-19-viewmodel-first-architecture-modernization-design.md` for the full design spec, migration strategy, and `LoggingActivity` refactor target.
+- See `docs/superpowers/specs/2026-07-19-viewmodel-first-architecture-modernization-design.md` for the full design spec and migration strategy; `LoggingActivity` is the existing local-feature ViewModel-first precedent, not a future refactor target.
 
 ## State synchronisation and mutation architecture
 
-The full specification lives at `docs/architecture/state-synchronization-and-mutation-refactor.md`. The rules below are mandatory for all new and refactored code in migrated domains (feed, comments, likes, replies, media-list entries).
+The full specification lives at `docs/architecture/state-synchronization-and-mutation-refactor.md`. It is a proposed specification: the rules below are mandatory for new and refactored code in migrated domains (feed, comments, likes, replies, media-list entries) only. Do not assume the entire repository is migrated or that the specification is complete.
 
 ### Canonical stores
 - Each migrated domain has one canonical store as the exclusive mutable owner of committed entity state. Repositories commit successful mutation responses into stores; ViewModels observe store state.
-- Do not use repository `SharedFlow` mutation events (`mutationEvents`) as a business-state propagation mechanism. Business state must live in observable store or ViewModel state, not transient event streams.
+- Do not introduce repository `SharedFlow` mutation events (`mutationEvents`); the pattern appears only in the proposed specification and has no current main-source symbol. Business state must live in observable store or ViewModel state, not transient event streams.
 - Do not create one generic global store. Stores are domain-specific (`FeedStore`, `MediaListStore`).
 
 ### No repository or coordinator access from adapters or widgets
-- Adapters and custom views must not resolve repositories, `WidgetMutationCoordinator`, or any Koin business dependency.
+- Adapters and custom views must not resolve repositories or any Koin business dependency.
 - Adapters render immutable item models and forward actions via callbacks. Widgets render immutable state and emit user actions only.
 - Do not launch business coroutines from adapters, ViewHolders, or widgets.
 
 ### Immutable RecyclerView items
 - Migrated adapters use `ListAdapter` or `AsyncListDiffer` with immutable item UI models. No submitted list or item may be mutated after submission.
 - Adapters must not maintain a canonical list independent of the ViewModel. Fragments call `submitList(state.items)`.
-- Stable IDs must use actual stable domain IDs, not `hashCode()` or object identity.
+- Stable IDs must use actual stable domain IDs, not `hashCode()` or object identity. For heterogeneous lists, namespace the ID by entity type (for example, `"media:123"` vs `"character:123"`) so different item types that share an ID do not collide.
 - The generic `RecyclerViewAdapter` base class is legacy infrastructure that uses `MutableList`, `notifyDataSetChanged()`, and `hashCode()`-based stable IDs. It remains for non-migrated screens. Do not use it for new or migrated screens. Use `ListAdapter` with `DiffUtil` instead. Track its removal as follow-up infrastructure debt.
 
 ### Identity-only navigation
@@ -90,10 +96,27 @@ The full specification lives at `docs/architecture/state-synchronization-and-mut
 - Stale responses must be rejected using revision ordering; an older response must not overwrite newer committed state.
 
 ### Reference
-- See `docs/architecture/state-synchronization-and-mutation-refactor.md` for the full specification, phase gates, prohibited patterns, and completion criteria.
+- See `docs/architecture/state-synchronization-and-mutation-refactor.md` for phase gates, prohibited patterns, and completion criteria.
+
+## Kotlin-first domain model migration
+- The migration is proposed, not complete. See `docs/adr/2026-08-01-kotlin-first-domain-model-and-navigation.md` and its companion inventory `docs/adr/2026-08-01-kotlin-first-domain-model-inventory.md`.
+- The legacy `com.mxt.anitrend.model.entity` tree is a compatibility boundary. The checked-in inventory is a 95-class snapshot from its generation time; the current legacy tree has 87 Kotlin files after deletions, and migration work must reconcile the inventory.
+- Do not treat every entity as a domain model. Update the checked-in inventory with every model migration PR; the assigned target roles are proposed, not completed work.
+- New domain values should be pure Kotlin and immutable. Persistence, remote, UI, framework/container, and navigation roles remain distinct; domain models must not import Android, ObjectBox, serialization frameworks, or presentation inheritance, and domain APIs must not expose generated GraphQL types.
 
 ## Material 3 design system
 - `@DESIGN.md` is the app-wide M3 design system. It defines color tokens, typography hierarchy, spacing scale, component specs (bottom sheets, dialogs, cards, buttons, text fields, switches, sliders, chips, lists, navigation, custom views, loading), motion and feedback rules, and do's and don'ts.
 - Consult `@DESIGN.md` before any UI/UX work: new screens, layout changes, component selection, styling, spacing, color usage, typography choices, dialog or sheet design, custom view creation, or any visual refactor.
 - The manage list editor (`BottomSheetSeriesManage`) is the reference implementation of this design language. Future design passes must carry the same philosophy across the whole app.
 - When a design decision changes (new component pattern, revised token usage, updated spacing convention), update `@DESIGN.md` in the same PR so it stays the source of truth.
+
+## Branch, commit, and PR conventions
+- Primary integration branch is `develop`. Branch prefixes in use: `feat/`, `fix/`, `chore/`, `refactor/`, `platform/`, `renovate/`, `translation/`.
+- Commits follow conventional commits; common scopes include `ui`, `deps`, `architecture`, `navigation`, `skill`, `startup`, `config`, `media-browse`. Automation/platform version bot commits are the exception.
+- Architecture PRs must document the fields required by `docs/architecture/pr-checklist.md`, including invariants, compatibility paths, tests, commands, limitations, follow-ups, and rollback.
+
+## Test stack
+- Unit tests: JUnit 4, coroutines test, Mockito.
+- MockK and Koin test are instrumentation-scoped.
+- Turbine is declared for androidTest but currently unused.
+- Instrumentation uses AndroidX test core/runner/rules/ActivityScenario as applicable; Espresso and fragment-testing dependencies are declared but currently unused.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,9 +28,6 @@ dependencies {
     /** Photo View */
     implementation(libs.photoview)
 
-    /** On-boarding Experience */
-    implementation(libs.onboarder)
-
     /** Charts */
     implementation(libs.mpandroidchart)
 

--- a/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
+++ b/app/src/main/java/com/mxt/anitrend/koin/Modules.kt
@@ -146,6 +146,7 @@ import com.mxt.anitrend.view.fragment.settings.SettingsCategoryLegacyFragment
 import com.mxt.anitrend.view.fragment.settings.SettingsHubFragment
 import com.mxt.anitrend.view.fragment.youtube.YouTubeEmbedFragment
 import com.mxt.anitrend.view.sheet.BottomSheetGiphy
+import com.mxt.anitrend.view.activity.base.OnboardingViewModel
 import com.mxt.anitrend.viewmodel.AccountSettingsViewModel
 import com.mxt.anitrend.viewmodel.AiringListViewModel
 import com.mxt.anitrend.viewmodel.BrowseReviewViewModel
@@ -749,6 +750,7 @@ private val studioFeatureModule = module {
 }
 
 private val utilityFeatureModule = module {
+    viewModel { OnboardingViewModel(settings = get()) }
     viewModel { GiphyViewModel(giphyService = get()) }
     viewModel { LoginAuthViewModel() }
     viewModel {

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/OnboardingViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/OnboardingViewModel.kt
@@ -1,0 +1,48 @@
+package com.mxt.anitrend.view.activity.base
+
+import androidx.lifecycle.ViewModel
+import com.mxt.anitrend.R
+import com.mxt.anitrend.util.Settings
+
+class OnboardingViewModel(
+    private val settings: Settings,
+) : ViewModel() {
+
+    val pages = listOf(
+        OnboardingPage(
+            R.string.app_name,
+            R.string.description_onboarding_welcome,
+            R.layout.layout_onboarding_welcome_hero,
+        ),
+        OnboardingPage(
+            R.string.app_intro_colors_title,
+            R.string.description_onboarding_colors,
+            R.layout.layout_onboarding_colors_hero,
+        ),
+        OnboardingPage(
+            R.string.app_intro_content_title,
+            R.string.description_onboarding_content,
+            R.layout.layout_onboarding_content_hero,
+        ),
+        OnboardingPage(
+            R.string.app_intro_search_title,
+            R.string.description_onboarding_searching,
+            R.layout.layout_onboarding_searching_hero,
+        ),
+        OnboardingPage(
+            R.string.title_onboarding_manage,
+            R.string.description_onboarding_manage,
+            R.layout.layout_onboarding_manage_hero,
+        ),
+    )
+
+    fun onPostFreshInstall() {
+        settings.isFreshInstall = false
+    }
+
+    data class OnboardingPage(
+        val titleRes: Int,
+        val descriptionRes: Int,
+        val heroLayoutRes: Int,
+    )
+}

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/OnboardingViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/OnboardingViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import com.mxt.anitrend.R
 import com.mxt.anitrend.util.Settings
 
+/**
+ * Defines the pages shown during first-run onboarding and records completion.
+ */
 class OnboardingViewModel(
     private val settings: Settings,
 ) : ViewModel() {
@@ -36,10 +39,12 @@ class OnboardingViewModel(
         ),
     )
 
+    /** Marks onboarding as completed so it is not shown on the next launch. */
     fun onPostFreshInstall() {
         settings.isFreshInstall = false
     }
 
+    /** Immutable resources used to render one onboarding page. */
     data class OnboardingPage(
         val titleRes: Int,
         val descriptionRes: Int,

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
@@ -19,6 +19,7 @@ import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.activity.index.MainActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+/** Hosts the first-run onboarding flow and routes users into the main activity. */
 class WelcomeActivity : CommonActivity() {
 
     private val onboardingViewModel by viewModel<OnboardingViewModel>()

--- a/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
+++ b/app/src/main/java/com/mxt/anitrend/view/activity/base/WelcomeActivity.kt
@@ -2,79 +2,83 @@ package com.mxt.anitrend.view.activity.base
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
-import androidx.core.content.ContextCompat
-import com.codemybrainsout.onboarder.AhoyOnboarderActivity
-import com.codemybrainsout.onboarder.AhoyOnboarderCard
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.children
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
 import com.mxt.anitrend.R
-import com.mxt.anitrend.extension.koinOf
+import com.mxt.anitrend.databinding.ActivityWelcomeBinding
+import com.mxt.anitrend.databinding.ItemOnboardingPageBinding
 import com.mxt.anitrend.util.CompatUtil
-import com.mxt.anitrend.util.Settings
+import com.mxt.anitrend.view.activity.CommonActivity
 import com.mxt.anitrend.view.activity.index.MainActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
-/**
- * Created by max on 2017/11/09.
- */
-class WelcomeActivity : AhoyOnboarderActivity() {
-    private lateinit var ahoyPages: List<AhoyOnboarderCard>
+class WelcomeActivity : CommonActivity() {
 
-    private fun applyStyle(card: AhoyOnboarderCard): AhoyOnboarderCard {
-        card.setBackgroundColor(R.color.black_transparent)
-        card.setTitleColor(R.color.grey_200)
-        card.setDescriptionColor(R.color.grey_300)
-        return card
-    }
+    private val onboardingViewModel by viewModel<OnboardingViewModel>()
+    private lateinit var binding: ActivityWelcomeBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val paintIcon = R.drawable.ic_format_paint_white_24dp
-        val chartIcon = R.drawable.ic_bubble_chart_white_24dp
-        val searchIcon = R.drawable.ic_search_white_24dp
+        binding = ActivityWelcomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        ahoyPages =
-            listOf(
-                AhoyOnboarderCard(
-                    getString(R.string.app_name),
-                    "${getString(R.string.app_greeting)} ${getString(R.string.app_provider)}",
-                    R.mipmap.ic_launcher,
-                ),
-                AhoyOnboarderCard(
-                    getString(R.string.app_intro_colors_title),
-                    getString(R.string.app_intro_colors_text),
-                    paintIcon,
-                ),
-                AhoyOnboarderCard(
-                    getString(R.string.app_intro_content_title),
-                    getString(R.string.app_intro_content_text),
-                    chartIcon,
-                ),
-                AhoyOnboarderCard(
-                    getString(R.string.app_intro_search_title),
-                    getString(R.string.app_intro_search_text),
-                    searchIcon,
-                ),
-                AhoyOnboarderCard(
-                    getString(R.string.app_intro_title),
-                    getString(R.string.app_intro_guide),
-                    R.mipmap.ic_launcher,
-                ),
-            ).map(::applyStyle)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val pagerParams = binding.viewPager.layoutParams as ConstraintLayout.LayoutParams
+            pagerParams.topMargin =
+                resources.getDimensionPixelSize(R.dimen.activity_vertical_margin) + systemBars.top
+            binding.viewPager.layoutParams = pagerParams
 
-        setFinishButtonDrawableStyle(ContextCompat.getDrawable(this, R.drawable.finish_button_style))
+            val buttonParams = binding.actionButton.layoutParams as ConstraintLayout.LayoutParams
+            buttonParams.bottomMargin =
+                resources.getDimensionPixelSize(R.dimen.activity_vertical_margin) + systemBars.bottom
+            binding.actionButton.layoutParams = buttonParams
+            insets
+        }
+        ViewCompat.requestApplyInsets(binding.root)
+
+        val adapter = OnboardingAdapter(onboardingViewModel.pages)
+        binding.viewPager.adapter = adapter
+
+        binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                updatePageIndicator(position)
+                if (position == onboardingViewModel.pages.size - 1) {
+                    binding.actionButton.setText(R.string.get_started)
+                } else {
+                    binding.actionButton.setText(R.string.action_onboarding_continue)
+                }
+            }
+        })
+        updatePageIndicator(binding.viewPager.currentItem)
+
+        binding.actionButton.setOnClickListener {
+            val currentItem = binding.viewPager.currentItem
+            if (currentItem < onboardingViewModel.pages.size - 1) {
+                binding.viewPager.currentItem = currentItem + 1
+            } else {
+                onFinishButtonPressed()
+            }
+        }
     }
 
-    override fun onPostCreate(savedInstanceState: Bundle?) {
-        super.onPostCreate(savedInstanceState)
-        setFinishButtonTitle(R.string.get_started)
-        showNavigationControls(true)
-        setGradientBackground()
-        setOnboardPages(ahoyPages)
+    private fun updatePageIndicator(position: Int) {
+        binding.indicatorContainer.children.forEachIndexed { index, view ->
+            view.isSelected = index == position
+        }
     }
 
-    override fun onFinishButtonPressed() {
-        koinOf<Settings>().isFreshInstall = false
-        val target = findViewById<View>(R.id.btn_skip)
-        CompatUtil.startRevealAnim(this, target, Intent(this, MainActivity::class.java), true)
+    private fun onFinishButtonPressed() {
+        onboardingViewModel.onPostFreshInstall()
+        CompatUtil.startRevealAnim(this, binding.actionButton, Intent(this, MainActivity::class.java), true)
     }
 
     @Suppress("DEPRECATION")
@@ -87,5 +91,32 @@ class WelcomeActivity : AhoyOnboarderActivity() {
                 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
                 View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
         }
+    }
+
+    private class OnboardingAdapter(
+        private val pages: List<OnboardingViewModel.OnboardingPage>,
+    ) : RecyclerView.Adapter<OnboardingAdapter.ViewHolder>() {
+
+        class ViewHolder(val binding: ItemOnboardingPageBinding) : RecyclerView.ViewHolder(binding.root)
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val binding = ItemOnboardingPageBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+            return ViewHolder(binding)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val page = pages[position]
+            holder.binding.title.setText(page.titleRes)
+            holder.binding.description.setText(page.descriptionRes)
+            holder.binding.heroContainer.removeAllViews()
+            LayoutInflater.from(holder.binding.root.context)
+                .inflate(page.heroLayoutRes, holder.binding.heroContainer, true)
+        }
+
+        override fun getItemCount() = pages.size
     }
 }

--- a/app/src/main/res/drawable/sel_onboarding_dot.xml
+++ b/app/src/main/res/drawable/sel_onboarding_dot.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="5dp" />
+            <solid android:color="?attr/colorPrimary" />
+            <size android:width="14dp" android:height="10dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="?attr/colorOutlineVariant" />
+            <size android:width="10dp" android:height="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/onboarding_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toTopOf="@id/indicator_container"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/indicator_container"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:accessibilityLiveRegion="polite"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:layout_marginBottom="@dimen/spacing_xs"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@id/action_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintVertical_bias="0.5">
+
+        <View
+            android:layout_width="14dp"
+            android:layout_height="10dp"
+            android:layout_marginStart="@dimen/md_margin"
+            android:layout_marginEnd="@dimen/md_margin"
+            android:background="@drawable/sel_onboarding_dot"
+            android:contentDescription="@null" />
+        <View
+            android:layout_width="14dp"
+            android:layout_height="10dp"
+            android:layout_marginStart="@dimen/md_margin"
+            android:layout_marginEnd="@dimen/md_margin"
+            android:background="@drawable/sel_onboarding_dot"
+            android:contentDescription="@null" />
+        <View
+            android:layout_width="14dp"
+            android:layout_height="10dp"
+            android:layout_marginStart="@dimen/md_margin"
+            android:layout_marginEnd="@dimen/md_margin"
+            android:background="@drawable/sel_onboarding_dot"
+            android:contentDescription="@null" />
+        <View
+            android:layout_width="14dp"
+            android:layout_height="10dp"
+            android:layout_marginStart="@dimen/md_margin"
+            android:layout_marginEnd="@dimen/md_margin"
+            android:background="@drawable/sel_onboarding_dot"
+            android:contentDescription="@null" />
+        <View
+            android:layout_width="14dp"
+            android:layout_height="10dp"
+            android:layout_marginStart="@dimen/md_margin"
+            android:layout_marginEnd="@dimen/md_margin"
+            android:background="@drawable/sel_onboarding_dot"
+            android:contentDescription="@null" />
+
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/action_button"
+        style="@style/Widget.Material3.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:minHeight="56dp"
+        android:text="@string/get_started"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_onboarding_page.xml
+++ b/app/src/main/res/layout/item_onboarding_page.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/spacing_xs"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
+    android:paddingBottom="@dimen/spacing_xs">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:paddingTop="@dimen/spacing_xs"
+        android:paddingBottom="@dimen/spacing_md"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <FrameLayout
+            android:id="@+id/hero_container"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_weight="1.25" />
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_sm"
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceTitleLarge"
+            android:textColor="?attr/colorOnSurface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/hero_container" />
+
+        <TextView
+            android:id="@+id/description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/mg_margin"
+            android:gravity="center"
+            android:maxWidth="340dp"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_onboarding_colors_hero.xml
+++ b/app/src/main/res/layout/layout_onboarding_colors_hero.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_watching"
+            app:chipBackgroundColor="?attr/colorSecondaryContainer"
+            app:chipIcon="@drawable/ic_remove_red_eye_white_18dp"
+            app:chipIconTint="?attr/colorOnSecondaryContainer" />
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_completed"
+            app:chipBackgroundColor="?attr/colorTertiaryContainer"
+            app:chipIcon="@drawable/ic_check_circle_white_24dp"
+            app:chipIconTint="?attr/colorOnTertiaryContainer" />
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_plan_to_watch"
+            app:chipBackgroundColor="?attr/colorPrimaryContainer"
+            app:chipIcon="@drawable/ic_time_white_18dp"
+            app:chipIconTint="?attr/colorOnPrimaryContainer" />
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_dropped"
+            app:chipBackgroundColor="?attr/colorErrorContainer"
+            app:chipIcon="@drawable/ic_delete_red_600_18dp"
+            app:chipIconTint="?attr/colorOnErrorContainer" />
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_on_hold"
+            app:chipBackgroundColor="?attr/colorSecondaryContainer"
+            app:chipIcon="@drawable/ic_pause_white_18dp"
+            app:chipIconTint="?attr/colorOnSecondaryContainer" />
+
+        <com.google.android.material.chip.Chip
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="@string/label_onboarding_status_rewatching"
+            app:chipBackgroundColor="?attr/colorPrimaryContainer"
+            app:chipIcon="@drawable/ic_repeat_white_18dp"
+            app:chipIconTint="?attr/colorPrimary" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_onboarding_content_hero.xml
+++ b/app/src/main/res/layout/layout_onboarding_content_hero.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:importantForAccessibility="no">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_back"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="152dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        android:layout_marginBottom="@dimen/spacing_lg"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="240dp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_middle"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="176dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        android:layout_marginBottom="@dimen/spacing_md"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="260dp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_front"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="204dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerHighest"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="280dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/poster_block"
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="64dp"
+                android:layout_height="96dp"
+                app:cardBackgroundColor="?attr/colorPrimaryContainer"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Small">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="bottom"
+                    android:orientation="vertical"
+                    android:padding="@dimen/md_margin">
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="32dp"
+                        android:background="?attr/colorPrimary" />
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"
+                        android:layout_marginTop="@dimen/md_margin"
+                        android:background="?attr/colorOnPrimaryContainer" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/action_surface"
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="64dp"
+                android:layout_height="40dp"
+                app:cardBackgroundColor="?attr/colorSecondaryContainer"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_mode_edit_white_24dp"
+                    app:tint="?attr/colorOnSecondaryContainer" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <View
+                android:id="@+id/title_line"
+                android:layout_width="0dp"
+                android:layout_height="12dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginTop="@dimen/spacing_xs"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorOnSurface"
+                app:layout_constraintEnd_toStartOf="@id/action_surface"
+                app:layout_constraintStart_toEndOf="@id/poster_block"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="8dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginTop="@dimen/md_margin"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorOnSurfaceVariant"
+                app:layout_constraintEnd_toStartOf="@id/action_surface"
+                app:layout_constraintStart_toEndOf="@id/poster_block"
+                app:layout_constraintTop_toBottomOf="@id/title_line" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="8dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginTop="@dimen/spacing_xs"
+                android:background="?attr/colorPrimary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/poster_block"
+                app:layout_constraintTop_toBottomOf="@id/poster_block" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="12dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorSurfaceVariant"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent">
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="0.65"
+                    android:background="?attr/colorPrimary" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="0.35"
+                    android:background="?attr/colorOutlineVariant" />
+            </LinearLayout>
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_menu_grey_600_24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_onboarding_manage_hero.xml
+++ b/app/src/main/res/layout/layout_onboarding_manage_hero.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:importantForAccessibility="no">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/manage_card_back"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="148dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        android:layout_marginBottom="@dimen/spacing_lg"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="240dp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/manage_card"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="192dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerHighest"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="280dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/manage_poster"
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="56dp"
+                android:layout_height="88dp"
+                app:cardBackgroundColor="?attr/colorTertiaryContainer"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Small">
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="32dp"
+                    android:layout_gravity="bottom"
+                    android:background="?attr/colorTertiary" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="12dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorOnSurface"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/manage_poster"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="8dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginTop="@dimen/md_margin"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorOnSurfaceVariant"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/manage_poster"
+                app:layout_constraintTop_toBottomOf="@id/manage_poster" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/long_press_hint"
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="64dp"
+                android:layout_height="40dp"
+                app:cardBackgroundColor="?attr/colorSecondaryContainer"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full">
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_touch_app_grey_600_24dp"
+                    app:tint="?attr/colorOnSecondaryContainer" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="12dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:background="?attr/colorSurfaceVariant"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent">
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="0.4"
+                    android:background="?attr/colorPrimary" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="0.6"
+                    android:background="?attr/colorOutlineVariant" />
+            </LinearLayout>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/status_surface"
+                style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="@dimen/spacing_xs"
+                android:layout_marginBottom="@dimen/spacing_xs"
+                app:cardBackgroundColor="?attr/colorPrimaryContainer"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Circle">
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_mode_edit_white_24dp"
+                    app:tint="?attr/colorOnPrimaryContainer" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginEnd="@dimen/spacing_xs"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_gesture_grey_600_24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_onboarding_searching_hero.xml
+++ b/app/src/main/res/layout/layout_onboarding_searching_hero.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/search_bar"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+        app:cardCornerRadius="24dp"
+        app:layout_constraintBottom_toTopOf="@id/results_list"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="300dp"
+        app:layout_constraintVertical_chainStyle="packed">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp">
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_msv_search"
+                app:tint="?attr/colorOnSurfaceVariant" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:text="@string/placeholder_onboarding_search"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <LinearLayout
+        android:id="@+id/results_list"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="@dimen/spacing_xs"
+        android:layout_marginEnd="@dimen/spacing_xs"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_bar">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginBottom="8dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_onboarding_search_result_jujutsu_kaisen"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurface" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginBottom="8dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_onboarding_search_result_one_piece"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurface" />
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_onboarding_welcome_hero.xml
+++ b/app/src/main/res/layout/layout_onboarding_welcome_hero.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/circle"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:contentDescription="@null"
+        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Circle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/play_card"
+        style="@style/Widget.AniTrend.ManageSheet.SectionCard"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        app:cardBackgroundColor="?attr/colorPrimary"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.AniTrend.Circle"
+        app:layout_constraintBottom_toBottomOf="@id/circle"
+        app:layout_constraintEnd_toEndOf="@id/circle"
+        app:layout_constraintStart_toStartOf="@id/circle"
+        app:layout_constraintTop_toTopOf="@id/circle">
+
+        <ImageView
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_gravity="center"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_play_circle_outline_white_24dp"
+            app:tint="?attr/colorOnPrimary" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- Status Badges (Simplified for now) -->
+    <com.google.android.material.chip.Chip
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_onboarding_status_watching"
+        app:chipBackgroundColor="?attr/colorSecondaryContainer"
+        app:chipIcon="@drawable/ic_remove_red_eye_white_18dp"
+        app:chipIconTint="?attr/colorOnSecondaryContainer"
+        app:layout_constraintBottom_toTopOf="@id/play_card"
+        app:layout_constraintEnd_toStartOf="@id/play_card"
+        app:layout_constraintHorizontal_bias="0.2"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.chip.Chip
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_onboarding_status_completed"
+        app:chipBackgroundColor="?attr/colorTertiaryContainer"
+        app:chipIcon="@drawable/ic_check_circle_white_24dp"
+        app:chipIconTint="?attr/colorOnTertiaryContainer"
+        app:layout_constraintBottom_toBottomOf="@id/play_card"
+        app:layout_constraintStart_toEndOf="@id/play_card" />
+
+    <com.google.android.material.chip.Chip
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_onboarding_status_plan_to_watch"
+        app:chipBackgroundColor="?attr/colorPrimaryContainer"
+        app:chipIcon="@drawable/ic_time_white_18dp"
+        app:chipIconTint="?attr/colorOnPrimaryContainer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/play_card" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -77,4 +77,6 @@
 
     <color name="toolbar_transparent">#50000000</color>
 
+    <color name="white">#FFFFFF</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
 
     <!--First time usage intro screen-->
     <string name="get_started">Get Started</string>
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Continue</string>
     <string name="app_intro_colors_title">Color States</string>
     <string name="app_intro_colors_text">Colors Representing Anime/Manga Status!</string>
     <string name="app_intro_content_title">Content</string>
@@ -99,6 +101,39 @@
     <string name="app_intro_videos_title">Videos</string>
     <string name="app_intro_videos_text">Using Builtin Youtube Video Player!</string>
     <string name="app_greeting">Welcome to AniTrend, this is not a streaming app!</string>
+
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Watching</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Completed</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Plan to Watch</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Dropped</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">On Hold</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Rewatching</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Search anime, manga...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Discover new favourites, track your progress, and keep every anime and manga list in one place.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Quickly identify what you\'re watching, completed, or planning to watch with intuitive color coding at a glance.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Browse thousands of titles with detailed info, ratings, seasonal charts, and staff credits - updated daily.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Powerful search with filters by genre, year, studio, and status - find exactly what you\'re looking for.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Manage Your List</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Long-press any anime or manga to manage its status, progress, and details.</string>
 
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Sort By?</string>

--- a/app/src/test/java/com/mxt/anitrend/koin/KoinModuleVerificationTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/koin/KoinModuleVerificationTest.kt
@@ -41,7 +41,7 @@ class KoinModuleVerificationTest {
         11 to 5, // characterFeatureModule
         12 to 7, // staffFeatureModule
         13 to 4, // studioFeatureModule
-        14 to 6, // utilityFeatureModule (GiphyVM + LoginAuthVM + LoggingVM + CustomizeSettingsVM + logFile + metadata)
+        14 to 7, // utilityFeatureModule (+ OnboardingVM, GiphyVM, LoginAuthVM, LoggingVM, CustomizeSettingsVM, logFile, metadata)
         15 to 44, // fragmentModule (settings hub + customize + legacy category + giphy sheet + 40 koin-owned fragment factories)
     )
 
@@ -85,11 +85,11 @@ class KoinModuleVerificationTest {
 
     @OptIn(KoinInternalApi::class)
     @Test
-    fun `appModules combined has 179 distinct definitions`() {
+    fun `appModules combined has 180 distinct definitions`() {
         val total = appModules.includedModules.sumOf { it.mappings.values.distinct().size }
         assertEquals(
-            "Combined distinct definition count drifted. Expected 179, got $total.",
-            179,
+            "Combined distinct definition count drifted. Expected 180, got $total.",
+            180,
             total,
         )
     }


### PR DESCRIPTION
# AniTrend Pull Request

## Description
Replaces the legacy onboarding experience with a Material 3 XML/ViewPager2 flow. Adds coherent onboarding hero assets, a compact accessible page indicator, a list-management teaching slide, and clearer first-slide copy. Removes the obsolete onboarding dependency and wires the onboarding ViewModel through Koin.

## Screenshots:
Validated on the Custom_API_36 Android emulator in dark and light themes. The five-page flow, compact indicator, first-slide copy, and final Get Started navigation were verified.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

## Verification
- `:app:processAppDebugResources`
- `:app:compileAppDebugKotlin`
- `:app:assembleAppDebug`
- `git diff --check`

Documentation and repository instructions were updated where necessary.