### PR TITLE
fix(ui): align system notification construction and fix permission check

### DIFF
--- a/app/src/main/java/com/mxt/anitrend/extension/ContextExt.kt
+++ b/app/src/main/java/com/mxt/anitrend/extension/ContextExt.kt
@@ -216,7 +216,7 @@ fun Context.checkNotificationPermission(channelId: String?): Boolean {
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && hasPermission && channelId != null) {
         val channel = NotificationManagerCompat.from(this).getNotificationChannel(channelId)
-        if (channel != null && channel.importance == NotificationManagerCompat.IMPORTANCE_DEFAULT) {
+        if (channel != null && channel.importance == NotificationManagerCompat.IMPORTANCE_NONE) {
             return false
         }
     }

--- a/app/src/main/java/com/mxt/anitrend/receiver/ClearNotifications.kt
+++ b/app/src/main/java/com/mxt/anitrend/receiver/ClearNotifications.kt
@@ -8,8 +8,14 @@ import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class ClearNotifications : BroadcastReceiver() {
+class ClearNotifications : KoinComponent, BroadcastReceiver() {
+
+    private val settings by inject<Settings>()
+    private val scheduler by inject<JobSchedulerUtil>()
+
     override fun onReceive(
         context: Context,
         intent: Intent?,
@@ -23,7 +29,6 @@ class ClearNotifications : BroadcastReceiver() {
             notificationManager?.cancel(extras.getInt(KeyUtil.NOTIFICATION_ID))
         }
 
-        val settings = koinOf<Settings>()
         if (extras.containsKey(KeyUtil.NOTIFICATION_ID_REMOTE)) {
             settings.lastDismissedNotificationId = extras.getLong(KeyUtil.NOTIFICATION_ID_REMOTE)
         }
@@ -35,8 +40,6 @@ class ClearNotifications : BroadcastReceiver() {
                 }
             }
         }
-
-        val scheduler = koinOf<JobSchedulerUtil>()
         scheduler.scheduleClearNotificationJob(context)
     }
 }

--- a/app/src/main/java/com/mxt/anitrend/receiver/ClearNotifications.kt
+++ b/app/src/main/java/com/mxt/anitrend/receiver/ClearNotifications.kt
@@ -4,14 +4,15 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.mxt.anitrend.extension.koinOf
 import com.mxt.anitrend.util.JobSchedulerUtil
 import com.mxt.anitrend.util.KeyUtil
 import com.mxt.anitrend.util.Settings
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class ClearNotifications : KoinComponent, BroadcastReceiver() {
+class ClearNotifications :
+    BroadcastReceiver(),
+    KoinComponent {
 
     private val settings by inject<Settings>()
     private val scheduler by inject<JobSchedulerUtil>()

--- a/app/src/main/java/com/mxt/anitrend/util/KeyUtil.kt
+++ b/app/src/main/java/com/mxt/anitrend/util/KeyUtil.kt
@@ -20,6 +20,7 @@ object KeyUtil {
 
     /** Notification Actions */
     const val NOTIFICATION_ID = "anitrend_notification_id"
+    const val NOTIFICATION_SUMMARY_ID = 0x00000011
     const val NOTIFICATION_ID_REMOTE = "anitrend_notification_id_remote"
     const val NOTIFICATION_ACTION = "anitrend_notification_action"
     const val NOTIFICATION_ACTION_CLEAR = "anitrend_notification_action_clear"

--- a/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
+++ b/app/src/main/java/com/mxt/anitrend/util/NotificationUtil.kt
@@ -18,6 +18,7 @@ import com.mxt.anitrend.extension.getCompatColor
 import com.mxt.anitrend.model.entity.anilist.User
 import com.mxt.anitrend.receiver.ClearNotifications
 import com.mxt.anitrend.view.activity.detail.NotificationActivity
+import timber.log.Timber
 import kotlin.math.min
 
 /**
@@ -30,7 +31,6 @@ class NotificationUtil(
     private val settings: Settings,
     private val notificationManager: NotificationManager?,
 ) {
-    private var defaultNotificationId = 0x00000011
 
     private fun multiContentIntent(): PendingIntent {
         // PendingIntent.FLAG_UPDATE_CURRENT will update notification
@@ -41,7 +41,7 @@ class NotificationUtil(
             )
         return PendingIntent.getActivity(
             context,
-            defaultNotificationId,
+            KeyUtil.NOTIFICATION_SUMMARY_ID,
             targetActivity,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
@@ -52,7 +52,7 @@ class NotificationUtil(
         notificationIdRemote: Long,
     ): PendingIntent {
         val intent = Intent(this.context, ClearNotifications::class.java)
-        intent.putExtra(KeyUtil.NOTIFICATION_ID, defaultNotificationId)
+        intent.putExtra(KeyUtil.NOTIFICATION_ID, KeyUtil.NOTIFICATION_SUMMARY_ID)
         intent.putExtra(KeyUtil.NOTIFICATION_ID_REMOTE, notificationIdRemote)
         intent.putExtra(KeyUtil.NOTIFICATION_ACTION, action)
         return PendingIntent.getBroadcast(
@@ -148,9 +148,6 @@ class NotificationUtil(
         }
 
         val notificationCount = userGraphContainer.unreadNotificationCount
-        if (notificationCount > 0) {
-            defaultNotificationId = defaultNotificationId.inc()
-        }
 
         val notificationBuilder =
             NotificationCompat
@@ -177,7 +174,7 @@ class NotificationUtil(
         when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
                 // define the importance level of the notification
-                val importance = NotificationManager.IMPORTANCE_DEFAULT
+                val importance = NotificationManager.IMPORTANCE_HIGH
 
                 // build the actual notification channel, giving it a unique ID and name
                 val channel =
@@ -218,7 +215,10 @@ class NotificationUtil(
                 )
 
             if (context.checkNotificationPermission(KeyUtil.CHANNEL_ID)) {
-                notificationManager?.notify(defaultNotificationId, notificationBuilder.build())
+                Timber.d("Issuing notification with ID: ${KeyUtil.NOTIFICATION_SUMMARY_ID} for $notificationCount unread items")
+                notificationManager?.notify(KeyUtil.NOTIFICATION_SUMMARY_ID, notificationBuilder.build())
+            } else {
+                Timber.w("Notification permission not granted for channel: ${KeyUtil.CHANNEL_ID}")
             }
         }
     }


### PR DESCRIPTION
# AniTrend Pull Request

Before opening a pull request, please ensure you've done the following:
- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-app/blob/develop/CONTRIBUTING.md)
- [x] Double checked that your branch is based on `develop` and targets `develop` (where applicable)
- [ ] Pull request has tests (if applicable)
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved


## Description
This PR fixes issues preventing system notifications from appearing and being cleared correctly on modern Android versions.

Key changes:
- Fixed a bug in `checkNotificationPermission` that incorrectly returned `false` for channels with `DEFAULT` importance.
- Aligned notification channel importance with notification priority (both set to `HIGH`).
- Introduced a stable `NOTIFICATION_SUMMARY_ID` in `KeyUtil` to ensure consistent notification identification.
- Refactored `NotificationUtil` to use the stable ID and added `Timber` logging for better traceability.
- Updated `ClearNotifications` receiver to use Koin injection and properly cancel notifications using the stable ID.

## Screenshots:
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (Improves existing functionality)