### PR TITLE
translation(ui): localize onboarding strings

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -104,6 +104,41 @@
     <string name="app_intro_videos_text">يستخدم مشغل مقاطع الفيديو الخاص بيوتيوب مدمج معه!</string>
     <string name="app_greeting">أهلا بك في AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">متابعة</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">قيد المشاهدة</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">مكتمل</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">مخطط للمشاهدة</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">متروك</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">متوقف مؤقتًا</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">إعادة المشاهدة</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">ابحث عن أنمي أو مانغا...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">اكتشف أعمالًا جديدة، وتابع تقدمك، واحتفظ بكل قوائم الأنمي والمانغا في مكان واحد.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">حدد بسرعة ما تشاهده وما أكملته وما تخطط لمشاهدته باستخدام ترميز لوني واضح.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">تصفح آلاف العناوين مع معلومات مفصلة وتقييمات ومخططات موسمية وبيانات فريق العمل، مع تحديثات يومية.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">ابحث باستخدام فلاتر النوع والسنة والاستوديو والحالة، واعثر على ما تبحث عنه بدقة.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">إدارة قائمتك</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">اضغط مطولًا على أي أنمي أو مانغا لإدارة حالته وتقدمه وتفاصيله.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">الفرز حسب:</string>
     <string name="app_filter_on_list">On My List?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,6 +99,41 @@ First time usage intro screen -->
     <string name="app_intro_videos_text">"Verwendet den eingebauten Youtube Video Player!"</string>
     <string name="app_greeting">"Wilkommen bei AniTrend! Dies ist keine Streaming App!"</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">"Weiter"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">"Wird angesehen"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">"Abgeschlossen"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">"Geplant"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">"Abgebrochen"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">"Pausiert"</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">"Wird erneut angesehen"</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">"Anime, Manga suchen..."</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">"Entdecke neue Favoriten, verfolge deinen Fortschritt und verwalte alle Anime- und Manga-Listen an einem Ort."</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">"Erkenne schnell, was du gerade ansiehst, abgeschlossen hast oder ansehen möchtest, dank intuitiver Farbcodierung."</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">"Durchsuche Tausende Titel mit detaillierten Infos, Bewertungen, saisonalen Übersichten und Mitarbeiterangaben, täglich aktualisiert."</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">"Leistungsstarke Suche mit Filtern nach Genre, Jahr, Studio und Status, damit du genau findest, was du suchst."</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">"Deine Liste verwalten"</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">"Drücke lange auf einen Anime oder Manga, um Status, Fortschritt und Details zu verwalten."</string>
+
     <!-- Filter menu entry these are the dialog titles -->
     <string name="app_filter_sort">"Sortieren nach?"</string>
     <string name="app_filter_order">"Reihenfolge?"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -100,6 +100,41 @@
     <string name="app_intro_videos_text">¡Facilita la visualización de vídeos de Youtube a través del reproductor integrado!</string>
     <string name="app_greeting">¡Bienvenido/a a AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Continuar</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Viendo</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Completado</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Pendiente</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Abandonado</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">En pausa</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Volviendo a ver</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Buscar anime, manga...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Descubre nuevos favoritos, sigue tu progreso y mantén todas tus listas de anime y manga en un solo lugar.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Identifica rápidamente lo que estás viendo, has completado o planeas ver con un código de colores intuitivo.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Explora miles de títulos con información detallada, valoraciones, listas de temporada y créditos del equipo, actualizados a diario.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Búsqueda potente con filtros por género, año, estudio y estado para encontrar exactamente lo que buscas.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Gestiona tu lista</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Mantén pulsado cualquier anime o manga para gestionar su estado, progreso y detalles.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Ordenar Por:</string>
     <string name="app_filter_on_list">On My List?</string>
@@ -728,7 +763,8 @@ elementos de tus favoritos al presionar en el icono del corazón .
     <string name="show_spoiler_tags">Show Spoiler Tags</string>
     <string name="notification_media_added">New Related Media Added</string>
     <string name="drawer_section_extras">Extras</string>
-    <string name="app_intro_videos_title">Videos</string>
+    <!-- Section title on the first-time intro screen; shows the videos feature -->
+    <string name="app_intro_videos_title">Vídeos</string>
     <string name="pref_header_general">General</string>
     <string name="text_error_auth_token">Invalid session, please log out and back in</string>
     <string name="text_migration_in_progress">Application is upgrading, please wait</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -88,6 +88,41 @@
     <string name="app_intro_videos_text">Les vidéos peuvent être visionner dans l\'application !</string>
     <string name="app_greeting">Bienvenue sur AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Continuer</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">En cours</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Terminé</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">À regarder</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Abandonné</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">En pause</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">À revoir</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Rechercher un anime, un manga...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Découvrez de nouveaux favoris, suivez votre progression et gardez toutes vos listes d\'animes et de mangas au même endroit.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Identifiez rapidement ce que vous regardez, avez terminé ou prévoyez de regarder grâce à un code couleur intuitif.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Parcourez des milliers de titres avec des informations détaillées, des notes, des classements saisonniers et les crédits de l\'équipe, mis à jour chaque jour.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Recherche puissante avec des filtres par genre, année, studio et statut pour trouver exactement ce que vous cherchez.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Gérer votre liste</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Maintenez appuyé sur un anime ou un manga pour gérer son statut, sa progression et ses détails.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Trier par ?</string>
     <string name="app_filter_on_list">On My List?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -96,6 +96,41 @@
     <string name="app_intro_videos_text">Usa il Player Video di Youtube integrato!</string>
     <string name="app_greeting">Benvenuto su AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Continua</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">In visione</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Completato</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Da vedere</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Abbandonato</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">In pausa</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Da rivedere</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Cerca anime, manga...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Scopri nuovi preferiti, segui i tuoi progressi e tieni tutte le tue liste di anime e manga in un unico posto.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Identifica rapidamente cosa stai guardando, cosa hai completato o cosa vuoi guardare grazie a una codifica a colori intuitiva.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Sfoglia migliaia di titoli con informazioni dettagliate, valutazioni, classifiche stagionali e crediti dello staff, aggiornati ogni giorno.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Ricerca potente con filtri per genere, anno, studio e stato per trovare esattamente ciò che cerchi.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Gestisci la tua lista</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Tieni premuto su un anime o un manga per gestirne stato, progressi e dettagli.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Organizza</string>
     <string name="app_filter_on_list">On My List?</string>
@@ -726,7 +761,8 @@
     <string name="drawer_title_hub">AniTrend Hub</string>
     <string name="drawer_title_home">Status Feeds</string>
     <string name="drawer_section_account">Account</string>
-    <string name="app_intro_videos_title">Videos</string>
+    <!-- Section title on the first-time intro screen; shows the videos feature -->
+    <string name="app_intro_videos_title">Video</string>
     <string name="text_error_auth_token">Invalid session, please log out and back in</string>
     <string name="text_migration_in_progress">Application is upgrading, please wait</string>
     <string name="title_migration_failed">Upgrade Failed</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -91,6 +91,41 @@
     <string name="app_intro_search_text">Anime, Manga &amp; Meer zoekfunctionaliteiten!</string>
     <string name="app_intro_videos_text">Gebruikt een ingebouwde Youtube Video Player!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Doorgaan</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Aan het kijken</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Voltooid</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Wil ik kijken</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Gestopt</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">Gepauzeerd</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Opnieuw kijken</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Anime, manga zoeken...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Ontdek nieuwe favorieten, houd je voortgang bij en bewaar al je anime- en mangalijsten op één plek.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Zie snel wat je kijkt, hebt voltooid of wilt kijken dankzij duidelijke kleurcodering.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Bekijk duizenden titels met uitgebreide informatie, beoordelingen, seizoensoverzichten en medewerkers, dagelijks bijgewerkt.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Krachtige zoekfunctie met filters voor genre, jaar, studio en status, zodat je precies vindt wat je zoekt.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Je lijst beheren</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Houd een anime of manga lang ingedrukt om de status, voortgang en details te beheren.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Sorteer op?</string>
     <string name="app_filter_on_list">On My List?</string>
@@ -728,8 +763,10 @@
     <string name="drawer_section_account">Account</string>
     <string name="app_filter_genres">Series Genres?</string>
     <string name="get_started">Get Started</string>
-    <string name="app_intro_videos_title">Videos</string>
-    <string name="app_intro_search_title">Searching</string>
+    <!-- Section title on the first-time intro screen; shows the videos feature -->
+    <string name="app_intro_videos_title">Video\'s</string>
+    <!-- Section title on the first-time intro screen; shows the searching feature -->
+    <string name="app_intro_search_title">Zoeken</string>
     <string name="app_greeting">Welcome to AniTrend, this is not a streaming app!</string>
     <string name="text_error_auth_token">Invalid session, please log out and back in</string>
     <string name="text_migration_in_progress">Application is upgrading, please wait</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -101,6 +101,41 @@
     <string name="app_intro_videos_text">Używa wbudowanego odtwarzacza wideo Youtube!</string>
     <string name="app_greeting">Witaj w AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Kontynuuj</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Oglądane</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Ukończone</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Planowane</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Porzucone</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">Wstrzymane</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Ponowne oglądanie</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Szukaj anime, mangi...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Odkrywaj nowe ulubione tytuły, śledź swoje postępy i trzymaj wszystkie listy anime i mang w jednym miejscu.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Szybko rozpoznaj, co oglądasz, co ukończyłeś lub co planujesz obejrzeć dzięki intuicyjnemu oznaczeniu kolorami.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Przeglądaj tysiące tytułów ze szczegółowymi informacjami, ocenami, zestawieniami sezonowymi i informacjami o twórcach, aktualizowanymi codziennie.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Zaawansowane wyszukiwanie z filtrami gatunku, roku, studia i statusu pozwala znaleźć dokładnie to, czego szukasz.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Zarządzaj swoją listą</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Przytrzymaj dowolne anime lub mangę, aby zarządzać jej statusem, postępami i szczegółami.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Sortuj według</string>
     <string name="app_filter_on_list">On My List?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -99,6 +99,41 @@
     <string name="app_intro_videos_text">Usando um Player Embutido do Youtube!</string>
     <string name="app_greeting">Bem-vindo ao AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Continuar</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Assistindo</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Concluído</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Planejado para assistir</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Abandonado</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">Em espera</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Assistindo novamente</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Pesquisar anime, mangá...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Descubra novos favoritos, acompanhe seu progresso e mantenha todas as suas listas de anime e mangá em um só lugar.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Identifique rapidamente o que você está assistindo, concluiu ou planeja assistir com um código de cores intuitivo.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Explore milhares de títulos com informações detalhadas, avaliações, calendários sazonais e créditos da equipe, atualizados diariamente.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Pesquisa poderosa com filtros por gênero, ano, estúdio e status para encontrar exatamente o que você procura.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Gerencie sua lista</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Mantenha pressionado qualquer anime ou mangá para gerenciar seu status, progresso e detalhes.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Classificar por?</string>
     <string name="app_filter_on_list">On My List?</string>
@@ -730,7 +765,8 @@
     <string name="tip_messages_title">Messages</string>
     <string name="nav_home">Home</string>
     <string name="drawer_section_extras">Extras</string>
-    <string name="app_intro_videos_title">Videos</string>
+    <!-- Section title on the first-time intro screen; shows the videos feature -->
+    <string name="app_intro_videos_title">Vídeos</string>
     <string name="text_error_auth_token">Invalid session, please log out and back in</string>
     <string name="text_migration_in_progress">Application is upgrading, please wait</string>
     <string name="title_migration_failed">Upgrade Failed</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -100,6 +100,41 @@
     <string name="app_intro_videos_text">Använda Inbyggd Youtube Video Player!</string>
     <string name="app_greeting">Välkommen till AniTrend, this is not a streaming app!</string>
 
+    <!-- Action label on the onboarding button before the final page; advances to the next page -->
+    <string name="action_onboarding_continue">Fortsätt</string>
+    <!-- Status chip label in the onboarding heroes; shows the "watching" list status -->
+    <string name="label_onboarding_status_watching">Tittar på</string>
+    <!-- Status chip label in the onboarding heroes; shows the "completed" list status -->
+    <string name="label_onboarding_status_completed">Slutförd</string>
+    <!-- Status chip label in the onboarding heroes; shows the "plan to watch" list status -->
+    <string name="label_onboarding_status_plan_to_watch">Planerad</string>
+    <!-- Status chip label in the onboarding heroes; shows the "dropped" list status -->
+    <string name="label_onboarding_status_dropped">Övergiven</string>
+    <!-- Status chip label in the onboarding heroes; shows the "on hold" list status -->
+    <string name="label_onboarding_status_on_hold">Pausad</string>
+    <!-- Status chip label in the onboarding heroes; shows the "rewatching" list status -->
+    <string name="label_onboarding_status_rewatching">Tittar igen</string>
+
+    <!-- Placeholder text in the search bar mockup of the onboarding searching hero -->
+    <string name="placeholder_onboarding_search">Sök anime, manga...</string>
+    <!-- Example search result in the onboarding searching hero; Jujutsu Kaisen is an anime title -->
+    <string name="label_onboarding_search_result_jujutsu_kaisen">Jujutsu Kaisen</string>
+    <!-- Example search result in the onboarding searching hero; One Piece is an anime title -->
+    <string name="label_onboarding_search_result_one_piece">One Piece</string>
+
+    <!-- First onboarding page description; friendly benefit-led copy about discovering, tracking, and organizing anime and manga -->
+    <string name="description_onboarding_welcome">Upptäck nya favoriter, följ dina framsteg och samla alla dina anime- och mangalistor på ett ställe.</string>
+    <!-- Colors page description; explains the color coding of anime/manga list statuses -->
+    <string name="description_onboarding_colors">Se snabbt vad du tittar på, har slutfört eller planerar att titta på med intuitiv färgkodning.</string>
+    <!-- Content page description; explains the browsable catalog -->
+    <string name="description_onboarding_content">Bläddra bland tusentals titlar med detaljerad information, betyg, säsongslistor och uppgifter om medverkande, uppdaterade dagligen.</string>
+    <!-- Searching page description; explains search and filter capabilities -->
+    <string name="description_onboarding_searching">Kraftfull sökning med filter för genre, år, studio och status så att du hittar exakt det du söker.</string>
+    <!-- Final onboarding page title; introduces managing anime and manga lists -->
+    <string name="title_onboarding_manage">Hantera din lista</string>
+    <!-- Final onboarding page description; long-pressing an anime or manga item opens list management for status, progress, and details -->
+    <string name="description_onboarding_manage">Tryck och håll på valfri anime eller manga för att hantera status, framsteg och detaljer.</string>
+
     <!--Filter menu entry these are the dialog titles-->
     <string name="app_filter_sort">Sortera efter?</string>
     <string name="app_filter_on_list">On My List?</string>


### PR DESCRIPTION
# AniTrend Pull Request

## Description
Adds the onboarding strings to all nine supported locale resources. Translates the new action, status labels, search placeholder, page descriptions, and list-management guidance. Also fixes stale English onboarding labels in Dutch, Spanish, Italian, and Portuguese resources.

## Screenshots:
Not applicable. This is a resource-only localization update.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

## Verification
- Confirmed all 16 onboarding keys exist in all 9 locale files.
- Confirmed all locale XML files parse successfully.
- `:app:processAppDebugResources` passed.
- `git diff --check` passed.

The default English resources and unrelated working-tree files were not changed.