### PR TITLE
refactor(network): migrate Retrofit services to suspend responses

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/ServiceFactory.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/ServiceFactory.kt
@@ -9,6 +9,7 @@ import com.mxt.anitrend.util.graphql.apiError
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import kotlinx.coroutines.runBlocking
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
@@ -79,15 +80,16 @@ object ServiceFactory {
                 ).addConverterFactory(GsonConverterFactory.create(gson))
                 .baseUrl(BuildConfig.API_AUTH_LINK)
                 .build()
-        val refreshTokenCall =
-            retrofit.create(AuthService::class.java).getAuthRequest(
-                KeyUtil.AUTHENTICATION_CODE,
-                BuildConfig.CLIENT_ID,
-                BuildConfig.CLIENT_SECRET,
-                BuildConfig.REDIRECT_URI,
-                code,
-            )
-        val response = refreshTokenCall.execute()
+        val response =
+            runBlocking {
+                retrofit.create(AuthService::class.java).getAuthRequest(
+                    KeyUtil.AUTHENTICATION_CODE,
+                    BuildConfig.CLIENT_ID,
+                    BuildConfig.CLIENT_SECRET,
+                    BuildConfig.REDIRECT_URI,
+                    code,
+                )
+            }
         if (!response.isSuccessful) Timber.tag("requestCodeTokenSync").w(response.apiError())
         response.body()
     } catch (e: Exception) {

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/AuthService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/AuthService.kt
@@ -1,7 +1,7 @@
 package com.mxt.anitrend.model.api.retro.anilist
 
 import com.mxt.anitrend.model.entity.anilist.WebToken
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
@@ -21,11 +21,11 @@ interface AuthService {
      */
     @FormUrlEncoded
     @POST("token")
-    fun getAuthRequest(
+    suspend fun getAuthRequest(
         @Field("grant_type") grant_type: String,
         @Field("client_id") client_id: String,
         @Field("client_secret") client_secret: String,
         @Field("redirect_uri") redirect_uri: String,
         @Field("code") code: String,
-    ): Call<WebToken>
+    ): Response<WebToken>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/BaseService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/BaseService.kt
@@ -11,7 +11,7 @@ import com.mxt.anitrend.graphql.generated.ToggleLikeVariables
 import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import okhttp3.ResponseBody
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -23,25 +23,25 @@ import retrofit2.http.POST
 interface BaseService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getGenres(
+    suspend fun getGenres(
         @Body request: GraphQLRequest<EmptyGraphQLVariables>,
-    ): Call<GraphContainer<GenreCollectionData>>
+    ): Response<GraphContainer<GenreCollectionData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getTags(
+    suspend fun getTags(
         @Body request: GraphQLRequest<EmptyGraphQLVariables>,
-    ): Call<GraphContainer<MediaTagCollectionData>>
+    ): Response<GraphContainer<MediaTagCollectionData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun toggleLike(
+    suspend fun toggleLike(
         @Body request: GraphQLOperationRequest<ToggleLikeVariables>,
-    ): Call<AniListContainer<List<UserBase>>>
+    ): Response<AniListContainer<List<UserBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun toggleFavourite(
+    suspend fun toggleFavourite(
         @Body request: GraphQLOperationRequest<ToggleFavouriteVariables>,
-    ): Call<ResponseBody>
+    ): Response<ResponseBody>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/BrowseService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/BrowseService.kt
@@ -21,7 +21,7 @@ import com.mxt.anitrend.model.entity.anilist.meta.DeleteState
 import com.mxt.anitrend.model.entity.base.MediaBase
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -33,73 +33,73 @@ import retrofit2.http.POST
 interface BrowseService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaListCollection(
+    suspend fun getMediaListCollection(
         @Body request: GraphQLOperationRequest<MediaListCollectionVariables>,
-    ): Call<GraphContainer<MediaListCollectionData>>
+    ): Response<GraphContainer<MediaListCollectionData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaBrowse(
+    suspend fun getMediaBrowse(
         @Body request: GraphQLOperationRequest<MediaBrowseVariables>,
-    ): Call<AniListContainer<PageContainer<MediaBase>>>
+    ): Response<AniListContainer<PageContainer<MediaBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getReviewBrowse(
+    suspend fun getReviewBrowse(
         @Body request: GraphQLOperationRequest<ReviewBrowseVariables>,
-    ): Call<AniListContainer<PageContainer<Review>>>
+    ): Response<AniListContainer<PageContainer<Review>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaListBrowse(
+    suspend fun getMediaListBrowse(
         @Body request: GraphQLOperationRequest<MediaListBrowseVariables>,
-    ): Call<AniListContainer<PageContainer<MediaList>>>
+    ): Response<AniListContainer<PageContainer<MediaList>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaList(
+    suspend fun getMediaList(
         @Body request: GraphQLOperationRequest<MediaListVariables>,
-    ): Call<AniListContainer<MediaList>>
+    ): Response<AniListContainer<MediaList>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaWithList(
+    suspend fun getMediaWithList(
         @Body request: GraphQLOperationRequest<MediaWithListVariables>,
-    ): Call<AniListContainer<MediaBase>>
+    ): Response<AniListContainer<MediaBase>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun deleteMediaListEntry(
+    suspend fun deleteMediaListEntry(
         @Body request: GraphQLOperationRequest<DeleteMediaListEntryVariables>,
-    ): Call<AniListContainer<DeleteState>>
+    ): Response<AniListContainer<DeleteState>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun deleteReview(
+    suspend fun deleteReview(
         @Body request: GraphQLOperationRequest<DeleteReviewVariables>,
-    ): Call<AniListContainer<DeleteState>>
+    ): Response<AniListContainer<DeleteState>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun saveMediaListEntry(
+    suspend fun saveMediaListEntry(
         @Body request: GraphQLOperationRequest<SaveMediaListEntryVariables>,
-    ): Call<AniListContainer<MediaList>>
+    ): Response<AniListContainer<MediaList>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun updateMediaListEntries(
+    suspend fun updateMediaListEntries(
         @Body request: GraphQLOperationRequest<UpdateMediaListEntriesVariables>,
-    ): Call<AniListContainer<List<MediaList>>>
+    ): Response<AniListContainer<List<MediaList>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun rateReview(
+    suspend fun rateReview(
         @Body request: GraphQLOperationRequest<RateReviewVariables>,
-    ): Call<AniListContainer<Review>>
+    ): Response<AniListContainer<Review>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun saveReview(
+    suspend fun saveReview(
         @Body request: GraphQLOperationRequest<SaveReviewVariables>,
-    ): Call<AniListContainer<Review>>
+    ): Response<AniListContainer<Review>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/CharacterService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/CharacterService.kt
@@ -14,7 +14,7 @@ import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -27,25 +27,25 @@ import retrofit2.http.POST
 interface CharacterService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterBase(
+    suspend fun getCharacterBase(
         @Body request: GraphQLOperationRequest<CharacterBaseVariables>,
-    ): Call<GraphContainer<CharacterBaseData>>
+    ): Response<GraphContainer<CharacterBaseData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterOverview(
+    suspend fun getCharacterOverview(
         @Body request: GraphQLOperationRequest<CharacterOverviewVariables>,
-    ): Call<GraphContainer<CharacterOverviewData>>
+    ): Response<GraphContainer<CharacterOverviewData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterMedia(
+    suspend fun getCharacterMedia(
         @Body request: GraphQLOperationRequest<CharacterMediaVariables>,
-    ): Call<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>>
+    ): Response<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterActors(
+    suspend fun getCharacterActors(
         @Body request: GraphQLOperationRequest<CharacterActorsVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/FeedService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/FeedService.kt
@@ -14,7 +14,7 @@ import com.mxt.anitrend.model.entity.anilist.FeedReply
 import com.mxt.anitrend.model.entity.anilist.meta.DeleteState
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -27,49 +27,49 @@ import retrofit2.http.POST
 interface FeedService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFeedList(
+    suspend fun getFeedList(
         @Body request: GraphQLOperationRequest<FeedListVariables>,
-    ): Call<AniListContainer<PageContainer<FeedList>>>
+    ): Response<AniListContainer<PageContainer<FeedList>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFeedListReply(
+    suspend fun getFeedListReply(
         @Body request: GraphQLOperationRequest<FeedListReplyVariables>,
-    ): Call<AniListContainer<FeedList>>
+    ): Response<AniListContainer<FeedList>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFeedMessage(
+    suspend fun getFeedMessage(
         @Body request: GraphQLOperationRequest<FeedMessageVariables>,
-    ): Call<AniListContainer<PageContainer<FeedList>>>
+    ): Response<AniListContainer<PageContainer<FeedList>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun saveTextActivity(
+    suspend fun saveTextActivity(
         @Body request: GraphQLOperationRequest<SaveTextActivityVariables>,
-    ): Call<AniListContainer<FeedList>>
+    ): Response<AniListContainer<FeedList>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun saveMessageActivity(
+    suspend fun saveMessageActivity(
         @Body request: GraphQLOperationRequest<SaveMessageActivityVariables>,
-    ): Call<AniListContainer<FeedList>>
+    ): Response<AniListContainer<FeedList>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun saveActivityReply(
+    suspend fun saveActivityReply(
         @Body request: GraphQLOperationRequest<SaveActivityReplyVariables>,
-    ): Call<AniListContainer<FeedReply>>
+    ): Response<AniListContainer<FeedReply>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun deleteActivity(
+    suspend fun deleteActivity(
         @Body request: GraphQLOperationRequest<DeleteActivityVariables>,
-    ): Call<AniListContainer<DeleteState>>
+    ): Response<AniListContainer<DeleteState>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun deleteActivityReply(
+    suspend fun deleteActivityReply(
         @Body request: GraphQLOperationRequest<DeleteActivityReplyVariables>,
-    ): Call<AniListContainer<DeleteState>>
+    ): Response<AniListContainer<DeleteState>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/MediaService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/MediaService.kt
@@ -30,7 +30,7 @@ import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -43,97 +43,97 @@ import retrofit2.http.POST
 interface MediaService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaBase(
+    suspend fun getMediaBase(
         @Body request: GraphQLOperationRequest<MediaBaseVariables>,
-    ): Call<AniListContainer<MediaBase>>
+    ): Response<AniListContainer<MediaBase>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaBaseRecord(
+    suspend fun getMediaBaseRecord(
         @Body request: GraphQLOperationRequest<MediaBaseVariables>,
-    ): Call<GraphContainer<MediaBaseData>>
+    ): Response<GraphContainer<MediaBaseData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaOverview(
+    suspend fun getMediaOverview(
         @Body request: GraphQLOperationRequest<MediaOverviewVariables>,
-    ): Call<AniListContainer<Media>>
+    ): Response<AniListContainer<Media>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaOverviewRecord(
+    suspend fun getMediaOverviewRecord(
         @Body request: GraphQLOperationRequest<MediaOverviewVariables>,
-    ): Call<GraphContainer<MediaOverviewData>>
+    ): Response<GraphContainer<MediaOverviewData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaRelations(
+    suspend fun getMediaRelations(
         @Body request: GraphQLOperationRequest<MediaRelationsVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaRelationsRecord(
+    suspend fun getMediaRelationsRecord(
         @Body request: GraphQLOperationRequest<MediaRelationsVariables>,
-    ): Call<GraphContainer<MediaRelationsData>>
+    ): Response<GraphContainer<MediaRelationsData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaStats(
+    suspend fun getMediaStats(
         @Body request: GraphQLOperationRequest<MediaStatsVariables>,
-    ): Call<AniListContainer<Media>>
+    ): Response<AniListContainer<Media>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaStatsRecord(
+    suspend fun getMediaStatsRecord(
         @Body request: GraphQLOperationRequest<MediaStatsVariables>,
-    ): Call<GraphContainer<MediaStatsData>>
+    ): Response<GraphContainer<MediaStatsData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaEpisodes(
+    suspend fun getMediaEpisodes(
         @Body request: GraphQLOperationRequest<MediaEpisodesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<List<ExternalLink>>>>
+    ): Response<AniListContainer<ConnectionContainer<List<ExternalLink>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaEpisodesRecord(
+    suspend fun getMediaEpisodesRecord(
         @Body request: GraphQLOperationRequest<MediaEpisodesVariables>,
-    ): Call<GraphContainer<MediaEpisodesData>>
+    ): Response<GraphContainer<MediaEpisodesData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaCharacters(
+    suspend fun getMediaCharacters(
         @Body request: GraphQLOperationRequest<MediaCharactersVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<CharacterEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<CharacterEdge>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaCharactersRecord(
+    suspend fun getMediaCharactersRecord(
         @Body request: GraphQLOperationRequest<MediaCharactersVariables>,
-    ): Call<GraphContainer<MediaCharactersData>>
+    ): Response<GraphContainer<MediaCharactersData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaStaff(
+    suspend fun getMediaStaff(
         @Body request: GraphQLOperationRequest<MediaStaffVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<StaffEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<StaffEdge>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaStaffRecord(
+    suspend fun getMediaStaffRecord(
         @Body request: GraphQLOperationRequest<MediaStaffVariables>,
-    ): Call<GraphContainer<MediaStaffData>>
+    ): Response<GraphContainer<MediaStaffData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaRecommendations(
+    suspend fun getMediaRecommendations(
         @Body request: GraphQLOperationRequest<RecommendationMediaVariables>,
-    ): Call<GraphContainer<RecommendationMediaData>>
+    ): Response<GraphContainer<RecommendationMediaData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaSocial(
+    suspend fun getMediaSocial(
         @Body request: GraphQLOperationRequest<MediaSocialVariables>,
-    ): Call<AniListContainer<PageContainer<FeedList>>>
+    ): Response<AniListContainer<PageContainer<FeedList>>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/RecommendationService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/RecommendationService.kt
@@ -5,7 +5,7 @@ import com.mxt.anitrend.graphql.generated.RecommendationMediaListVariables
 import com.mxt.anitrend.model.entity.anilist.Recommendation
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -13,7 +13,7 @@ import retrofit2.http.POST
 interface RecommendationService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getRecommendationMediaList(
+    suspend fun getRecommendationMediaList(
         @Body request: GraphQLOperationRequest<RecommendationMediaListVariables>,
-    ): Call<AniListContainer<PageContainer<Recommendation>>>
+    ): Response<AniListContainer<PageContainer<Recommendation>>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/SearchService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/SearchService.kt
@@ -9,7 +9,7 @@ import com.mxt.anitrend.graphql.generated.UserSearchVariables
 import com.mxt.anitrend.model.entity.base.*
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -23,21 +23,21 @@ interface SearchService {
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMediaSearch(@Body request: GraphQLOperationRequest<MediaSearchVariables>): Call<AniListContainer<PageContainer<MediaBase>>>
+    suspend fun getMediaSearch(@Body request: GraphQLOperationRequest<MediaSearchVariables>): Response<AniListContainer<PageContainer<MediaBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStudioSearch(@Body request: GraphQLOperationRequest<StudioSearchVariables>): Call<AniListContainer<PageContainer<StudioBase>>>
+    suspend fun getStudioSearch(@Body request: GraphQLOperationRequest<StudioSearchVariables>): Response<AniListContainer<PageContainer<StudioBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffSearch(@Body request: GraphQLOperationRequest<StaffSearchVariables>): Call<AniListContainer<PageContainer<StaffBase>>>
+    suspend fun getStaffSearch(@Body request: GraphQLOperationRequest<StaffSearchVariables>): Response<AniListContainer<PageContainer<StaffBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterSearch(@Body request: GraphQLOperationRequest<CharacterSearchVariables>): Call<AniListContainer<PageContainer<CharacterBase>>>
+    suspend fun getCharacterSearch(@Body request: GraphQLOperationRequest<CharacterSearchVariables>): Response<AniListContainer<PageContainer<CharacterBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getUserSearch(@Body request: GraphQLOperationRequest<UserSearchVariables>): Call<AniListContainer<PageContainer<UserBase>>>
+    suspend fun getUserSearch(@Body request: GraphQLOperationRequest<UserSearchVariables>): Response<AniListContainer<PageContainer<UserBase>>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/StaffService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/StaffService.kt
@@ -15,7 +15,7 @@ import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.EdgeContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -28,31 +28,31 @@ import retrofit2.http.POST
 interface StaffService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffBase(
+    suspend fun getStaffBase(
         @Body request: GraphQLOperationRequest<StaffBaseVariables>,
-    ): Call<GraphContainer<StaffBaseData>>
+    ): Response<GraphContainer<StaffBaseData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffOverview(
+    suspend fun getStaffOverview(
         @Body request: GraphQLOperationRequest<StaffOverviewVariables>,
-    ): Call<AniListContainer<StaffBase>>
+    ): Response<AniListContainer<StaffBase>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffCharacters(
+    suspend fun getStaffCharacters(
         @Body request: GraphQLOperationRequest<StaffCharactersVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffMedia(
+    suspend fun getStaffMedia(
         @Body request: GraphQLOperationRequest<StaffMediaVariables>,
-    ): Call<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>>
+    ): Response<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffRoles(
+    suspend fun getStaffRoles(
         @Body request: GraphQLOperationRequest<StaffRolesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
+    ): Response<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/StudioService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/StudioService.kt
@@ -6,7 +6,7 @@ import com.mxt.anitrend.graphql.generated.StudioBaseData
 import com.mxt.anitrend.graphql.generated.StudioBaseVariables
 import com.mxt.anitrend.graphql.generated.StudioMediaData
 import com.mxt.anitrend.graphql.generated.StudioMediaVariables
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -19,13 +19,13 @@ import retrofit2.http.POST
 interface StudioService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStudioBase(
+    suspend fun getStudioBase(
         @Body request: GraphQLOperationRequest<StudioBaseVariables>,
-    ): Call<GraphContainer<StudioBaseData>>
+    ): Response<GraphContainer<StudioBaseData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStudioMedia(
+    suspend fun getStudioMedia(
         @Body request: GraphQLOperationRequest<StudioMediaVariables>,
-    ): Call<GraphContainer<StudioMediaData>>
+    ): Response<GraphContainer<StudioMediaData>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/UserService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/anilist/UserService.kt
@@ -26,7 +26,7 @@ import com.mxt.anitrend.model.entity.base.UserBase
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import com.mxt.anitrend.model.entity.container.body.ConnectionContainer
 import com.mxt.anitrend.model.entity.container.body.PageContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -39,92 +39,92 @@ import retrofit2.http.POST
 interface UserService {
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getUserNotifications(
+    suspend fun getUserNotifications(
         @Body request: GraphQLOperationRequest<UserNotificationsVariables>,
-    ): Call<GraphContainer<UserNotificationsData>>
+    ): Response<GraphContainer<UserNotificationsData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCurrentUser(
+    suspend fun getCurrentUser(
         @Body request: GraphQLOperationRequest<CurrentUserVariables>,
-    ): Call<AniListContainer<User>>
+    ): Response<AniListContainer<User>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getUserBase(
+    suspend fun getUserBase(
         @Body request: GraphQLOperationRequest<UserBaseVariables>,
-    ): Call<AniListContainer<UserBase>>
+    ): Response<AniListContainer<UserBase>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getUserOverview(
+    suspend fun getUserOverview(
         @Body request: GraphQLOperationRequest<UserOverviewVariables>,
-    ): Call<AniListContainer<User>>
+    ): Response<AniListContainer<User>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getUserStats(
+    suspend fun getUserStats(
         @Body request: GraphQLOperationRequest<UserStatsVariables>,
-    ): Call<GraphContainer<UserStatsData>>
+    ): Response<GraphContainer<UserStatsData>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFollowers(
+    suspend fun getFollowers(
         @Body request: GraphQLOperationRequest<UserFollowersVariables>,
-    ): Call<AniListContainer<PageContainer<UserBase>>>
+    ): Response<AniListContainer<PageContainer<UserBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFollowing(
+    suspend fun getFollowing(
         @Body request: GraphQLOperationRequest<UserFollowingVariables>,
-    ): Call<AniListContainer<PageContainer<UserBase>>>
+    ): Response<AniListContainer<PageContainer<UserBase>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getFavouritesCount(
+    suspend fun getFavouritesCount(
         @Body request: GraphQLOperationRequest<UserFavouriteCountVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getAnimeFavourites(
+    suspend fun getAnimeFavourites(
         @Body request: GraphQLOperationRequest<AnimeFavouritesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getMangaFavourites(
+    suspend fun getMangaFavourites(
         @Body request: GraphQLOperationRequest<MangaFavouritesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getCharacterFavourites(
+    suspend fun getCharacterFavourites(
         @Body request: GraphQLOperationRequest<CharacterFavouritesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStaffFavourites(
+    suspend fun getStaffFavourites(
         @Body request: GraphQLOperationRequest<StaffFavouritesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun getStudioFavourites(
+    suspend fun getStudioFavourites(
         @Body request: GraphQLOperationRequest<StudioFavouritesVariables>,
-    ): Call<AniListContainer<ConnectionContainer<Favourite>>>
+    ): Response<AniListContainer<ConnectionContainer<Favourite>>>
 
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun toggleFollow(
+    suspend fun toggleFollow(
         @Body request: GraphQLOperationRequest<ToggleFollowVariables>,
-    ): Call<AniListContainer<UserBase>>
+    ): Response<AniListContainer<UserBase>>
 
     /** Sends a typed UpdateUser mutation request to AniList. */
     @POST("/")
     @Headers("Content-Type: application/json")
-    fun updateUser(
+    suspend fun updateUser(
         @Body request: GraphQLOperationRequest<UpdateUserVariables>,
-    ): Call<GraphContainer<UpdateUserData>>
+    ): Response<GraphContainer<UpdateUserData>>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/base/GiphyService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/base/GiphyService.kt
@@ -1,7 +1,7 @@
 package com.mxt.anitrend.model.api.retro.base
 
 import com.mxt.anitrend.model.entity.giphy.GiphyContainer
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -12,20 +12,20 @@ import retrofit2.http.Query
 
 interface GiphyService {
     @GET("search")
-    fun findGif(
+    suspend fun findGif(
         @Query("api_key") api_key: String,
         @Query("q") q: String?,
         @Query("limit") limit: Int,
         @Query("offset") offset: Int?,
         @Query("rating") rating: String,
         @Query("lang") lang: String?,
-    ): Call<GiphyContainer>
+    ): Response<GiphyContainer>
 
     @GET("trending")
-    fun getTrending(
+    suspend fun getTrending(
         @Query("api_key") api_key: String,
         @Query("limit") limit: Int?,
         @Query("offset") offset: Int,
         @Query("rating") rating: String?,
-    ): Call<GiphyContainer>
+    ): Response<GiphyContainer>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/base/RepositoryService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/base/RepositoryService.kt
@@ -1,7 +1,7 @@
 package com.mxt.anitrend.model.api.retro.base
 
 import com.mxt.anitrend.model.entity.base.VersionBase
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -11,11 +11,11 @@ import retrofit2.http.Path
  */
 interface RepositoryService {
     @GET("/AniTrend/anitrend-app/raw/{branch}/app/.meta/version.json")
-    fun checkVersion(
+    suspend fun checkVersion(
         @Path(
             "branch",
         ) branch: String?,
-    ): Call<VersionBase>
+    ): Response<VersionBase>
 
     companion object {
         const val DOWNLOAD_LINK = "https://github.com/AniTrend/anitrend-app/releases/download/%s/app%s-release.apk"

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
@@ -1,7 +1,7 @@
 package com.mxt.anitrend.model.api.retro.crunchy
 
 import com.mxt.anitrend.model.entity.crunchy.Rss
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Url
 
@@ -10,14 +10,14 @@ import retrofit2.http.Url
  */
 
 interface EpisodeService {
-    @get:GET("crunchyroll/rss/popular?format=xml")
-    val popularFeed: Call<Rss>
+    @GET("crunchyroll/rss/popular?format=xml")
+    suspend fun getPopularFeed(): Response<Rss>
 
-    @get:GET("crunchyroll/rss")
-    val latestFeed: Call<Rss>
+    @GET("crunchyroll/rss")
+    suspend fun getLatestFeed(): Response<Rss>
 
     @GET
-    fun getRssByUrl(
+    suspend fun getRssByUrl(
         @Url link: String?,
-    ): Call<Rss>
+    ): Response<Rss>
 }

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
@@ -10,9 +10,11 @@ import retrofit2.http.Url
  */
 
 interface EpisodeService {
+    /** Fetches the popular Crunchyroll episode feed as RSS. */
     @GET("crunchyroll/rss/popular?format=xml")
     suspend fun getPopularFeed(): Response<Rss>
 
+    /** Fetches the latest Crunchyroll episode feed as RSS. */
     @GET("crunchyroll/rss")
     suspend fun getLatestFeed(): Response<Rss>
 

--- a/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
+++ b/app/src/main/java/com/mxt/anitrend/model/api/retro/crunchy/EpisodeService.kt
@@ -18,6 +18,7 @@ interface EpisodeService {
     @GET("crunchyroll/rss")
     suspend fun getLatestFeed(): Response<Rss>
 
+    /** Fetches the Crunchyroll episode feed from the given URL as RSS. */
     @GET
     suspend fun getRssByUrl(
         @Url link: String?,

--- a/app/src/main/java/com/mxt/anitrend/repository/BaseRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/BaseRepository.kt
@@ -54,7 +54,7 @@ class BaseRepository(
                 query = GenreCollection.document,
                 operationName = GenreCollection.name,
             )
-            val response = baseService.getGenres(request).execute()
+            val response = baseService.getGenres(request)
             if (response.isSuccessful) {
                 handleGenreCollection(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -77,7 +77,7 @@ class BaseRepository(
                 query = MediaTagCollection.document,
                 operationName = MediaTagCollection.name,
             )
-            val response = baseService.getTags(request).execute()
+            val response = baseService.getTags(request)
             if (response.isSuccessful) {
                 handleMediaTagCollection(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -103,7 +103,7 @@ class BaseRepository(
     ): Result<List<UserEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = ToggleLike.request(id = id.toInt(), type = type)
-            val response = baseService.toggleLike(request).execute()
+            val response = baseService.toggleLike(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -156,7 +156,7 @@ class BaseRepository(
     ): Result<List<UserSummaryRecord>> = withContext(ioDispatcher) {
         runCatching {
             val request = ToggleLike.request(id = id.toInt(), type = type)
-            val response = baseService.toggleLike(request).execute()
+            val response = baseService.toggleLike(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val likes = result.toUserSummaryRecords()
@@ -205,7 +205,7 @@ class BaseRepository(
     ): Result<Unit> = withContext(ioDispatcher) {
         runCatching {
             val request = ToggleFavourite.request(animeId = animeId, mangaId = mangaId, characterId = characterId, staffId = staffId, studioId = studioId, page = page, perPage = perPage)
-            val response = baseService.toggleFavourite(request).execute()
+            val response = baseService.toggleFavourite(request)
             if (!response.isSuccessful) {
                 throw RuntimeException(response.apiError())
             }

--- a/app/src/main/java/com/mxt/anitrend/repository/BrowseRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/BrowseRepository.kt
@@ -74,7 +74,7 @@ class BrowseRepository(
                 statusIn = statusIn,
                 scoreFormat = scoreFormat,
             )
-            val response = browseService.getMediaListCollection(request).execute()
+            val response = browseService.getMediaListCollection(request)
             if (response.isSuccessful) {
                 val result = handleMediaListCollection(response.body() ?: throw IllegalStateException("Empty response body"))
                 val resolvedQueryKey = queryKey ?: MediaListQueryKey(
@@ -146,7 +146,7 @@ class BrowseRepository(
                 isAdult = isAdult, sort = sort, onList = onList,
                 status = status, tags = tags, tagsExclude = tagsExclude,
             )
-            val response = browseService.getMediaBrowse(request).execute()
+            val response = browseService.getMediaBrowse(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -168,7 +168,7 @@ class BrowseRepository(
     ): Result<PageContainer<Review>> = withContext(ioDispatcher) {
         runCatching {
             val request = ReviewBrowse.request(page = page, perPage = perPage, mediaId = mediaId?.toInt(), type = type, sort = sort, asHtml = asHtml)
-            val response = browseService.getReviewBrowse(request).execute()
+            val response = browseService.getReviewBrowse(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.takeIf { it.hasPageInfo() }?.pageInfo?.toPageInfoRecord()
@@ -210,7 +210,7 @@ class BrowseRepository(
     ): Result<PageContainer<MediaEntityList>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaListBrowse.request(id = id, userId = userId?.toInt(), userName = userName, page = page, perPage = perPage, type = type, status = status, sort = sort, scoreFormat = scoreFormat)
-            val response = browseService.getMediaListBrowse(request).execute()
+            val response = browseService.getMediaListBrowse(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -230,7 +230,7 @@ class BrowseRepository(
     ): Result<MediaEntityList> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaList.request(id = id, mediaId = mediaId?.toInt(), userName = userName, type = type, status = status, sort = sort, scoreFormat = scoreFormat)
-            val response = browseService.getMediaList(request).execute()
+            val response = browseService.getMediaList(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -247,7 +247,7 @@ class BrowseRepository(
     ): Result<com.mxt.anitrend.model.entity.base.MediaBase> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaWithList.request(id = id.toInt(), type = type, onList = onList, scoreFormat = scoreFormat)
-            val response = browseService.getMediaWithList(request).execute()
+            val response = browseService.getMediaWithList(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -266,7 +266,7 @@ class BrowseRepository(
     ): Result<DeleteState> = withContext(ioDispatcher) {
         runCatching {
             val request = DeleteMediaListEntry.request(id = id.toInt())
-            val response = browseService.deleteMediaListEntry(request).execute()
+            val response = browseService.deleteMediaListEntry(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore && result.isDeleted) {
@@ -293,7 +293,7 @@ class BrowseRepository(
     ): Result<DeleteState> = withContext(ioDispatcher) {
         runCatching {
             val request = DeleteReview.request(id = id.toInt())
-            val response = browseService.deleteReview(request).execute()
+            val response = browseService.deleteReview(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore && result.isDeleted) {
@@ -343,7 +343,7 @@ class BrowseRepository(
                 notes = notes, scoreFormat = scoreFormat,
                 startedAt = startedAt, completedAt = completedAt,
             )
-            val response = browseService.saveMediaListEntry(request).execute()
+            val response = browseService.saveMediaListEntry(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -369,7 +369,7 @@ class BrowseRepository(
     ): Result<Review> = withContext(ioDispatcher) {
         runCatching {
             val request = RateReview.request(id = id.toInt(), rating = rating, asHtml = asHtml)
-            val response = browseService.rateReview(request).execute()
+            val response = browseService.rateReview(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -400,7 +400,7 @@ class BrowseRepository(
     ): Result<Review> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveReview.request(id = id, mediaId = mediaId.toInt(), body = body, summary = summary, score = score, privateValue = private, asHtml = asHtml)
-            val response = browseService.saveReview(request).execute()
+            val response = browseService.saveReview(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {

--- a/app/src/main/java/com/mxt/anitrend/repository/CharacterRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/CharacterRepository.kt
@@ -33,7 +33,7 @@ class CharacterRepository(
     suspend fun getCharacterBase(id: Long): Result<CharacterRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterBase.request(id = id.toInt())
-            val response = characterService.getCharacterBase(request).execute()
+            val response = characterService.getCharacterBase(request)
             if (response.isSuccessful) {
                 handleCharacterBase(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -53,7 +53,7 @@ class CharacterRepository(
     suspend fun getCharacterOverview(id: Long, asHtml: Boolean = false): Result<MediaCharacter> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterOverview.request(id = id.toInt(), asHtml = asHtml)
-            val response = characterService.getCharacterOverview(request).execute()
+            val response = characterService.getCharacterOverview(request)
             if (response.isSuccessful) {
                 handleCharacterOverview(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -79,7 +79,7 @@ class CharacterRepository(
     ): Result<ConnectionContainer<PageContainer<MediaEntity>>> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterMedia.request(id = id.toInt(), page = page, perPage = perPage, sort = sort, type = type)
-            val response = characterService.getCharacterMedia(request).execute()
+            val response = characterService.getCharacterMedia(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -96,7 +96,7 @@ class CharacterRepository(
     ): Result<ConnectionContainer<EdgeContainer<MediaEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterActors.request(id = id.toInt(), page = page, perPage = perPage, sort = sort)
-            val response = characterService.getCharacterActors(request).execute()
+            val response = characterService.getCharacterActors(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {

--- a/app/src/main/java/com/mxt/anitrend/repository/CrunchyrollRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/CrunchyrollRepository.kt
@@ -6,7 +6,7 @@ import com.mxt.anitrend.util.graphql.apiError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.Call
+import retrofit2.Response
 
 class CrunchyrollRepository(
     private val feedService: EpisodeService,
@@ -14,15 +14,15 @@ class CrunchyrollRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
-    suspend fun getLatestFeed(): Result<Rss> = execute(feedService.latestFeed)
+    suspend fun getLatestFeed(): Result<Rss> = execute { feedService.getLatestFeed() }
 
-    suspend fun getPopularFeed(): Result<Rss> = execute(feedService.popularFeed)
+    suspend fun getPopularFeed(): Result<Rss> = execute { feedService.getPopularFeed() }
 
-    suspend fun getRss(link: String?): Result<Rss> = execute(crunchyrollService.getRssByUrl(link))
+    suspend fun getRss(link: String?): Result<Rss> = execute { crunchyrollService.getRssByUrl(link) }
 
-    private suspend fun execute(call: Call<Rss>): Result<Rss> = withContext(ioDispatcher) {
+    private suspend fun execute(request: suspend () -> Response<Rss>): Result<Rss> = withContext(ioDispatcher) {
         runCatching {
-            val response = call.execute()
+            val response = request()
             if (response.isSuccessful) {
                 response.body() ?: throw IllegalStateException("Empty response body")
             } else {

--- a/app/src/main/java/com/mxt/anitrend/repository/FeedRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/FeedRepository.kt
@@ -73,7 +73,7 @@ class FeedRepository(
     ): Result<PageContainer<FeedListEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedList.request(page = page, perPage = perPage, id = id?.toInt(), isFollowing = isFollowing, userId = userId?.toInt(), type = type, isMixed = isMixed, asHtml = asHtml)
-            val response = feedService.getFeedList(request).execute()
+            val response = feedService.getFeedList(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.takeIf { it.hasPageInfo() }?.pageInfo?.toPageInfoRecord()
@@ -118,7 +118,7 @@ class FeedRepository(
     ): Result<FeedListEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedListReply.request(id = id.toInt(), asHtml = asHtml)
-            val response = feedService.getFeedListReply(request).execute()
+            val response = feedService.getFeedListReply(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body")).also { result ->
                     if (commitToStore) {
@@ -153,7 +153,7 @@ class FeedRepository(
     ): Result<PageContainer<FeedListEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedMessage.request(page = page, perPage = perPage, messengerId = messengerId?.toInt(), userId = userId?.toInt(), asHtml = asHtml)
-            val response = feedService.getFeedMessage(request).execute()
+            val response = feedService.getFeedMessage(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.takeIf { it.hasPageInfo() }?.pageInfo?.toPageInfoRecord()
@@ -196,7 +196,7 @@ class FeedRepository(
     ): Result<FeedListEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveTextActivity.request(id = id?.toInt(), text = text, asHtml = asHtml)
-            val response = feedService.saveTextActivity(request).execute()
+            val response = feedService.saveTextActivity(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -223,7 +223,7 @@ class FeedRepository(
     ): Result<FeedListEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveMessageActivity.request(id = id?.toInt(), message = message, recipientId = recipientId.toInt(), asHtml = asHtml)
-            val response = feedService.saveMessageActivity(request).execute()
+            val response = feedService.saveMessageActivity(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -250,7 +250,7 @@ class FeedRepository(
     ): Result<FeedReply> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveActivityReply.request(id = id?.toInt(), activityId = activityId.toInt(), text = text, asHtml = asHtml)
-            val response = feedService.saveActivityReply(request).execute()
+            val response = feedService.saveActivityReply(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore) {
@@ -275,7 +275,7 @@ class FeedRepository(
     ): Result<DeleteState> = withContext(ioDispatcher) {
         runCatching {
             val request = DeleteActivity.request(id = id.toInt())
-            val response = feedService.deleteActivity(request).execute()
+            val response = feedService.deleteActivity(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore && result.isDeleted) {
@@ -301,7 +301,7 @@ class FeedRepository(
     ): Result<DeleteState> = withContext(ioDispatcher) {
         runCatching {
             val request = DeleteActivityReply.request(id = id.toInt())
-            val response = feedService.deleteActivityReply(request).execute()
+            val response = feedService.deleteActivityReply(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 if (commitToStore && result.isDeleted) {
@@ -346,7 +346,7 @@ class FeedRepository(
     ): Result<FeedRecordPage> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedList.request(page = page, perPage = perPage, id = id?.toInt(), isFollowing = isFollowing, userId = userId?.toInt(), type = type, isMixed = isMixed, asHtml = asHtml)
-            val response = feedService.getFeedList(request).execute()
+            val response = feedService.getFeedList(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.toRecordPageInfo()
@@ -392,7 +392,7 @@ class FeedRepository(
     ): Result<FeedDetailResult> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedListReply.request(id = id.toInt(), asHtml = asHtml)
-            val response = feedService.getFeedListReply(request).execute()
+            val response = feedService.getFeedListReply(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val feed = result.toFeedRecord(revision = readToken)
@@ -429,7 +429,7 @@ class FeedRepository(
     ): Result<FeedRecordPage> = withContext(ioDispatcher) {
         runCatching {
             val request = FeedMessage.request(page = page, perPage = perPage, messengerId = messengerId?.toInt(), userId = userId?.toInt(), asHtml = asHtml)
-            val response = feedService.getFeedMessage(request).execute()
+            val response = feedService.getFeedMessage(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.toRecordPageInfo()
@@ -471,7 +471,7 @@ class FeedRepository(
     ): Result<FeedRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveTextActivity.request(id = id?.toInt(), text = text, asHtml = asHtml)
-            val response = feedService.saveTextActivity(request).execute()
+            val response = feedService.saveTextActivity(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val feed = result.toFeedRecord(revision = revision)
@@ -499,7 +499,7 @@ class FeedRepository(
     ): Result<FeedRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveMessageActivity.request(id = id?.toInt(), message = message, recipientId = recipientId.toInt(), asHtml = asHtml)
-            val response = feedService.saveMessageActivity(request).execute()
+            val response = feedService.saveMessageActivity(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val feed = result.toFeedRecord(revision = revision)
@@ -527,7 +527,7 @@ class FeedRepository(
     ): Result<FeedReplyRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = SaveActivityReply.request(id = id?.toInt(), activityId = activityId.toInt(), text = text, asHtml = asHtml)
-            val response = feedService.saveActivityReply(request).execute()
+            val response = feedService.saveActivityReply(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val reply = result.toFeedReplyRecord(activityId = activityId, revision = revision)

--- a/app/src/main/java/com/mxt/anitrend/repository/MediaRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/MediaRepository.kt
@@ -66,7 +66,7 @@ class MediaRepository(
     suspend fun getMediaBase(id: Long, type: MediaType?, isAdult: Boolean?): Result<MediaEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaBase.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaBase(request).execute()
+            val response = mediaService.getMediaBase(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -83,7 +83,7 @@ class MediaRepository(
     suspend fun getMediaBaseRecord(id: Long, type: MediaType?, isAdult: Boolean?): Result<MediaDetailRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaBase.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaBaseRecord(request).execute()
+            val response = mediaService.getMediaBaseRecord(request)
             if (response.isSuccessful) {
                 handleMediaBaseRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -95,7 +95,7 @@ class MediaRepository(
     suspend fun getMediaOverview(id: Long, type: MediaType?, isAdult: Boolean?, asHtml: Boolean = false): Result<Media> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaOverview.request(id = id.toInt(), type = type, isAdult = isAdult, asHtml = asHtml)
-            val response = mediaService.getMediaOverview(request).execute()
+            val response = mediaService.getMediaOverview(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -115,7 +115,7 @@ class MediaRepository(
     suspend fun getMediaOverviewRecord(id: Long, type: MediaType?, isAdult: Boolean?, asHtml: Boolean = false): Result<MediaOverviewRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaOverview.request(id = id.toInt(), type = type, isAdult = isAdult, asHtml = asHtml)
-            val response = mediaService.getMediaOverviewRecord(request).execute()
+            val response = mediaService.getMediaOverviewRecord(request)
             if (response.isSuccessful) {
                 handleMediaOverviewRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -127,7 +127,7 @@ class MediaRepository(
     suspend fun getMediaRelations(id: Long, type: MediaType?, isAdult: Boolean?): Result<ConnectionContainer<EdgeContainer<MediaEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaRelations.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaRelations(request).execute()
+            val response = mediaService.getMediaRelations(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -146,7 +146,7 @@ class MediaRepository(
     suspend fun getMediaRelationsRecord(id: Long, type: MediaType?, isAdult: Boolean?): Result<MediaRelationsRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaRelations.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaRelationsRecord(request).execute()
+            val response = mediaService.getMediaRelationsRecord(request)
             if (response.isSuccessful) {
                 handleMediaRelationsRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -158,7 +158,7 @@ class MediaRepository(
     suspend fun getMediaStats(id: Long, type: MediaType?, isAdult: Boolean?): Result<Media> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaStats.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaStats(request).execute()
+            val response = mediaService.getMediaStats(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -177,7 +177,7 @@ class MediaRepository(
     suspend fun getMediaStatsRecord(id: Long, type: MediaType?, isAdult: Boolean?): Result<MediaStatsRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaStats.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaStatsRecord(request).execute()
+            val response = mediaService.getMediaStatsRecord(request)
             if (response.isSuccessful) {
                 handleMediaStatsRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -189,7 +189,7 @@ class MediaRepository(
     suspend fun getMediaEpisodes(id: Long, type: MediaType?, isAdult: Boolean?): Result<ConnectionContainer<List<ExternalLink>>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaEpisodes.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaEpisodes(request).execute()
+            val response = mediaService.getMediaEpisodes(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -208,7 +208,7 @@ class MediaRepository(
     suspend fun getMediaEpisodesRecord(id: Long, type: MediaType?, isAdult: Boolean?): Result<MediaEpisodesRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaEpisodes.request(id = id.toInt(), type = type, isAdult = isAdult)
-            val response = mediaService.getMediaEpisodesRecord(request).execute()
+            val response = mediaService.getMediaEpisodesRecord(request)
             if (response.isSuccessful) {
                 handleMediaEpisodesRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -227,7 +227,7 @@ class MediaRepository(
     ): Result<ConnectionContainer<EdgeContainer<CharacterEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaCharacters.request(id = id.toInt(), type = type, isAdult = isAdult, page = page, perPage = perPage, sort = sort)
-            val response = mediaService.getMediaCharacters(request).execute()
+            val response = mediaService.getMediaCharacters(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -253,7 +253,7 @@ class MediaRepository(
     ): Result<MediaCharactersRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaCharacters.request(id = id.toInt(), type = type, isAdult = isAdult, page = page, perPage = perPage, sort = sort)
-            val response = mediaService.getMediaCharactersRecord(request).execute()
+            val response = mediaService.getMediaCharactersRecord(request)
             if (response.isSuccessful) {
                 handleMediaCharactersRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -272,7 +272,7 @@ class MediaRepository(
     ): Result<ConnectionContainer<EdgeContainer<StaffEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaStaff.request(id = id.toInt(), type = type, sort = sort, isAdult = isAdult, page = page, perPage = perPage)
-            val response = mediaService.getMediaStaff(request).execute()
+            val response = mediaService.getMediaStaff(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -298,7 +298,7 @@ class MediaRepository(
     ): Result<MediaStaffRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaStaff.request(id = id.toInt(), type = type, sort = sort, isAdult = isAdult, page = page, perPage = perPage)
-            val response = mediaService.getMediaStaffRecord(request).execute()
+            val response = mediaService.getMediaStaffRecord(request)
             if (response.isSuccessful) {
                 handleMediaStaffRecord(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -317,7 +317,7 @@ class MediaRepository(
     ): Result<RecommendationPageResult> = withContext(ioDispatcher) {
         runCatching {
             val request = RecommendationMedia.request(id = id.toInt(), type = type, isAdult = isAdult, page = page, perPage = perPage, sort = sort)
-            val response = mediaService.getMediaRecommendations(request).execute()
+            val response = mediaService.getMediaRecommendations(request)
             if (response.isSuccessful) {
                 handleMediaRecommendations(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -420,7 +420,7 @@ class MediaRepository(
     ): Result<PageContainer<FeedList>> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaSocial.request(mediaId = mediaId.toInt(), isFollowing = isFollowing, page = page, perPage = perPage)
-            val response = mediaService.getMediaSocial(request).execute()
+            val response = mediaService.getMediaSocial(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.takeIf { it.hasPageInfo() }?.pageInfo?.toPageInfoRecord()
@@ -469,7 +469,7 @@ class MediaRepository(
     ): Result<FeedRecordPage> = withContext(ioDispatcher) {
         runCatching {
             val request = MediaSocial.request(mediaId = mediaId.toInt(), isFollowing = isFollowing, page = page, perPage = perPage)
-            val response = mediaService.getMediaSocial(request).execute()
+            val response = mediaService.getMediaSocial(request)
             if (response.isSuccessful) {
                 val result = handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
                 val pageInfo = result.toRecordPageInfo()

--- a/app/src/main/java/com/mxt/anitrend/repository/SearchRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/SearchRepository.kt
@@ -52,7 +52,7 @@ class SearchRepository(
                 genresExclude = genresExclude, isAdult = isAdult,
                 sort = sort,
             )
-            val response = searchService.getMediaSearch(request).execute()
+            val response = searchService.getMediaSearch(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -70,7 +70,7 @@ class SearchRepository(
     ): Result<PageContainer<StudioEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = StudioSearch.request(id = id, page = page, perPage = perPage, search = search, sort = sort)
-            val response = searchService.getStudioSearch(request).execute()
+            val response = searchService.getStudioSearch(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -88,7 +88,7 @@ class SearchRepository(
     ): Result<PageContainer<StaffEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffSearch.request(id = id, page = page, perPage = perPage, search = search, sort = sort)
-            val response = searchService.getStaffSearch(request).execute()
+            val response = searchService.getStaffSearch(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -106,7 +106,7 @@ class SearchRepository(
     ): Result<PageContainer<CharacterEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterSearch.request(id = id, page = page, perPage = perPage, search = search, sort = sort)
-            val response = searchService.getCharacterSearch(request).execute()
+            val response = searchService.getCharacterSearch(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -124,7 +124,7 @@ class SearchRepository(
     ): Result<PageContainer<UserEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = UserSearch.request(id = id, page = page, perPage = perPage, search = search, sort = sort)
-            val response = searchService.getUserSearch(request).execute()
+            val response = searchService.getUserSearch(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {

--- a/app/src/main/java/com/mxt/anitrend/repository/StaffRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/StaffRepository.kt
@@ -31,7 +31,7 @@ class StaffRepository(
     suspend fun getStaffBase(id: Long): Result<StaffRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffBase.request(id = id.toInt())
-            val response = staffService.getStaffBase(request).execute()
+            val response = staffService.getStaffBase(request)
             if (response.isSuccessful) {
                 handleStaffBase(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -51,7 +51,7 @@ class StaffRepository(
     suspend fun getStaffOverview(id: Long, asHtml: Boolean = false): Result<StaffEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffOverview.request(id = id.toInt(), asHtml = asHtml)
-            val response = staffService.getStaffOverview(request).execute()
+            val response = staffService.getStaffOverview(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -68,7 +68,7 @@ class StaffRepository(
     ): Result<ConnectionContainer<EdgeContainer<MediaEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffCharacters.request(id = id.toInt(), onList = onList, page = page, sort = sort)
-            val response = staffService.getStaffCharacters(request).execute()
+            val response = staffService.getStaffCharacters(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -87,7 +87,7 @@ class StaffRepository(
     ): Result<ConnectionContainer<PageContainer<MediaEntity>>> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffMedia.request(id = id.toInt(), onList = onList, page = page, perPage = perPage, sort = sort, type = type)
-            val response = staffService.getStaffMedia(request).execute()
+            val response = staffService.getStaffMedia(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -106,7 +106,7 @@ class StaffRepository(
     ): Result<ConnectionContainer<EdgeContainer<MediaEdge>>> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffRoles.request(id = id.toInt(), onList = onList, page = page, perPage = perPage, sort = sort, type = type)
-            val response = staffService.getStaffRoles(request).execute()
+            val response = staffService.getStaffRoles(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {

--- a/app/src/main/java/com/mxt/anitrend/repository/StudioRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/StudioRepository.kt
@@ -28,7 +28,7 @@ class StudioRepository(
     suspend fun getStudioBase(id: Long): Result<StudioRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = StudioBase.request(id = id.toInt())
-            val response = studioService.getStudioBase(request).execute()
+            val response = studioService.getStudioBase(request)
             if (response.isSuccessful) {
                 handleStudioBase(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -53,7 +53,7 @@ class StudioRepository(
     ): Result<ConnectionContainer<PageContainer<MediaEntity>>> = withContext(ioDispatcher) {
         runCatching {
             val request = StudioMedia.request(id = id.toInt(), page = page, perPage = perPage, sort = sort)
-            val response = studioService.getStudioMedia(request).execute()
+            val response = studioService.getStudioMedia(request)
             if (response.isSuccessful) {
                 handleStudioMedia(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {

--- a/app/src/main/java/com/mxt/anitrend/repository/UserRepository.kt
+++ b/app/src/main/java/com/mxt/anitrend/repository/UserRepository.kt
@@ -78,7 +78,7 @@ class UserRepository(
     suspend fun getCurrentUser(asHtml: Boolean = false): Result<User> = withContext(ioDispatcher) {
         runCatching {
             val request = CurrentUser.request(asHtml = asHtml)
-            val response = userService.getCurrentUser(request).execute()
+            val response = userService.getCurrentUser(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -92,7 +92,7 @@ class UserRepository(
     suspend fun getUserBase(id: Long? = null, userName: String? = null): Result<UserEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = UserBase.request(id = id?.toInt(), userName = userName)
-            val response = userService.getUserBase(request).execute()
+            val response = userService.getUserBase(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -104,7 +104,7 @@ class UserRepository(
     suspend fun getUserOverview(id: Long? = null, userName: String? = null, asHtml: Boolean = false): Result<User> = withContext(ioDispatcher) {
         runCatching {
             val request = UserOverview.request(id = id?.toInt(), userName = userName, asHtml = asHtml)
-            val response = userService.getUserOverview(request).execute()
+            val response = userService.getUserOverview(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -116,7 +116,7 @@ class UserRepository(
     suspend fun getUserStats(id: Long? = null, userName: String? = null): Result<UserStatisticsRecord> = withContext(ioDispatcher) {
         runCatching {
             val request = UserStats.request(id = id?.toInt(), userName = userName)
-            val response = userService.getUserStats(request).execute()
+            val response = userService.getUserStats(request)
             if (response.isSuccessful) {
                 handleUserStats(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -133,7 +133,7 @@ class UserRepository(
     ): Result<PageContainer<UserEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = UserFollowers.request(id = id.toInt(), page = page, perPage = perPage, sort = sort)
-            val response = userService.getFollowers(request).execute()
+            val response = userService.getFollowers(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -150,7 +150,7 @@ class UserRepository(
     ): Result<PageContainer<UserEntity>> = withContext(ioDispatcher) {
         runCatching {
             val request = UserFollowing.request(id = id.toInt(), page = page, perPage = perPage, sort = sort)
-            val response = userService.getFollowing(request).execute()
+            val response = userService.getFollowing(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -167,7 +167,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = UserFavouriteCount.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getFavouritesCount(request).execute()
+            val response = userService.getFavouritesCount(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -184,7 +184,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = AnimeFavourites.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getAnimeFavourites(request).execute()
+            val response = userService.getAnimeFavourites(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -201,7 +201,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = MangaFavourites.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getMangaFavourites(request).execute()
+            val response = userService.getMangaFavourites(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -218,7 +218,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = CharacterFavourites.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getCharacterFavourites(request).execute()
+            val response = userService.getCharacterFavourites(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -235,7 +235,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = StaffFavourites.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getStaffFavourites(request).execute()
+            val response = userService.getStaffFavourites(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -252,7 +252,7 @@ class UserRepository(
     ): Result<ConnectionContainer<Favourite>> = withContext(ioDispatcher) {
         runCatching {
             val request = StudioFavourites.request(id = id?.toInt(), userName = userName, page = page, perPage = perPage)
-            val response = userService.getStudioFavourites(request).execute()
+            val response = userService.getStudioFavourites(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -270,7 +270,7 @@ class UserRepository(
     ): Result<NotificationPageResult> = withContext(ioDispatcher) {
         runCatching {
             val request = UserNotifications.request(page = page, perPage = perPage, type = type, typeIn = typeIn, resetNotificationCount = resetNotificationCount)
-            val response = userService.getUserNotifications(request).execute()
+            val response = userService.getUserNotifications(request)
             if (response.isSuccessful) {
                 handleUserNotifications(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -298,7 +298,7 @@ class UserRepository(
     suspend fun toggleFollow(userId: Long): Result<UserEntity> = withContext(ioDispatcher) {
         runCatching {
             val request = ToggleFollow.request(userId = userId.toInt())
-            val response = userService.toggleFollow(request).execute()
+            val response = userService.toggleFollow(request)
             if (response.isSuccessful) {
                 handleGraphResponse(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {
@@ -332,7 +332,7 @@ class UserRepository(
                 scoreFormat = update.scoreFormat?.let { ScoreFormat.valueOf(it) },
                 titleLanguage = update.titleLanguage?.let { UserTitleLanguage.valueOf(it) },
             )
-            val response = userService.updateUser(request).execute()
+            val response = userService.updateUser(request)
             if (response.isSuccessful) {
                 handleUpdateUser(response.body() ?: throw IllegalStateException("Empty response body"))
             } else {

--- a/app/src/main/java/com/mxt/anitrend/viewmodel/GiphyViewModel.kt
+++ b/app/src/main/java/com/mxt/anitrend/viewmodel/GiphyViewModel.kt
@@ -40,7 +40,7 @@ class GiphyViewModel(
                         limit = KeyUtil.PAGING_LIMIT,
                         offset = offset,
                         rating = "PG",
-                    ).execute()
+                    )
                     if (response.isSuccessful) {
                         response.body()
                             ?: throw IllegalStateException("Empty response body")
@@ -74,7 +74,7 @@ class GiphyViewModel(
                         offset = offset,
                         rating = "PG",
                         lang = "en",
-                    ).execute()
+                    )
                     if (response.isSuccessful) {
                         response.body()
                             ?: throw IllegalStateException("Empty response body")

--- a/app/src/main/java/com/mxt/anitrend/worker/UpdateWorker.kt
+++ b/app/src/main/java/com/mxt/anitrend/worker/UpdateWorker.kt
@@ -30,12 +30,12 @@ class UpdateWorker(
             )
     }
 
-    private fun requestUpdateInformation(): VersionBase? = if (shouldCheckForUpdate()) {
+    private suspend fun requestUpdateInformation(): VersionBase? = if (shouldCheckForUpdate()) {
         val response =
             repositoryService
                 .checkVersion(
                     presenter.settings.updateChannel,
-                ).execute()
+                )
 
         val data = response.body()
 

--- a/app/src/test/java/com/mxt/anitrend/model/api/converter/AniGraphConverterTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/model/api/converter/AniGraphConverterTest.kt
@@ -3,6 +3,7 @@ package com.mxt.anitrend.model.api.converter
 import co.anitrend.retrofit.graphql.model.EmptyGraphQLVariables
 import co.anitrend.retrofit.graphql.model.GraphQLRequest
 import co.anitrend.retrofit.graphql.model.body.GraphContainer
+import co.anitrend.retrofit.graphql.model.request.GraphQLOperationRequest
 import co.anitrend.retrofit.graphql.serialization.kotlinx.KotlinxGraphQLJson
 import com.google.gson.GsonBuilder
 import com.mxt.anitrend.graphql.generated.GeneratedGraphQLRegistry
@@ -11,19 +12,20 @@ import com.mxt.anitrend.graphql.generated.GenreCollectionData
 import com.mxt.anitrend.graphql.generated.LikeableType
 import com.mxt.anitrend.graphql.generated.MediaTagCollectionData
 import com.mxt.anitrend.graphql.generated.ToggleLike
-import com.mxt.anitrend.model.api.retro.anilist.BaseService
+import com.mxt.anitrend.graphql.generated.ToggleLikeVariables
 import com.mxt.anitrend.model.entity.container.body.AniListContainer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import retrofit2.Converter
 import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -41,12 +43,6 @@ class AniGraphConverterTest {
 
     private val retrofit = Retrofit.Builder()
         .baseUrl("https://example.com/")
-        .build()
-
-    /** Retrofit wired exactly like production: only [AniGraphConverter] is registered. */
-    private val converterRetrofit = Retrofit.Builder()
-        .baseUrl("https://example.com/")
-        .addConverterFactory(converter)
         .build()
 
     @Test
@@ -105,12 +101,12 @@ class AniGraphConverterTest {
 
     @Test
     fun `serializes generated GraphQLOperationRequest bodies through toggleLike`() {
-        val service = converterRetrofit.create(BaseService::class.java)
-        val call = service.toggleLike(
-            ToggleLike.request(id = 1, type = LikeableType.ACTIVITY),
+        val requestBody = serializedBody(
+            request = ToggleLike.request(id = 1, type = LikeableType.ACTIVITY),
+            type = parameterizedType(GraphQLOperationRequest::class.java, ToggleLikeVariables::class.java),
         )
 
-        val body = jsonObject(call.request())
+        val body = jsonObject(requestBody)
 
         assertEquals("ToggleLike", body["operationName"]?.jsonPrimitive?.content)
         assertTrue(body["query"]?.jsonPrimitive?.content?.contains("ToggleLike") == true)
@@ -121,22 +117,31 @@ class AniGraphConverterTest {
 
     @Test
     fun `preserves manual compat GraphQLRequest serialization through getGenres`() {
-        val service = converterRetrofit.create(BaseService::class.java)
-        val call = service.getGenres(
-            GraphQLRequest<EmptyGraphQLVariables>(
+        val requestBody = serializedBody(
+            request = GraphQLRequest<EmptyGraphQLVariables>(
                 query = GenreCollection.document,
                 operationName = GenreCollection.name,
             ),
+            type = parameterizedType(GraphQLRequest::class.java, EmptyGraphQLVariables::class.java),
         )
 
-        val body = jsonObject(call.request())
+        val body = jsonObject(requestBody)
 
         assertEquals("GenreCollection", body["operationName"]?.jsonPrimitive?.content)
         assertTrue(body["query"]?.jsonPrimitive?.content?.contains("query GenreCollection") == true)
     }
 
-    private fun jsonObject(request: Request): JsonObject {
-        val body = request.body ?: error("Expected a serialized request body")
+    private fun serializedBody(request: Any, type: Type): RequestBody {
+        val converter = converter.requestBodyConverter(
+            type = type,
+            parameterAnnotations = emptyArray(),
+            methodAnnotations = emptyArray(),
+            retrofit = retrofit,
+        ) as Converter<Any, RequestBody>
+        return converter.convert(request) ?: error("Expected a serialized request body")
+    }
+
+    private fun jsonObject(body: RequestBody): JsonObject {
         val buffer = Buffer()
         body.writeTo(buffer)
         return Json.parseToJsonElement(buffer.readUtf8()).jsonObject

--- a/app/src/test/java/com/mxt/anitrend/repository/BaseRepositoryLikeRecordsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/BaseRepositoryLikeRecordsTest.kt
@@ -22,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -122,8 +121,8 @@ class BaseRepositoryLikeRecordsTest {
     fun `failed like is server authoritative and leaves store unchanged`() = runTest {
         store.apply(FeedStoreChange.FeedUpserted(createFeedRecord(id = 1L, revision = 1L)))
         val request = ToggleLike.request(id = 1, type = LikeableType.ACTIVITY)
-        val call = responseCall(AniListContainer<List<UserBase>>(data = null, errors = null))
-        `when`(service.toggleLike(request)).thenReturn(call)
+        val response = success(AniListContainer<List<UserBase>>(data = null, errors = null))
+        `when`(service.toggleLike(request)).thenReturn(response)
 
         val result = repository.toggleLikeRecords(id = 1L, type = LikeableType.ACTIVITY, revision = 2L)
 
@@ -132,12 +131,12 @@ class BaseRepositoryLikeRecordsTest {
         assertTrue(store.state.value.feedsById.getValue(1L).likes.isEmpty())
     }
 
-    private fun stubLikeResponse(
+    private suspend fun stubLikeResponse(
         request: GraphQLOperationRequest<ToggleLikeVariables>,
         likes: List<UserBase>,
     ) {
-        val call = responseCall(AniListContainer(DataContainer(likes), errors = null))
-        `when`(service.toggleLike(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(likes), errors = null))
+        `when`(service.toggleLike(request)).thenReturn(response)
     }
 
     private fun userEntity(id: Long, name: String): UserBase = UserBase(name = name).apply {
@@ -178,12 +177,7 @@ class BaseRepositoryLikeRecordsTest {
         revision = revision,
     )
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <R> responseCall(
+    private fun <R> success(
         body: AniListContainer<R>,
-    ): Call<AniListContainer<R>> {
-        val call = mock(Call::class.java) as Call<AniListContainer<R>>
-        `when`(call.execute()).thenReturn(Response.success(body))
-        return call
-    }
+    ): Response<AniListContainer<R>> = Response.success(body)
 }

--- a/app/src/test/java/com/mxt/anitrend/repository/BrowseMediaListCollectionRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/BrowseMediaListCollectionRepositoryTest.kt
@@ -31,7 +31,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -55,9 +54,7 @@ class BrowseMediaListCollectionRepositoryTest {
             ioDispatcher = testDispatcher,
             mediaListStore = mediaListStore,
         )
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer(
                     data = collectionData(
@@ -102,9 +99,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection parses custom lists and advanced scores JSON scalars`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer(
                     data = collectionData(
@@ -154,9 +149,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection degrades null wrong-shape and non-string non-numeric JSON scalars`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer(
                     data = collectionData(
@@ -221,9 +214,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection skips null lists and null entries while preserving order`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer(
                     data = collectionData(
@@ -254,9 +245,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection GraphQL error returns failed Result with message`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer<MediaListCollectionData>(
                     data = null,
@@ -281,9 +270,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection empty body returns failed Result`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(Response.success(null))
 
         val result = repository.getMediaListCollection(
             userId = 42L,
@@ -301,9 +288,7 @@ class BrowseMediaListCollectionRepositoryTest {
     @Test
     fun `getMediaListCollection null root collection returns failed Result`() = runTest {
         val repository = BrowseRepository(browseService = service, ioDispatcher = testDispatcher)
-        val call = collectionCall()
-        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaListCollection(collectionRequest())).thenReturn(
             Response.success(
                 GraphContainer<MediaListCollectionData>(
                     data = MediaListCollectionData(mediaListCollection = null),
@@ -324,9 +309,6 @@ class BrowseMediaListCollectionRepositoryTest {
         assertTrue(result.isFailure)
         assertEquals("Empty response body", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun collectionCall(): Call<GraphContainer<MediaListCollectionData>> = mock(Call::class.java) as Call<GraphContainer<MediaListCollectionData>>
 
     private fun collectionRequest() = MediaListCollection.request(
         userId = 42,

--- a/app/src/test/java/com/mxt/anitrend/repository/BrowseReviewRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/BrowseReviewRepositoryTest.kt
@@ -27,7 +27,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -58,8 +57,8 @@ class BrowseReviewRepositoryTest {
             sort = listOf(ReviewSort.CREATED_AT_DESC),
             asHtml = false,
         )
-        val call = call(AniListContainer(DataContainer(pageContainer), null))
-        `when`(service.getReviewBrowse(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(pageContainer), null))
+        `when`(service.getReviewBrowse(request)).thenReturn(response)
         val queryKey = ReviewQueryKey(mediaId = 100L, mediaType = MediaType.ANIME, sort = ReviewSort.CREATED_AT_DESC)
 
         val result = repository.getReviewBrowse(
@@ -91,8 +90,8 @@ class BrowseReviewRepositoryTest {
     fun `rateReview returns legacy Review and commits ReviewRated with mapped record`() = runTest {
         val rated = review(id = 42L, mediaId = 100L, rating = 55, ratingAmount = 3, userRating = "UP_VOTE")
         val request = RateReview.request(id = 42, rating = ReviewRating.UP_VOTE, asHtml = false)
-        val call = call(AniListContainer(DataContainer(rated), null))
-        `when`(service.rateReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(rated), null))
+        `when`(service.rateReview(request)).thenReturn(response)
 
         val result = repository.rateReview(
             id = 42L,
@@ -128,8 +127,8 @@ class BrowseReviewRepositoryTest {
             privateValue = false,
             asHtml = false,
         )
-        val call = call(AniListContainer(DataContainer(saved), null))
-        `when`(service.saveReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(saved), null))
+        `when`(service.saveReview(request)).thenReturn(response)
 
         val result = repository.saveReview(
             id = null,
@@ -177,8 +176,8 @@ class BrowseReviewRepositoryTest {
             privateValue = false,
             asHtml = false,
         )
-        val call = call(AniListContainer(DataContainer(saved), null))
-        `when`(service.saveReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(saved), null))
+        `when`(service.saveReview(request)).thenReturn(response)
 
         val result = repository.saveReview(
             id = null,
@@ -223,8 +222,8 @@ class BrowseReviewRepositoryTest {
             privateValue = false,
             asHtml = false,
         )
-        val call = call(AniListContainer(DataContainer(saved), null))
-        `when`(service.saveReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(saved), null))
+        `when`(service.saveReview(request)).thenReturn(response)
 
         val result = repository.saveReview(
             id = 12,
@@ -258,8 +257,8 @@ class BrowseReviewRepositoryTest {
             ),
         )
         val request = DeleteReview.request(id = 9)
-        val call = call(AniListContainer(DataContainer(DeleteState(true)), null))
-        `when`(service.deleteReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(DeleteState(true)), null))
+        `when`(service.deleteReview(request)).thenReturn(response)
 
         val result = repository.deleteReview(id = 9L, commitToStore = true, revision = 2L)
 
@@ -289,8 +288,8 @@ class BrowseReviewRepositoryTest {
             sort = listOf(ReviewSort.CREATED_AT_DESC),
             asHtml = false,
         )
-        val call = call(AniListContainer(DataContainer(pageContainer), null))
-        `when`(service.getReviewBrowse(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(pageContainer), null))
+        `when`(service.getReviewBrowse(request)).thenReturn(response)
 
         repository.getReviewBrowse(
             page = 1,
@@ -312,8 +311,8 @@ class BrowseReviewRepositoryTest {
     fun `review store is never committed legacy Review entities`() = runTest {
         val rated = review(id = 55L, mediaId = 100L, rating = 77)
         val request = RateReview.request(id = 55, rating = ReviewRating.UP_VOTE, asHtml = false)
-        val call = call(AniListContainer(DataContainer(rated), null))
-        `when`(service.rateReview(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(rated), null))
+        `when`(service.rateReview(request)).thenReturn(response)
 
         repository.rateReview(
             id = 55L,
@@ -346,10 +345,5 @@ class BrowseReviewRepositoryTest {
         media.type = MediaType.ANIME.name
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> call(body: T): Call<T> {
-        val call = mock(Call::class.java) as Call<T>
-        `when`(call.execute()).thenReturn(Response.success(body))
-        return call
-    }
+    private fun <T> success(body: T): Response<T> = Response.success(body)
 }

--- a/app/src/test/java/com/mxt/anitrend/repository/CharacterRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/CharacterRepositoryTest.kt
@@ -25,7 +25,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 import com.mxt.anitrend.model.entity.base.MediaBase as MediaEntity
 
@@ -41,10 +40,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterBase success maps GraphContainer data to CharacterRecord`() = runTest {
-        val call = characterBaseCall()
         val request = CharacterBase.request(id = 1)
-        `when`(service.getCharacterBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = characterBaseData(),
@@ -65,10 +62,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterBase GraphQL error returns failed Result with message`() = runTest {
-        val call = characterBaseCall()
         val request = CharacterBase.request(id = 1)
-        `when`(service.getCharacterBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterBase(request)).thenReturn(
             Response.success(
                 GraphContainer<CharacterBaseData>(
                     data = null,
@@ -85,10 +80,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterBase null body returns failed Result`() = runTest {
-        val call = characterBaseCall()
         val request = CharacterBase.request(id = 1)
-        `when`(service.getCharacterBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getCharacterBase(request)).thenReturn(Response.success(null))
 
         val result = repository.getCharacterBase(id = 1L)
 
@@ -98,10 +91,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterBase null data returns failed Result`() = runTest {
-        val call = characterBaseCall()
         val request = CharacterBase.request(id = 1)
-        `when`(service.getCharacterBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterBase(request)).thenReturn(
             Response.success(
                 GraphContainer<CharacterBaseData>(
                     data = null,
@@ -118,10 +109,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterBase null root returns failed Result`() = runTest {
-        val call = characterBaseCall()
         val request = CharacterBase.request(id = 1)
-        `when`(service.getCharacterBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = CharacterBaseData(character = null),
@@ -138,10 +127,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterOverview success maps GraphContainer data to MediaCharacter`() = runTest {
-        val call = characterOverviewCall()
         val request = CharacterOverview.request(id = 2, asHtml = true)
-        `when`(service.getCharacterOverview(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterOverview(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = characterOverviewData(),
@@ -163,10 +150,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterOverview GraphQL error returns failed Result with message`() = runTest {
-        val call = characterOverviewCall()
         val request = CharacterOverview.request(id = 2, asHtml = false)
-        `when`(service.getCharacterOverview(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterOverview(request)).thenReturn(
             Response.success(
                 GraphContainer<CharacterOverviewData>(
                     data = null,
@@ -183,10 +168,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterOverview null body returns failed Result`() = runTest {
-        val call = characterOverviewCall()
         val request = CharacterOverview.request(id = 2, asHtml = false)
-        `when`(service.getCharacterOverview(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getCharacterOverview(request)).thenReturn(Response.success(null))
 
         val result = repository.getCharacterOverview(id = 2L)
 
@@ -196,10 +179,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterOverview null data returns failed Result`() = runTest {
-        val call = characterOverviewCall()
         val request = CharacterOverview.request(id = 2, asHtml = false)
-        `when`(service.getCharacterOverview(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterOverview(request)).thenReturn(
             Response.success(
                 GraphContainer<CharacterOverviewData>(
                     data = null,
@@ -216,10 +197,8 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterOverview null root returns failed Result`() = runTest {
-        val call = characterOverviewCall()
         val request = CharacterOverview.request(id = 2, asHtml = false)
-        `when`(service.getCharacterOverview(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterOverview(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = CharacterOverviewData(character = null),
@@ -236,7 +215,6 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterMedia keeps legacy AniListContainer response handling`() = runTest {
-        val call = characterMediaCall()
         val request = CharacterMedia.request(id = 3, page = null, perPage = null, sort = null, type = null)
         val expected = ConnectionContainer<PageContainer<MediaEntity>>().also { connection ->
             connection.connection = PageContainer<MediaEntity>().also { page ->
@@ -247,8 +225,7 @@ class CharacterRepositoryTest {
                 )
             }
         }
-        `when`(service.getCharacterMedia(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterMedia(request)).thenReturn(
             Response.success(
                 AniListContainer(
                     data = DataContainer(result = expected),
@@ -266,7 +243,6 @@ class CharacterRepositoryTest {
 
     @Test
     fun `getCharacterActors keeps legacy AniListContainer response handling`() = runTest {
-        val call = characterActorsCall()
         val request = CharacterActors.request(id = 4, page = null, perPage = null, sort = null)
         val expected = ConnectionContainer<EdgeContainer<MediaEdge>>().also { connection ->
             connection.connection = EdgeContainer<MediaEdge>().also { edgeContainer ->
@@ -277,8 +253,7 @@ class CharacterRepositoryTest {
                 )
             }
         }
-        `when`(service.getCharacterActors(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getCharacterActors(request)).thenReturn(
             Response.success(
                 AniListContainer(
                     data = DataContainer(result = expected),
@@ -293,18 +268,6 @@ class CharacterRepositoryTest {
         assertSame(expected, result.getOrThrow())
         assertEquals("MAIN", result.getOrThrow().connection.edges.single().characterRole)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun characterBaseCall(): Call<GraphContainer<CharacterBaseData>> = mock(Call::class.java) as Call<GraphContainer<CharacterBaseData>>
-
-    @Suppress("UNCHECKED_CAST")
-    private fun characterOverviewCall(): Call<GraphContainer<CharacterOverviewData>> = mock(Call::class.java) as Call<GraphContainer<CharacterOverviewData>>
-
-    @Suppress("UNCHECKED_CAST")
-    private fun characterMediaCall(): Call<AniListContainer<ConnectionContainer<PageContainer<MediaEntity>>>> = mock(Call::class.java) as Call<AniListContainer<ConnectionContainer<PageContainer<MediaEntity>>>>
-
-    @Suppress("UNCHECKED_CAST")
-    private fun characterActorsCall(): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>> = mock(Call::class.java) as Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>>
 
     private fun characterBaseData(): CharacterBaseData = CharacterBaseData(
         character = CharacterBaseData.Character(

--- a/app/src/test/java/com/mxt/anitrend/repository/CrunchyrollRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/CrunchyrollRepositoryTest.kt
@@ -1,0 +1,103 @@
+package com.mxt.anitrend.repository
+
+import com.mxt.anitrend.model.api.retro.crunchy.EpisodeService
+import com.mxt.anitrend.model.entity.crunchy.Channel
+import com.mxt.anitrend.model.entity.crunchy.Rss
+import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import retrofit2.Response
+
+/**
+ * Focused tests for the CrunchyrollRepository suspend response boundary.
+ *
+ * Transport exceptions thrown by the service must surface as Result.failure
+ * instead of escaping the withContext/runCatching boundary, while successful,
+ * HTTP-error, and empty-body responses keep their existing behavior.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CrunchyrollRepositoryTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val feedService = mock(EpisodeService::class.java)
+    private val crunchyrollService = mock(EpisodeService::class.java)
+    private val repository = CrunchyrollRepository(
+        feedService = feedService,
+        crunchyrollService = crunchyrollService,
+        ioDispatcher = testDispatcher,
+    )
+
+    @Test
+    fun `getLatestFeed returns failure when service throws transport exception`() = runTest {
+        val transportError = IOException("network unreachable")
+        `when`(feedService.getLatestFeed()).thenAnswer { throw transportError }
+
+        val result = repository.getLatestFeed()
+
+        assertTrue(result.isFailure)
+        assertEquals(transportError, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getPopularFeed returns failure when service throws transport exception`() = runTest {
+        val transportError = IOException("network unreachable")
+        `when`(feedService.getPopularFeed()).thenAnswer { throw transportError }
+
+        val result = repository.getPopularFeed()
+
+        assertTrue(result.isFailure)
+        assertEquals(transportError, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getRss returns failure when service throws transport exception`() = runTest {
+        val transportError = IOException("network unreachable")
+        `when`(crunchyrollService.getRssByUrl("https://example.com/rss")).thenAnswer { throw transportError }
+
+        val result = repository.getRss("https://example.com/rss")
+
+        assertTrue(result.isFailure)
+        assertEquals(transportError, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getLatestFeed returns body for successful response`() = runTest {
+        val rss = Rss(Channel())
+        `when`(feedService.getLatestFeed()).thenReturn(Response.success(rss))
+
+        val result = repository.getLatestFeed()
+
+        assertTrue(result.isSuccess)
+        assertEquals(rss, result.getOrThrow())
+    }
+
+    @Test
+    fun `getPopularFeed returns failure with apiError message for HTTP error`() = runTest {
+        val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
+            .toResponseBody("application/json".toMediaType())
+        `when`(feedService.getPopularFeed()).thenReturn(Response.error(500, errorBody))
+
+        val result = repository.getPopularFeed()
+
+        assertTrue(result.isFailure)
+        assertEquals("Server exploded", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `getRss returns failure with empty body message when body is null`() = runTest {
+        `when`(crunchyrollService.getRssByUrl(null)).thenReturn(Response.success(null))
+
+        val result = repository.getRss(null)
+
+        assertTrue(result.isFailure)
+        assertEquals("Empty response body", result.exceptionOrNull()?.message)
+    }
+}

--- a/app/src/test/java/com/mxt/anitrend/repository/FeedRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/FeedRepositoryTest.kt
@@ -29,7 +29,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 import com.mxt.anitrend.model.entity.anilist.FeedList as FeedListEntity
 
@@ -63,8 +62,8 @@ class FeedRepositoryTest {
     @Test
     fun `getFeedListRecords success commits FeedRecord page to store`() = runTest {
         val request = FeedList.request(page = 1, perPage = 10, id = null, isFollowing = null, userId = null, type = null, isMixed = null, asHtml = false)
-        val call = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
-        `when`(service.getFeedList(request)).thenReturn(call)
+        val response = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
+        `when`(service.getFeedList(request)).thenReturn(response)
 
         val result = repository.getFeedListRecords(
             page = 1,
@@ -89,8 +88,8 @@ class FeedRepositoryTest {
     @Test
     fun `legacy getFeedList still returns entity typed page`() = runTest {
         val request = FeedList.request(page = 1, perPage = 10, id = null, isFollowing = null, userId = null, type = null, isMixed = null, asHtml = false)
-        val call = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
-        `when`(service.getFeedList(request)).thenReturn(call)
+        val response = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
+        `when`(service.getFeedList(request)).thenReturn(response)
 
         val result = repository.getFeedList(page = 1, perPage = 10)
 
@@ -117,8 +116,8 @@ class FeedRepositoryTest {
     @Test
     fun `getFeedMessageRecords commits FeedRecord page to store`() = runTest {
         val request = FeedMessage.request(page = 1, perPage = 10, messengerId = 7, userId = null, asHtml = false)
-        val call = pageCall(page = 1, feeds = listOf(feedEntity(1L)))
-        `when`(service.getFeedMessage(request)).thenReturn(call)
+        val response = pageCall(page = 1, feeds = listOf(feedEntity(1L)))
+        `when`(service.getFeedMessage(request)).thenReturn(response)
         val outboxKey = FeedQueryKey(
             scope = FeedScope.MESSAGE_OUTBOX,
             userId = 7,
@@ -147,8 +146,8 @@ class FeedRepositoryTest {
             replies = listOf(replyEntity(10L, text = "first"), replyEntity(11L, text = "second"))
         }
         val request = FeedListReply.request(id = 5, asHtml = false)
-        val call = responseCall(AniListContainer(DataContainer(feed), errors = null))
-        `when`(service.getFeedListReply(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(feed), errors = null))
+        `when`(service.getFeedListReply(request)).thenReturn(response)
 
         val result = repository.getFeedListReplyRecords(id = 5L, readToken = 3L)
 
@@ -166,8 +165,8 @@ class FeedRepositoryTest {
     @Test
     fun `saveTextActivityRecord commits FeedUpserted with revision`() = runTest {
         val request = SaveTextActivity.request(id = null, text = "hello", asHtml = false)
-        val call = responseCall(AniListContainer(DataContainer(feedEntity(1L, text = "hello")), errors = null))
-        `when`(service.saveTextActivity(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(feedEntity(1L, text = "hello")), errors = null))
+        `when`(service.saveTextActivity(request)).thenReturn(response)
 
         val result = repository.saveTextActivityRecord(text = "hello", revision = 7L)
 
@@ -182,8 +181,8 @@ class FeedRepositoryTest {
     @Test
     fun `saveMessageActivityRecord commits FeedUpserted`() = runTest {
         val request = SaveMessageActivity.request(id = null, message = "hi", recipientId = 9, asHtml = false)
-        val call = responseCall(AniListContainer(DataContainer(feedEntity(1L, text = "hi")), errors = null))
-        `when`(service.saveMessageActivity(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(feedEntity(1L, text = "hi")), errors = null))
+        `when`(service.saveMessageActivity(request)).thenReturn(response)
 
         val result = repository.saveMessageActivityRecord(message = "hi", recipientId = 9L, revision = 2L)
 
@@ -195,8 +194,8 @@ class FeedRepositoryTest {
     fun `saveActivityReplyRecord commits ReplyUpserted under parent feed`() = runTest {
         seedFeed(id = 5L)
         val request = SaveActivityReply.request(id = null, activityId = 5, text = "thanks", asHtml = false)
-        val call = responseCall(AniListContainer(DataContainer(replyEntity(10L, text = "thanks")), errors = null))
-        `when`(service.saveActivityReply(request)).thenReturn(call)
+        val response = success(AniListContainer(DataContainer(replyEntity(10L, text = "thanks")), errors = null))
+        `when`(service.saveActivityReply(request)).thenReturn(response)
 
         val result = repository.saveActivityReplyRecord(activityId = 5L, text = "thanks", revision = 4L)
 
@@ -211,13 +210,13 @@ class FeedRepositoryTest {
     @Test
     fun `deleteActivity commits FeedDeleted and converges store`() = runTest {
         val saveRequest = SaveTextActivity.request(id = null, text = "to delete", asHtml = false)
-        val saveCall = responseCall(AniListContainer(DataContainer(feedEntity(1L, text = "to delete")), errors = null))
+        val saveCall = success(AniListContainer(DataContainer(feedEntity(1L, text = "to delete")), errors = null))
         `when`(service.saveTextActivity(saveRequest)).thenReturn(saveCall)
         repository.saveTextActivityRecord(text = "to delete", revision = 1L)
         assertTrue(store.state.value.feedsById.containsKey(1L))
 
         val deleteRequest = DeleteActivity.request(id = 1)
-        val deleteCall = responseCall(AniListContainer(DataContainer(DeleteState(isDeleted = true)), errors = null))
+        val deleteCall = success(AniListContainer(DataContainer(DeleteState(isDeleted = true)), errors = null))
         `when`(service.deleteActivity(deleteRequest)).thenReturn(deleteCall)
 
         val result = repository.deleteActivity(id = 1L, revision = 2L)
@@ -230,8 +229,8 @@ class FeedRepositoryTest {
     @Test
     fun `failed save is server authoritative and leaves store unchanged`() = runTest {
         val request = SaveTextActivity.request(id = null, text = "boom", asHtml = false)
-        val call = responseCall(AniListContainer<FeedListEntity>(data = null, errors = null))
-        `when`(service.saveTextActivity(request)).thenReturn(call)
+        val response = success(AniListContainer<FeedListEntity>(data = null, errors = null))
+        `when`(service.saveTextActivity(request)).thenReturn(response)
 
         val result = repository.saveTextActivityRecord(text = "boom", revision = 1L)
 
@@ -243,12 +242,12 @@ class FeedRepositoryTest {
     @Test
     fun `stale revision save is rejected by store`() = runTest {
         val newerRequest = SaveTextActivity.request(id = null, text = "newer", asHtml = false)
-        val newerCall = responseCall(AniListContainer(DataContainer(feedEntity(1L, text = "newer")), errors = null))
+        val newerCall = success(AniListContainer(DataContainer(feedEntity(1L, text = "newer")), errors = null))
         `when`(service.saveTextActivity(newerRequest)).thenReturn(newerCall)
         repository.saveTextActivityRecord(text = "newer", revision = 10L)
 
         val olderRequest = SaveTextActivity.request(id = null, text = "older", asHtml = false)
-        val olderCall = responseCall(AniListContainer(DataContainer(feedEntity(1L, text = "older")), errors = null))
+        val olderCall = success(AniListContainer(DataContainer(feedEntity(1L, text = "older")), errors = null))
         `when`(service.saveTextActivity(olderRequest)).thenReturn(olderCall)
         repository.saveTextActivityRecord(text = "older", revision = 9L)
 
@@ -306,20 +305,15 @@ class FeedRepositoryTest {
     private fun pageCall(
         page: Int,
         feeds: List<FeedListEntity>,
-    ): Call<AniListContainer<PageContainer<FeedListEntity>>> {
+    ): Response<AniListContainer<PageContainer<FeedListEntity>>> {
         val content = PageContainer<FeedListEntity>().apply {
             pageData = feeds
             pageInfo = PageInfo(total = feeds.size, perPage = 10, currentPage = page).apply { setHasNextPage(false) }
         }
-        return responseCall(AniListContainer(DataContainer(content), errors = null))
+        return success(AniListContainer(DataContainer(content), errors = null))
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <R> responseCall(
+    private fun <R> success(
         body: AniListContainer<R>,
-    ): Call<AniListContainer<R>> {
-        val call = mock(Call::class.java) as Call<AniListContainer<R>>
-        `when`(call.execute()).thenReturn(Response.success(body))
-        return call
-    }
+    ): Response<AniListContainer<R>> = Response.success(body)
 }

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaBaseRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaBaseRecordRepositoryTest.kt
@@ -19,7 +19,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -37,10 +36,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord success maps GraphContainer data to MediaDetailRecord`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaBaseRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaBaseData(
@@ -73,10 +70,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord success maps nullable mediaListEntry`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaBaseRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaBaseData(
@@ -98,10 +93,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaBaseRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaBaseData>(
                     data = null,
@@ -118,10 +111,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord null body returns failed Result`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaBaseRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaBaseRecord(id = 7L, type = MediaType.ANIME, isAdult = false)
 
@@ -131,10 +122,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord null data returns failed Result`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaBaseRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaBaseData>(
                     data = null,
@@ -151,10 +140,8 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord null root media returns failed Result`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaBaseRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaBaseData(media = null),
@@ -171,21 +158,16 @@ class MediaBaseRecordRepositoryTest {
 
     @Test
     fun `getMediaBaseRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaBaseCall()
         val request = MediaBase.request(id = 7, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaBaseRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaBaseRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaBaseRecord(id = 7L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaBaseCall(): Call<GraphContainer<MediaBaseData>> = mock(Call::class.java) as Call<GraphContainer<MediaBaseData>>
 
     private fun mediaBaseData(
         id: Int,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaCharactersRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaCharactersRecordRepositoryTest.kt
@@ -20,7 +20,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -38,10 +37,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord success maps GraphContainer data to MediaCharactersRecord`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaCharactersData(
@@ -97,7 +94,6 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord forwards pagination and sort request inputs`() = runTest {
-        val call = mediaCharactersCall()
         val sort = listOf(CharacterSort.ROLE, CharacterSort.RELEVANCE, CharacterSort.ID)
         val request = MediaCharacters.request(
             id = 21,
@@ -107,8 +103,7 @@ class MediaCharactersRecordRepositoryTest {
             perPage = 50,
             sort = sort,
         )
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaCharactersData(
@@ -156,10 +151,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord preserves nullable optional blocks`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaCharactersData(),
@@ -178,10 +171,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaCharactersData>(
                     data = null,
@@ -198,10 +189,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord null body returns failed Result`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaCharactersRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -211,10 +200,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord null data returns failed Result`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaCharactersData>(
                     data = null,
@@ -231,10 +218,8 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord null root media returns failed Result`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaCharactersData(media = null),
@@ -251,21 +236,16 @@ class MediaCharactersRecordRepositoryTest {
 
     @Test
     fun `getMediaCharactersRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaCharactersCall()
         val request = MediaCharacters.request(id = 21, type = MediaType.ANIME, isAdult = false, sort = null)
-        `when`(service.getMediaCharactersRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaCharactersRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaCharactersRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaCharactersCall(): Call<GraphContainer<MediaCharactersData>> = mock(Call::class.java) as Call<GraphContainer<MediaCharactersData>>
 
     private fun mediaCharactersData(
         edges: List<MediaCharactersData.MediaCharactersEdges?>? = null,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaEpisodesRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaEpisodesRecordRepositoryTest.kt
@@ -18,7 +18,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -36,10 +35,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord success maps GraphContainer data to MediaEpisodesRecord`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaEpisodesData(
@@ -76,10 +73,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord preserves nullable optional blocks`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaEpisodesData(),
@@ -97,10 +92,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaEpisodesData>(
                     data = null,
@@ -117,10 +110,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord null body returns failed Result`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaEpisodesRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -130,10 +121,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord null data returns failed Result`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaEpisodesData>(
                     data = null,
@@ -150,10 +139,8 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord null root media returns failed Result`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaEpisodesData(media = null),
@@ -170,21 +157,16 @@ class MediaEpisodesRecordRepositoryTest {
 
     @Test
     fun `getMediaEpisodesRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaEpisodesCall()
         val request = MediaEpisodes.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaEpisodesRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaEpisodesRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaEpisodesRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaEpisodesCall(): Call<GraphContainer<MediaEpisodesData>> = mock(Call::class.java) as Call<GraphContainer<MediaEpisodesData>>
 
     private fun mediaEpisodesData(
         externalLinks: List<MediaEpisodesData.MediaExternalLinks?>? = null,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaOverviewRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaOverviewRecordRepositoryTest.kt
@@ -20,7 +20,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -38,10 +37,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord success maps GraphContainer data to MediaOverviewRecord`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = overviewData(
@@ -74,10 +71,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord maps optional trailer studios and tags blocks`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaOverviewData(
@@ -134,10 +129,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord preserves nullable optional blocks`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaOverviewData(
@@ -162,10 +155,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord forwards asHtml to the generated request`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = true)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaOverviewData(
@@ -184,10 +175,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaOverviewData>(
                     data = null,
@@ -204,10 +193,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord null body returns failed Result`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaOverviewRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -217,10 +204,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord null data returns failed Result`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaOverviewData>(
                     data = null,
@@ -237,10 +222,8 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord null root media returns failed Result`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaOverviewData(media = null),
@@ -257,21 +240,16 @@ class MediaOverviewRecordRepositoryTest {
 
     @Test
     fun `getMediaOverviewRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = overviewCall()
         val request = MediaOverview.request(id = 21, type = MediaType.ANIME, isAdult = false, asHtml = false)
-        `when`(service.getMediaOverviewRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaOverviewRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaOverviewRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun overviewCall(): Call<GraphContainer<MediaOverviewData>> = mock(Call::class.java) as Call<GraphContainer<MediaOverviewData>>
 
     private fun overviewData(
         id: Int,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaRecommendationsRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaRecommendationsRepositoryTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -32,10 +31,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations success maps GraphContainer nodes preserving order and page info`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = recommendationMediaData(nodes = listOf(firstNode(), secondNode())),
@@ -61,10 +58,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations success returns empty result for empty nodes`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = recommendationMediaData(nodes = emptyList()),
@@ -83,10 +78,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations GraphQL error returns failed Result with message`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer<RecommendationMediaData>(
                     data = null,
@@ -103,10 +96,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations null body returns failed Result`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaRecommendations(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaRecommendations(id = 7L, type = MediaType.MANGA, isAdult = false)
 
@@ -116,10 +107,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations null data returns failed Result`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer<RecommendationMediaData>(
                     data = null,
@@ -136,10 +125,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations null root media returns failed Result`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = RecommendationMediaData(media = null),
@@ -156,10 +143,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations null recommendations block returns failed Result`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = RecommendationMediaData(
@@ -178,10 +163,8 @@ class MediaRecommendationsRepositoryTest {
 
     @Test
     fun `getMediaRecommendations drops null nodes while preserving order`() = runTest {
-        val call = recommendationCall()
         val request = RecommendationMedia.request(id = 7, type = MediaType.MANGA, isAdult = false, page = null, perPage = null, sort = null)
-        `when`(service.getMediaRecommendations(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRecommendations(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = recommendationMediaData(nodes = listOf(firstNode(), null, secondNode())),
@@ -196,9 +179,6 @@ class MediaRecommendationsRepositoryTest {
         val page: RecommendationPageResult = result.getOrThrow()
         assertEquals(listOf(1L, 4L), page.recommendations.map { it.id })
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun recommendationCall(): Call<GraphContainer<RecommendationMediaData>> = mock(Call::class.java) as Call<GraphContainer<RecommendationMediaData>>
 
     private fun recommendationMediaData(
         nodes: List<RecommendationMediaData.MediaRecommendationsNodes?>,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaRelationsRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaRelationsRecordRepositoryTest.kt
@@ -23,7 +23,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -41,10 +40,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord success maps GraphContainer data to MediaRelationsRecord`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaRelationsData(
@@ -121,10 +118,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord preserves nullable optional blocks`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaRelationsData(),
@@ -143,10 +138,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaRelationsData>(
                     data = null,
@@ -163,10 +156,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord null body returns failed Result`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaRelationsRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -176,10 +167,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord null data returns failed Result`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaRelationsData>(
                     data = null,
@@ -196,10 +185,8 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord null root media returns failed Result`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaRelationsData(media = null),
@@ -216,21 +203,16 @@ class MediaRelationsRecordRepositoryTest {
 
     @Test
     fun `getMediaRelationsRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaRelationsCall()
         val request = MediaRelations.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaRelationsRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaRelationsRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaRelationsRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaRelationsCall(): Call<GraphContainer<MediaRelationsData>> = mock(Call::class.java) as Call<GraphContainer<MediaRelationsData>>
 
     private fun mediaRelationsData(
         edges: List<MediaRelationsData.MediaRelationsEdges?>? = null,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaSocialRecordsRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaSocialRecordsRepositoryTest.kt
@@ -18,7 +18,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -41,8 +40,8 @@ class MediaSocialRecordsRepositoryTest {
     @Test
     fun `getMediaSocialRecords commits FeedRecord page to store under MEDIA scope`() = runTest {
         val request = MediaSocial.request(mediaId = 7, isFollowing = true, page = 1, perPage = 10)
-        val call = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
-        `when`(service.getMediaSocial(request)).thenReturn(call)
+        val response = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
+        `when`(service.getMediaSocial(request)).thenReturn(response)
         val mediaKey = FeedQueryKey(
             scope = FeedScope.MEDIA,
             userId = null,
@@ -75,8 +74,8 @@ class MediaSocialRecordsRepositoryTest {
     @Test
     fun `legacy getMediaSocial still returns entity typed page`() = runTest {
         val request = MediaSocial.request(mediaId = 7, isFollowing = true, page = 1, perPage = 10)
-        val call = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
-        `when`(service.getMediaSocial(request)).thenReturn(call)
+        val response = pageCall(page = 1, feeds = listOf(feedEntity(1L), feedEntity(2L)))
+        `when`(service.getMediaSocial(request)).thenReturn(response)
 
         val result = repository.getMediaSocial(
             mediaId = 7L,
@@ -93,8 +92,8 @@ class MediaSocialRecordsRepositoryTest {
     @Test
     fun `getMediaSocialRecords failure returns failed Result and does not commit`() = runTest {
         val request = MediaSocial.request(mediaId = 7, isFollowing = true, page = 1, perPage = 10)
-        val call = responseCall(AniListContainer<PageContainer<FeedList>>(data = null, errors = null))
-        `when`(service.getMediaSocial(request)).thenReturn(call)
+        val response = success(AniListContainer<PageContainer<FeedList>>(data = null, errors = null))
+        `when`(service.getMediaSocial(request)).thenReturn(response)
 
         val result = repository.getMediaSocialRecords(mediaId = 7L, isFollowing = true, page = 1, perPage = 10)
 
@@ -114,20 +113,15 @@ class MediaSocialRecordsRepositoryTest {
     private fun pageCall(
         page: Int,
         feeds: List<FeedList>,
-    ): Call<AniListContainer<PageContainer<FeedList>>> {
+    ): Response<AniListContainer<PageContainer<FeedList>>> {
         val content = PageContainer<FeedList>().apply {
             pageData = feeds
             pageInfo = PageInfo(total = feeds.size, perPage = 10, currentPage = page).apply { setHasNextPage(false) }
         }
-        return responseCall(AniListContainer(DataContainer(content), errors = null))
+        return success(AniListContainer(DataContainer(content), errors = null))
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <R> responseCall(
+    private fun <R> success(
         body: AniListContainer<R>,
-    ): Call<AniListContainer<R>> {
-        val call = mock(Call::class.java) as Call<AniListContainer<R>>
-        `when`(call.execute()).thenReturn(Response.success(body))
-        return call
-    }
+    ): Response<AniListContainer<R>> = Response.success(body)
 }

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaStaffRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaStaffRecordRepositoryTest.kt
@@ -20,7 +20,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -38,10 +37,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord success maps GraphContainer data to MediaStaffRecord`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaStaffData(
@@ -99,7 +96,6 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord forwards pagination and sort request inputs`() = runTest {
-        val call = mediaStaffCall()
         val sort = listOf(StaffSort.ROLE, StaffSort.RELEVANCE, StaffSort.ID)
         val request = MediaStaff.request(
             id = 21,
@@ -109,8 +105,7 @@ class MediaStaffRecordRepositoryTest {
             page = 3,
             perPage = 50,
         )
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaStaffData(
@@ -159,10 +154,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord preserves nullable optional blocks`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaStaffData(),
@@ -181,10 +174,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaStaffData>(
                     data = null,
@@ -201,10 +192,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord null body returns failed Result`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaStaffRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaStaffRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -214,10 +203,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord null data returns failed Result`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaStaffData>(
                     data = null,
@@ -234,10 +221,8 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord null root media returns failed Result`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStaffRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaStaffData(media = null),
@@ -254,21 +239,16 @@ class MediaStaffRecordRepositoryTest {
 
     @Test
     fun `getMediaStaffRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaStaffCall()
         val request = MediaStaff.request(id = 21, type = MediaType.ANIME, sort = null, isAdult = false)
-        `when`(service.getMediaStaffRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaStaffRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaStaffRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaStaffCall(): Call<GraphContainer<MediaStaffData>> = mock(Call::class.java) as Call<GraphContainer<MediaStaffData>>
 
     private fun mediaStaffData(
         edges: List<MediaStaffData.MediaStaffEdges?>? = null,

--- a/app/src/test/java/com/mxt/anitrend/repository/MediaStatsRecordRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/MediaStatsRecordRepositoryTest.kt
@@ -22,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -40,10 +39,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord success maps GraphContainer data to MediaStatsRecord`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStatsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaStatsData(
@@ -100,10 +97,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord preserves nullable optional blocks`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStatsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = mediaStatsData(),
@@ -125,10 +120,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord GraphQL error returns failed Result with message`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStatsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaStatsData>(
                     data = null,
@@ -145,10 +138,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord null body returns failed Result`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getMediaStatsRecord(request)).thenReturn(Response.success(null))
 
         val result = repository.getMediaStatsRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
@@ -158,10 +149,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord null data returns failed Result`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStatsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer<MediaStatsData>(
                     data = null,
@@ -178,10 +167,8 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord null root media returns failed Result`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getMediaStatsRecord(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = MediaStatsData(media = null),
@@ -198,21 +185,16 @@ class MediaStatsRecordRepositoryTest {
 
     @Test
     fun `getMediaStatsRecord HTTP error returns failed Result with server message`() = runTest {
-        val call = mediaStatsCall()
         val request = MediaStats.request(id = 21, type = MediaType.ANIME, isAdult = false)
-        `when`(service.getMediaStatsRecord(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.getMediaStatsRecord(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.getMediaStatsRecord(id = 21L, type = MediaType.ANIME, isAdult = false)
 
         assertTrue(result.isFailure)
         assertEquals("Server exploded", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun mediaStatsCall(): Call<GraphContainer<MediaStatsData>> = mock(Call::class.java) as Call<GraphContainer<MediaStatsData>>
 
     private fun mediaStatsData(
         type: MediaType? = null,

--- a/app/src/test/java/com/mxt/anitrend/repository/StaffRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/StaffRepositoryTest.kt
@@ -15,7 +15,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -30,10 +29,8 @@ class StaffRepositoryTest {
 
     @Test
     fun `getStaffBase success maps GraphContainer data to StaffRecord`() = runTest {
-        val call = staffBaseCall()
         val request = StaffBase.request(id = 5)
-        `when`(service.getStaffBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStaffBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = staffBaseData(),
@@ -54,10 +51,8 @@ class StaffRepositoryTest {
 
     @Test
     fun `getStaffBase GraphQL error returns failed Result with message`() = runTest {
-        val call = staffBaseCall()
         val request = StaffBase.request(id = 5)
-        `when`(service.getStaffBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStaffBase(request)).thenReturn(
             Response.success(
                 GraphContainer<StaffBaseData>(
                     data = null,
@@ -74,10 +69,8 @@ class StaffRepositoryTest {
 
     @Test
     fun `getStaffBase null body returns failed Result`() = runTest {
-        val call = staffBaseCall()
         val request = StaffBase.request(id = 5)
-        `when`(service.getStaffBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getStaffBase(request)).thenReturn(Response.success(null))
 
         val result = repository.getStaffBase(id = 5L)
 
@@ -87,10 +80,8 @@ class StaffRepositoryTest {
 
     @Test
     fun `getStaffBase null root returns failed Result`() = runTest {
-        val call = staffBaseCall()
         val request = StaffBase.request(id = 5)
-        `when`(service.getStaffBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStaffBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StaffBaseData(staff = null),
@@ -107,10 +98,8 @@ class StaffRepositoryTest {
 
     @Test
     fun `getStaffBase unmapped staff name falls back correctly`() = runTest {
-        val call = staffBaseCall()
         val request = StaffBase.request(id = 6)
-        `when`(service.getStaffBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStaffBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StaffBaseData(
@@ -137,9 +126,6 @@ class StaffRepositoryTest {
         assertNull(staff.siteUrl)
         assertFalse(staff.isFavourite)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun staffBaseCall(): Call<GraphContainer<StaffBaseData>> = mock(Call::class.java) as Call<GraphContainer<StaffBaseData>>
 
     private fun staffBaseData(): StaffBaseData = StaffBaseData(
         staff = StaffBaseData.Staff(

--- a/app/src/test/java/com/mxt/anitrend/repository/StudioRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/StudioRepositoryTest.kt
@@ -24,7 +24,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -41,10 +40,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioBase success maps GraphContainer data to StudioRecord`() = runTest {
-        val call = studioBaseCall()
         val request = StudioBase.request(id = 5)
-        `when`(service.getStudioBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StudioBaseData(
@@ -73,10 +70,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioBase GraphQL error returns failed Result with message`() = runTest {
-        val call = studioBaseCall()
         val request = StudioBase.request(id = 5)
-        `when`(service.getStudioBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioBase(request)).thenReturn(
             Response.success(
                 GraphContainer<StudioBaseData>(
                     data = null,
@@ -93,10 +88,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioBase null body returns failed Result`() = runTest {
-        val call = studioBaseCall()
         val request = StudioBase.request(id = 5)
-        `when`(service.getStudioBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getStudioBase(request)).thenReturn(Response.success(null))
 
         val result = repository.getStudioBase(id = 5L)
 
@@ -106,10 +99,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioBase null root returns failed Result`() = runTest {
-        val call = studioBaseCall()
         val request = StudioBase.request(id = 5)
-        `when`(service.getStudioBase(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioBase(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StudioBaseData(studio = null),
@@ -126,15 +117,13 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioMedia success maps GraphContainer data to connection page`() = runTest {
-        val call = studioMediaCall()
         val request = StudioMedia.request(
             id = 5,
             page = 1,
             perPage = 20,
             sort = listOf(MediaSort.POPULARITY_DESC),
         )
-        `when`(service.getStudioMedia(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioMedia(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StudioMediaData(
@@ -180,10 +169,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioMedia GraphQL error returns failed Result with message`() = runTest {
-        val call = studioMediaCall()
         val request = StudioMedia.request(id = 5, page = null, perPage = null, sort = null)
-        `when`(service.getStudioMedia(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioMedia(request)).thenReturn(
             Response.success(
                 GraphContainer<StudioMediaData>(
                     data = null,
@@ -200,10 +187,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioMedia null body returns failed Result`() = runTest {
-        val call = studioMediaCall()
         val request = StudioMedia.request(id = 5, page = null, perPage = null, sort = null)
-        `when`(service.getStudioMedia(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getStudioMedia(request)).thenReturn(Response.success(null))
 
         val result = repository.getStudioMedia(id = 5L)
 
@@ -213,10 +198,8 @@ class StudioRepositoryTest {
 
     @Test
     fun `getStudioMedia null root returns failed Result`() = runTest {
-        val call = studioMediaCall()
         val request = StudioMedia.request(id = 5, page = null, perPage = null, sort = null)
-        `when`(service.getStudioMedia(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getStudioMedia(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = StudioMediaData(studio = null),
@@ -230,12 +213,6 @@ class StudioRepositoryTest {
         assertTrue(result.isFailure)
         assertEquals("Empty response body", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun studioBaseCall(): Call<GraphContainer<StudioBaseData>> = mock(Call::class.java) as Call<GraphContainer<StudioBaseData>>
-
-    @Suppress("UNCHECKED_CAST")
-    private fun studioMediaCall(): Call<GraphContainer<StudioMediaData>> = mock(Call::class.java) as Call<GraphContainer<StudioMediaData>>
 
     private fun studioMediaNode(): StudioMediaData.StudioMediaNodes = StudioMediaData.StudioMediaNodes(
         id = 10,

--- a/app/src/test/java/com/mxt/anitrend/repository/UserRepositoryNotificationsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/UserRepositoryNotificationsTest.kt
@@ -22,7 +22,6 @@ import org.mockito.ArgumentMatchers.argThat
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,10 +38,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications success maps page nodes preserving order and page info`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = userNotificationsData(
@@ -81,10 +78,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications success maps thread and deletion specific fields`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = userNotificationsData(
@@ -120,10 +115,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications success returns empty result for empty nodes`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = userNotificationsData(notifications = emptyList()),
@@ -142,10 +135,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications drops null nodes while preserving order`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = userNotificationsData(
@@ -169,10 +160,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications GraphQL error returns failed Result with message`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer<UserNotificationsData>(
                     data = null,
@@ -189,10 +178,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications null body returns failed Result`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getUserNotifications(request)).thenReturn(Response.success(null))
 
         val result = repository.getUserNotifications()
 
@@ -202,10 +189,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications null data returns failed Result`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer<UserNotificationsData>(
                     data = null,
@@ -222,10 +207,8 @@ class UserRepositoryNotificationsTest {
 
     @Test
     fun `getUserNotifications null page returns failed Result`() = runTest {
-        val call = notificationsCall()
         val request = UserNotifications.request(page = null, perPage = null, type = null, typeIn = null, resetNotificationCount = false)
-        `when`(service.getUserNotifications(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserNotifications(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UserNotificationsData(page = null),
@@ -261,9 +244,6 @@ class UserRepositoryNotificationsTest {
             },
         )
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun notificationsCall(): Call<GraphContainer<UserNotificationsData>> = mock(Call::class.java) as Call<GraphContainer<UserNotificationsData>>
 
     private fun userNotificationsData(
         notifications: List<UserNotificationsData.PageNotifications?>,

--- a/app/src/test/java/com/mxt/anitrend/repository/UserRepositoryStatsTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/UserRepositoryStatsTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import retrofit2.Call
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,10 +30,8 @@ class UserRepositoryStatsTest {
 
     @Test
     fun `getUserStats success maps transport stats to record`() = runTest {
-        val call = statsCall()
         val request = UserStats.request(id = null, userName = "profile")
-        `when`(service.getUserStats(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserStats(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = statsData(animeCount = 6),
@@ -54,10 +51,8 @@ class UserRepositoryStatsTest {
 
     @Test
     fun `getUserStats GraphQL error returns failed Result with message`() = runTest {
-        val call = statsCall()
         val request = UserStats.request(id = null, userName = "profile")
-        `when`(service.getUserStats(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserStats(request)).thenReturn(
             Response.success(
                 GraphContainer<UserStatsData>(
                     data = null,
@@ -74,10 +69,8 @@ class UserRepositoryStatsTest {
 
     @Test
     fun `getUserStats null body returns failed Result`() = runTest {
-        val call = statsCall()
         val request = UserStats.request(id = null, userName = "profile")
-        `when`(service.getUserStats(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.getUserStats(request)).thenReturn(Response.success(null))
 
         val result = repository.getUserStats(userName = "profile")
 
@@ -87,10 +80,8 @@ class UserRepositoryStatsTest {
 
     @Test
     fun `getUserStats null data returns failed Result`() = runTest {
-        val call = statsCall()
         val request = UserStats.request(id = null, userName = "profile")
-        `when`(service.getUserStats(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.getUserStats(request)).thenReturn(
             Response.success(
                 GraphContainer<UserStatsData>(
                     data = null,
@@ -104,9 +95,6 @@ class UserRepositoryStatsTest {
         assertTrue(result.isFailure)
         assertEquals("Empty response body", result.exceptionOrNull()?.message)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun statsCall(): Call<GraphContainer<UserStatsData>> = mock(Call::class.java) as Call<GraphContainer<UserStatsData>>
 
     private fun statsData(animeCount: Int): UserStatsData = UserStatsData(
         user = UserStatsData.User(

--- a/app/src/test/java/com/mxt/anitrend/repository/UserSettingsRepositoryTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/repository/UserSettingsRepositoryTest.kt
@@ -29,7 +29,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 
 /**
@@ -48,14 +47,12 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser success maps GraphContainer data to UserSettingsRecord`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request(
             about = "New bio",
             displayAdultContent = true,
             scoreFormat = ScoreFormat.POINT_5,
         )
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UpdateUserData(
@@ -106,10 +103,8 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser success preserves nullable settings blocks`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request(titleLanguage = UserTitleLanguage.NATIVE)
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UpdateUserData(
@@ -145,10 +140,8 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser GraphQL error returns failed Result with message`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request(profileColor = "red")
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer<UpdateUserData>(
                     data = null,
@@ -165,10 +158,8 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser null body returns failed Result`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request()
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(null))
+        `when`(service.updateUser(request)).thenReturn(Response.success(null))
 
         val result = repository.updateUser()
 
@@ -178,10 +169,8 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser null data returns failed Result`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request()
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer<UpdateUserData>(
                     data = null,
@@ -198,10 +187,8 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser null root user returns failed Result`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request()
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UpdateUserData(updateUser = null),
@@ -218,12 +205,10 @@ class UserSettingsRepositoryTest {
 
     @Test
     fun `updateUser HTTP error returns failed Result with server message`() = runTest {
-        val call = updateUserCall()
         val request = UpdateUser.request(airingNotifications = false)
-        `when`(service.updateUser(request)).thenReturn(call)
         val errorBody = """{"errors":[{"message":"Server exploded"}]}"""
             .toResponseBody("application/json".toMediaType())
-        `when`(call.execute()).thenReturn(Response.error(500, errorBody))
+        `when`(service.updateUser(request)).thenReturn(Response.error(500, errorBody))
 
         val result = repository.updateUser(UserSettingsUpdate(airingNotifications = false))
 
@@ -243,10 +228,8 @@ class UserSettingsRepositoryTest {
             boxQuery = boxQuery,
             ioDispatcher = testDispatcher,
         )
-        val call = updateUserCall()
         val request = UpdateUser.request(about = "New bio")
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UpdateUserData(
@@ -309,10 +292,8 @@ class UserSettingsRepositoryTest {
             boxQuery = boxQuery,
             ioDispatcher = testDispatcher,
         )
-        val call = updateUserCall()
         val request = UpdateUser.request(about = "New bio")
-        `when`(service.updateUser(request)).thenReturn(call)
-        `when`(call.execute()).thenReturn(
+        `when`(service.updateUser(request)).thenReturn(
             Response.success(
                 GraphContainer(
                     data = UpdateUserData(
@@ -382,7 +363,4 @@ class UserSettingsRepositoryTest {
         voiceActors = null,
         volumesRead = 0,
     )
-
-    @Suppress("UNCHECKED_CAST")
-    private fun updateUserCall(): Call<GraphContainer<UpdateUserData>> = mock(Call::class.java) as Call<GraphContainer<UpdateUserData>>
 }

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/GiphyViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/GiphyViewModelTest.kt
@@ -17,7 +17,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import retrofit2.Call
 import retrofit2.Response
 import java.io.IOException
 
@@ -71,12 +70,10 @@ class GiphyViewModelTest {
 
     @Test
     fun `loadTrending emits Success on successful response`() = runTest {
-        @Suppress("UNCHECKED_CAST")
-        val call = mock(Call::class.java) as Call<GiphyContainer>
         val container = GiphyContainer()
 
-        `when`(service.getTrending(BuildConfig.GIPHY_KEY, KeyUtil.PAGING_LIMIT, 0, "PG")).thenReturn(call)
-        `when`(call.execute()).thenReturn(Response.success(container))
+        `when`(service.getTrending(BuildConfig.GIPHY_KEY, KeyUtil.PAGING_LIMIT, 0, "PG"))
+            .thenReturn(Response.success(container))
 
         val vm = GiphyViewModel(
             giphyService = service,
@@ -91,9 +88,6 @@ class GiphyViewModelTest {
 
     @Test
     fun `search emits Error on request failure`() = runTest {
-        @Suppress("UNCHECKED_CAST")
-        val call = mock(Call::class.java) as Call<GiphyContainer>
-
         `when`(
             service.findGif(
                 BuildConfig.GIPHY_KEY,
@@ -103,8 +97,7 @@ class GiphyViewModelTest {
                 "PG",
                 "en",
             ),
-        ).thenReturn(call)
-        `when`(call.execute()).thenThrow(IOException("Network failed"))
+        ).thenAnswer { throw IOException("Network failed") }
 
         val vm = GiphyViewModel(
             giphyService = service,

--- a/app/src/test/java/com/mxt/anitrend/viewmodel/MediaFormatViewModelTest.kt
+++ b/app/src/test/java/com/mxt/anitrend/viewmodel/MediaFormatViewModelTest.kt
@@ -36,8 +36,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import okhttp3.Request
-import okio.Timeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -52,8 +50,6 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import retrofit2.Call
-import retrofit2.Callback
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -667,7 +663,7 @@ class MediaFormatViewModelTest {
 
 /**
  * Fake [CharacterService] serving per-page fixtures through a real [CharacterRepository].
- * A single page can be held mid-response: its Call signals entry on a latch, then
+ * A single page can be held mid-response: its suspend call signals entry on a latch, then
  * blocks on a release latch, so its reply is genuinely in flight while later pages
  * are requested. Requests are recorded in arrival order.
  */
@@ -700,44 +696,26 @@ private class GatedCharacterService : CharacterService {
         release.countDown()
     }
 
-    override fun getCharacterMedia(
+    override suspend fun getCharacterMedia(
         request: GraphQLOperationRequest<CharacterMediaVariables>,
-    ): Call<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>> {
+    ): Response<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>> {
         val page = request.variables?.page ?: 0
         requestedPages.add(page)
-        return object : Call<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>> {
-            override fun execute(): Response<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>> {
-                if (heldPage == page) {
-                    entry.countDown()
-                    if (!release.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                        error("page $page response was never released")
-                    }
-                }
-                val fixture = fixtures[page] ?: error("no fixture for page $page")
-                return Response.success(fixture)
+        if (heldPage == page) {
+            entry.countDown()
+            if (!release.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                error("page $page response was never released")
             }
-
-            override fun enqueue(callback: Callback<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>>) = Unit
-
-            override fun isExecuted(): Boolean = false
-
-            override fun cancel() = Unit
-
-            override fun isCanceled(): Boolean = false
-
-            override fun clone(): Call<AniListContainer<ConnectionContainer<PageContainer<MediaBase>>>> = this
-
-            override fun request(): Request = Request.Builder().url("https://anilist.co/").build()
-
-            override fun timeout(): Timeout = Timeout.NONE
         }
+        val fixture = fixtures[page] ?: error("no fixture for page $page")
+        return Response.success(fixture)
     }
 
-    override fun getCharacterBase(request: GraphQLOperationRequest<CharacterBaseVariables>): Call<GraphContainer<CharacterBaseData>> = error("unused")
+    override suspend fun getCharacterBase(request: GraphQLOperationRequest<CharacterBaseVariables>): Response<GraphContainer<CharacterBaseData>> = error("unused")
 
-    override fun getCharacterOverview(request: GraphQLOperationRequest<CharacterOverviewVariables>): Call<GraphContainer<CharacterOverviewData>> = error("unused")
+    override suspend fun getCharacterOverview(request: GraphQLOperationRequest<CharacterOverviewVariables>): Response<GraphContainer<CharacterOverviewData>> = error("unused")
 
-    override fun getCharacterActors(request: GraphQLOperationRequest<CharacterActorsVariables>): Call<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>> = error("unused")
+    override suspend fun getCharacterActors(request: GraphQLOperationRequest<CharacterActorsVariables>): Response<AniListContainer<ConnectionContainer<EdgeContainer<MediaEdge>>>> = error("unused")
 
     private companion object {
         const val TIMEOUT_MILLIS = 5_000L


### PR DESCRIPTION
## Summary
- Migrate Retrofit service methods from `Call<T>` to `suspend fun ...: Response<T>` across AniList, Giphy, repository, and Crunchyroll services.
- Preserve repository HTTP, GraphQL, empty-body, transport-error, and `Result` semantics, including the synchronous auth compatibility bridge.
- Update affected unit tests and add Crunchyroll exception-boundary coverage.

## Validation
- `./gradlew :app:compileAppDebugKotlin :app:compileAppDebugUnitTestKotlin :app:testAppDebugUnitTest :app:assembleAppDebug :app:spotlessCheck --no-daemon`
- All tasks passed.
- Full app unit tests passed.
- Known non-blocking ObjectBox configuration-cache serialization warning remains.

## Scope notes
- Retrofit 3.0.0 already provides native suspend `Response<T>` support, so no dependency or call-adapter changes were required.
- Pre-existing local `.idea/planningMode.xml` and `.artifacts/` changes are excluded.